### PR TITLE
Update README PyPI badge to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AIsbom: The Supply Chain for Artificial Intelligence
-[![PyPI version](https://badge.fury.io/py/aisbom-cli.svg)](https://badge.fury.io/py/aisbom-cli)
+[![PyPI version](https://img.shields.io/pypi/v/aisbom-cli.svg)](https://pypi.org/project/aisbom-cli/)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue)
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue)
 ![Compliance](https://img.shields.io/badge/standard-CycloneDX-green)


### PR DESCRIPTION
## Summary
- switch the PyPI version badge in README to the shields.io service for faster updates
- link the badge directly to the aisbom-cli project page on PyPI

## Testing
- not run (docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940c8eee8348320a8953f208b695acb)