### PR TITLE
feat(scan): structured per-format findings as CycloneDX properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We use HTTP Range requests to inspect just the headers — scans complete in sec
 aisbom scan ./my-project-folder --share
 ```
 
-Generates a hosted, shareable link. The SBOM is uploaded to `aisbom.io` and remains viewable for 30 days. You'll be prompted to confirm before upload (use `--share-yes` to skip the prompt in CI).
+Generates a hosted, shareable link. The SBOM is uploaded to `aisbom.io` and remains viewable for 30 days. You'll be prompted to confirm before upload (use `--share-yes` to skip the prompt in CI). For exactly what the uploaded document contains, see [Telemetry & Privacy](#telemetry--privacy).
 
 ### Detect drift between two scans
 
@@ -275,7 +275,7 @@ AIsbom collects a small amount of anonymous usage telemetry — what model forma
 
 Per `aisbom scan`: `target_type` (the **bucket**: `local` / `huggingface` / `http` / `https` — never the actual path or URL), `model_format` (the file-type bucket), `risk_level_max`, `scan_duration_ms`, `file_count`, `parse_error_count`, `strict_mode`. A `cli_scan_critical_found` event with a count is added when at least one CRITICAL is found.
 
-If you explicitly use `--share`: the generated `sbom.json` document is uploaded to our servers and retained for 30 days to generate the shareable viewer link. A `cli_share_created` event is fired tracking whether `has_share_yes=true|false`.
+If you explicitly use `--share`: the generated `sbom.json` document is uploaded to our servers and retained for 30 days to generate the shareable viewer link. That document is the **full CycloneDX SBOM** — for each scanned model it carries the file name, SHA-256 hash, detected license, and structured `aisbom:*` properties describing the file's format and scan findings (such as dangerous pickle opcodes, tensor/header metadata, and model architecture details) so the hosted viewer can render per-format detail. These describe the *structure and findings* of your model files, never their weights or data. Nothing leaves your machine unless you pass `--share` and confirm the prompt (or pass `--share-yes`). A `cli_share_created` event is fired tracking whether `has_share_yes=true|false`.
 
 Per `aisbom diff`: a `cli_diff` event with `has_drift=true|false`.
 

--- a/aisbom/cli.py
+++ b/aisbom/cli.py
@@ -9,7 +9,7 @@ from rich.table import Table
 from rich.panel import Panel
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component, ComponentType
-from cyclonedx.model import HashAlgorithm, HashType
+from cyclonedx.model import HashAlgorithm, HashType, Property
 from cyclonedx.output.json import JsonV1Dot5, JsonV1Dot6
 from cyclonedx.factory.license import LicenseFactory
 from .mock_generator import create_mock_malware_file, create_mock_restricted_file, create_mock_gguf, create_demo_diff_sboms, create_mock_broken_file
@@ -17,6 +17,7 @@ from pathlib import Path
 import importlib.metadata
 from .scanner import DeepScanner
 from .diff import SBOMDiff
+from .properties import build_component_properties
 
 import threading
 import time
@@ -465,7 +466,13 @@ def scan(
             # Create a License object (using name since we don't have SPDX ID validation yet)
             lic = lf.make_from_string(art['license'])
             c.licenses.add(lic)
-        
+
+        # Attach structured, namespaced per-format findings as CycloneDX
+        # properties so consumers can render them directly (the description
+        # string above is kept unchanged for backwards compatibility).
+        for prop_name, prop_value in build_component_properties(art):
+            c.properties.add(Property(name=prop_name, value=prop_value))
+
         bom.components.add(c)
 
     # Add Libraries

--- a/aisbom/properties.py
+++ b/aisbom/properties.py
@@ -1,0 +1,78 @@
+"""Build structured, namespaced CycloneDX component properties from a scanned
+artifact.
+
+The scanner produces a per-artifact ``meta`` dict (see ``DeepScanner``); this
+module maps that dict into a flat list of ``(name, value)`` property pairs using
+``aisbom:*`` keys so downstream consumers (the web platform's artifact drawer)
+can render format-specific findings directly, instead of re-parsing the human
+readable ``description`` string.
+
+Keys are namespaced under ``aisbom:`` so they never collide with properties
+emitted by other tooling. The ``description`` string is left untouched for
+backwards compatibility — these properties are purely additive.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+# Map the scanner's human "framework" label to a stable format token.
+_FRAMEWORK_TO_FORMAT = {
+    "PyTorch": "pickle",
+    "SafeTensors": "safetensors",
+    "GGUF": "gguf",
+}
+
+
+def _format_for(art: Dict[str, Any]) -> str | None:
+    return _FRAMEWORK_TO_FORMAT.get(art.get("framework"))
+
+
+def _csv(values) -> str:
+    """Join an iterable of values into a stable comma-separated string."""
+    return ",".join(str(v) for v in values if str(v) != "")
+
+
+def build_component_properties(art: Dict[str, Any]) -> List[Tuple[str, str]]:
+    """Return ``(name, value)`` property pairs for a scanned artifact.
+
+    Returns an empty list for non-model artifacts (e.g. config files) or
+    formats we don't emit structured findings for. Property names that would
+    have an empty value are omitted.
+    """
+    fmt = _format_for(art)
+    if fmt is None:
+        return []
+
+    details = art.get("details") or {}
+    props: List[Tuple[str, str]] = [("aisbom:format", fmt)]
+
+    if fmt == "pickle":
+        threats = details.get("threats") or []
+        for threat in threats:
+            props.append(("aisbom:pickle:opcode", str(threat)))
+        props.append(("aisbom:pickle:opcode_count", str(len(threats))))
+
+    elif fmt == "safetensors":
+        tensor_count = details.get("tensors")
+        if tensor_count is not None:
+            props.append(("aisbom:safetensors:tensor_count", str(tensor_count)))
+        dtypes = details.get("dtypes") or []
+        if dtypes:
+            props.append(("aisbom:safetensors:dtypes", _csv(dtypes)))
+        header_keys = details.get("header_keys") or []
+        if header_keys:
+            props.append(("aisbom:safetensors:header_keys", _csv(header_keys)))
+
+    elif fmt == "gguf":
+        architecture = details.get("architecture")
+        if architecture:
+            props.append(("aisbom:gguf:architecture", str(architecture)))
+        quantization = details.get("quantization")
+        if quantization is not None and str(quantization) != "":
+            props.append(("aisbom:gguf:quantization", str(quantization)))
+        metadata_keys = details.get("metadata_keys") or []
+        if metadata_keys:
+            props.append(("aisbom:gguf:metadata_keys", _csv(metadata_keys)))
+
+    return props

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -246,9 +246,22 @@ class DeepScanner:
                 meta["license"] = license_info
                 meta["legal_status"] = self._assess_legal_risk(license_info)
 
+                # Structured per-format findings (consumed by the platform's
+                # artifact drawer as CycloneDX properties). "__metadata__" is a
+                # header key but not a tensor, so exclude it from the count.
+                tensor_entries = {
+                    k: v for k, v in header_json.items() if k != "__metadata__"
+                }
+                dtypes = sorted({
+                    v.get("dtype")
+                    for v in tensor_entries.values()
+                    if isinstance(v, dict) and v.get("dtype")
+                })
                 meta["details"] = {
-                    "tensors": len(header_json.keys()),
-                    "metadata": metadata
+                    "tensors": len(tensor_entries),
+                    "metadata": metadata,
+                    "dtypes": dtypes,
+                    "header_keys": list(header_json.keys()),
                 }
         except Exception as e:
             meta["error"] = str(e)
@@ -304,52 +317,74 @@ class DeepScanner:
             kv_count = struct.unpack('<Q', kv_count_bytes)[0]
             
             extracted_meta = {}
-            
+            metadata_keys = []   # every KV key we successfully read (for properties)
+            quantization = None  # general.file_type / quantization_version (scalar)
+
+            # Little-endian struct formats for the integer scalar types, so we
+            # can decode quantization enums rather than blindly skipping them.
+            int_fmt = {0: '<B', 1: '<b', 2: '<H', 3: '<h', 4: '<I', 5: '<i', 10: '<Q', 11: '<q'}
+
             # 3. Parse Key-Value Pairs
-            # We interpret just enough to find the license
+            # We interpret just enough to find the license, architecture, and
+            # quantization, and to enumerate the metadata keys present.
             for _ in range(kv_count):
                 # Read Key (String: Length (Q) + Bytes)
                 key_len_b = f.read(8)
                 if not key_len_b: break
                 key_len = struct.unpack('<Q', key_len_b)[0]
                 key = f.read(key_len).decode('utf-8', errors='ignore')
-                
+
                 # Read Value Type (uint32)
                 type_b = f.read(4)
                 val_type = struct.unpack('<I', type_b)[0]
-                
+
                 # GGUF Value Types: 8=String, others are numbers/bools/arrays
                 # We strictly care about Strings (8) for metadata
                 value = "N/A"
                 if val_type == 8: # String
                     val_len = struct.unpack('<Q', f.read(8))[0]
                     value = f.read(val_len).decode('utf-8', errors='ignore')
-                elif val_type in [0, 1, 2, 3, 4, 5, 10, 11, 12]: 
-                    # Simple scalar types (1-8 bytes), skip them to get to next key
-                    # Mapping sizes roughly: 
+                elif val_type in [0, 1, 2, 3, 4, 5, 10, 11, 12]:
+                    # Simple scalar types (1-8 bytes), read them to get to next key
+                    # Mapping sizes roughly:
                     # 0(uint8):1, 1(int8):1, 2(uint16):2, 3(int16):2, 4(uint32):4, 5(int32):4
                     # 10(uint64):8, 11(int64):8, 12(float64):8
                     skip_map = {0:1, 1:1, 2:2, 3:2, 4:4, 5:4, 6:4, 7:8, 10:8, 11:8, 12:8}
                     skip = skip_map.get(val_type, 0)
-                    if skip > 0: f.read(skip)
+                    raw = f.read(skip) if skip > 0 else b""
                     if val_type == 12: value = "float" # Placeholder
+                    # Quantization is stored as an integer enum, usually under
+                    # general.file_type (or general.quantization_version).
+                    if ("file_type" in key or "quantization" in key) and val_type in int_fmt:
+                        try:
+                            quantization = struct.unpack(int_fmt[val_type], raw)[0]
+                        except struct.error:
+                            pass
                 elif val_type == 9: # Array
                     # Arrays are complex to skip without recursion, abort parsing to avoid crash
                     # Most metadata strings are at the top of the file anyway
-                    break 
-                
+                    metadata_keys.append(key)
+                    break
+
+                metadata_keys.append(key)
+
                 # Capture interesting keys
                 if val_type == 8:
                     if "license" in key:
                         extracted_meta[key] = value
                     if "architecture" in key:
                         extracted_meta["arch"] = value
- 
+
             # 4. Analyze License
             # GGUF usually stores it as "general.license"
             lic = extracted_meta.get("general.license") or extracted_meta.get("license") or "Unknown"
             meta["license"] = lic
             meta["legal_status"] = self._assess_legal_risk(lic)
+            # Structured per-format findings for CycloneDX properties.
+            extracted_meta["architecture"] = extracted_meta.get("arch")
+            if quantization is not None:
+                extracted_meta["quantization"] = quantization
+            extracted_meta["metadata_keys"] = metadata_keys
             meta["details"] = extracted_meta
 
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aisbom-cli"
-version = "1.0.4"
+version = "1.0.5"
 description = "An AI Supply Chain security tool that that detects Pickle bombs and generates CycloneDX SBOMs for Machine Learning models."
 authors = ["Ajoy L <lab700xdev@gmail.com>"]
 readme = "README.md"

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -51,6 +51,46 @@ def test_cli_scan_subprocess_creates_sbom(tmp_path):
     assert {"mock_malware.pt", "mock_restricted.safetensors", "mock_restricted.gguf", "torch", "requests"} <= names
 
 
+def test_cli_scan_emits_namespaced_properties_per_format(tmp_path):
+    _write_malicious_pt(tmp_path / "mock_malware.pt")
+    create_mock_restricted_file(tmp_path)
+    create_mock_gguf(tmp_path)
+
+    output_path = tmp_path / "sbom.json"
+    _run_cli(["scan", str(tmp_path), "--output", str(output_path)], cwd=tmp_path)
+
+    sbom = json.loads(output_path.read_text())
+    by_name = {c["name"]: c for c in sbom["components"]}
+
+    def props(comp):
+        out = {}
+        for p in comp.get("properties", []):
+            out.setdefault(p["name"], []).append(p["value"])
+        return out
+
+    # Pickle: format + at least one opcode + a count, all aisbom:* namespaced.
+    pkl = props(by_name["mock_malware.pt"])
+    assert pkl["aisbom:format"] == ["pickle"]
+    assert len(pkl["aisbom:pickle:opcode"]) >= 1
+    assert pkl["aisbom:pickle:opcode_count"][0] == str(len(pkl["aisbom:pickle:opcode"]))
+
+    # SafeTensors: format + tensor count.
+    st = props(by_name["mock_restricted.safetensors"])
+    assert st["aisbom:format"] == ["safetensors"]
+    assert "aisbom:safetensors:tensor_count" in st
+
+    # GGUF: format + metadata keys.
+    gg = props(by_name["mock_restricted.gguf"])
+    assert gg["aisbom:format"] == ["gguf"]
+    assert "aisbom:gguf:metadata_keys" in gg
+
+    # Backwards compatibility: the human description string is unchanged.
+    assert by_name["mock_malware.pt"]["description"].startswith("Risk:")
+    for comp in (by_name["mock_malware.pt"], by_name["mock_restricted.safetensors"]):
+        for name in props(comp):
+            assert name.startswith("aisbom:")
+
+
 def test_cli_info_shows_version(tmp_path):
     result = _run_cli(["info"], cwd=tmp_path)
     assert result.returncode == 0, result.stderr

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,113 @@
+from aisbom.properties import build_component_properties
+
+
+def _props_dict(pairs):
+    """Collapse pairs into a dict; for repeated keys, collect values in a list."""
+    out = {}
+    for k, v in pairs:
+        if k in out:
+            out[k].append(v)
+        else:
+            out[k] = [v]
+    return out
+
+
+def test_non_model_artifact_emits_no_properties():
+    art = {"framework": "Python Path Config", "details": {}}
+    assert build_component_properties(art) == []
+
+
+def test_unknown_framework_emits_no_properties():
+    art = {"framework": "Something New", "details": {}}
+    assert build_component_properties(art) == []
+
+
+def test_pickle_emits_one_opcode_per_threat_plus_count():
+    art = {
+        "framework": "PyTorch",
+        "details": {"threats": ["os.system", "subprocess.Popen"]},
+    }
+    pairs = build_component_properties(art)
+    d = _props_dict(pairs)
+
+    assert d["aisbom:format"] == ["pickle"]
+    assert d["aisbom:pickle:opcode"] == ["os.system", "subprocess.Popen"]
+    assert d["aisbom:pickle:opcode_count"] == ["2"]
+
+
+def test_pickle_with_no_threats_reports_zero_count_and_no_opcodes():
+    art = {"framework": "PyTorch", "details": {"threats": []}}
+    d = _props_dict(build_component_properties(art))
+
+    assert d["aisbom:format"] == ["pickle"]
+    assert "aisbom:pickle:opcode" not in d
+    assert d["aisbom:pickle:opcode_count"] == ["0"]
+
+
+def test_pickle_missing_threats_key_is_safe():
+    art = {"framework": "PyTorch", "details": {}}
+    d = _props_dict(build_component_properties(art))
+    assert d["aisbom:pickle:opcode_count"] == ["0"]
+
+
+def test_safetensors_emits_tensor_count_dtypes_header_keys():
+    art = {
+        "framework": "SafeTensors",
+        "details": {
+            "tensors": 2,
+            "dtypes": ["F16", "F32"],
+            "header_keys": ["weight", "bias"],
+        },
+    }
+    d = _props_dict(build_component_properties(art))
+
+    assert d["aisbom:format"] == ["safetensors"]
+    assert d["aisbom:safetensors:tensor_count"] == ["2"]
+    assert d["aisbom:safetensors:dtypes"] == ["F16,F32"]
+    assert d["aisbom:safetensors:header_keys"] == ["weight,bias"]
+
+
+def test_safetensors_omits_empty_optional_fields():
+    art = {"framework": "SafeTensors", "details": {"tensors": 0}}
+    d = _props_dict(build_component_properties(art))
+
+    assert d["aisbom:safetensors:tensor_count"] == ["0"]
+    assert "aisbom:safetensors:dtypes" not in d
+    assert "aisbom:safetensors:header_keys" not in d
+
+
+def test_gguf_emits_architecture_quantization_metadata_keys():
+    art = {
+        "framework": "GGUF",
+        "details": {
+            "architecture": "llama",
+            "quantization": "10",
+            "metadata_keys": ["general.architecture", "general.file_type"],
+        },
+    }
+    d = _props_dict(build_component_properties(art))
+
+    assert d["aisbom:format"] == ["gguf"]
+    assert d["aisbom:gguf:architecture"] == ["llama"]
+    assert d["aisbom:gguf:quantization"] == ["10"]
+    assert d["aisbom:gguf:metadata_keys"] == ["general.architecture,general.file_type"]
+
+
+def test_gguf_omits_missing_optional_fields():
+    art = {"framework": "GGUF", "details": {"metadata_keys": ["general.license"]}}
+    d = _props_dict(build_component_properties(art))
+
+    assert d["aisbom:format"] == ["gguf"]
+    assert "aisbom:gguf:architecture" not in d
+    assert "aisbom:gguf:quantization" not in d
+    assert d["aisbom:gguf:metadata_keys"] == ["general.license"]
+
+
+def test_all_keys_are_namespaced():
+    for art in (
+        {"framework": "PyTorch", "details": {"threats": ["os.system"]}},
+        {"framework": "SafeTensors", "details": {"tensors": 1, "dtypes": ["F16"], "header_keys": ["w"]}},
+        {"framework": "GGUF", "details": {"architecture": "llama", "quantization": "10", "metadata_keys": ["k"]}},
+    ):
+        for name, _ in build_component_properties(art):
+            assert name.startswith("aisbom:")


### PR DESCRIPTION
Attaches namespaced `aisbom:*` properties to each `machine-learning-model` component in the CycloneDX SBOM so downstream tools can render per-format scan detail without re-parsing the description string.

- **pickle** — `aisbom:pickle:opcode` (one per dangerous global) + `aisbom:pickle:opcode_count`
- **safetensors** — `aisbom:safetensors:tensor_count`, `dtypes` (CSV), `header_keys` (CSV)
- **gguf** — `aisbom:gguf:architecture`, `quantization`, `metadata_keys` (CSV)

The existing `description` string is untouched, so the change is purely additive and backwards-compatible. Verified that an SBOM generated by this build is byte-identical to the prior build except for the added `properties[]`.

Also bumps the version to 1.0.5 and documents what the `--share` upload contains in the README Privacy section.

Tests: 191 passed, 87% coverage.