### PR TITLE
feat(action): emit X-Aisbom-Ref (real scanned branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 - Add optional `token` / `platform-url` / `fail-on-platform-error` inputs for posting SBOM to an external dashboard (private early access).
+- Action upload now includes the scanned branch/tag (`GITHUB_REF_NAME`) so the dashboard can attribute results to the right ref.

--- a/action/platform_upload.py
+++ b/action/platform_upload.py
@@ -29,6 +29,16 @@ def compute_run_id(env: Mapping[str, str]) -> str:
     return f"{run_id}-{attempt}"
 
 
+def compute_ref(env: Mapping[str, str]) -> str | None:
+    """The branch/tag actually scanned, sourced from GITHUB_REF_NAME.
+
+    Returns None when unset or blank so callers can omit the header entirely
+    rather than send an empty string (mirrors compute_run_id's env sourcing).
+    """
+    ref = (env.get("GITHUB_REF_NAME") or "").strip()
+    return ref or None
+
+
 def summarize_response(status: int, body: str) -> str:
     snippet = (body or "")[:400]
     return f"status={status} body={snippet!r}"
@@ -51,13 +61,25 @@ def upload(
     base = normalize_platform_url(platform_url)
     url = f"{base}{WEBHOOK_PATH}"
     run_id = compute_run_id(env)
+    ref = compute_ref(env)
 
     # Loud, neutral log group — opted-in users see exactly where the data goes
     # and how to turn it off.
     print("::group::aisbom platform upload")
     print(f"[aisbom-action] POST {url}")
-    print(f"[aisbom-action] trigger={trigger} run-id={run_id}")
+    print(f"[aisbom-action] trigger={trigger} run-id={run_id} ref={ref or '-'}")
     print("[aisbom-action] To disable, unset AISBOM_TOKEN in the repo secrets.")
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "X-Aisbom-Trigger": trigger,
+        "X-Aisbom-Run-Id": run_id,
+    }
+    # Only send the ref when we actually know it — an empty header would be a
+    # lie the receiver can't distinguish from "real branch named ''".
+    if ref:
+        headers["X-Aisbom-Ref"] = ref
 
     try:
         with open(sbom_path, "rb") as fh:
@@ -65,12 +87,7 @@ def upload(
         resp = requests.post(
             url,
             data=payload,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Content-Type": "application/json",
-                "X-Aisbom-Trigger": trigger,
-                "X-Aisbom-Run-Id": run_id,
-            },
+            headers=headers,
             timeout=REQUEST_TIMEOUT_SEC,
         )
     except (requests.RequestException, OSError) as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aisbom-cli"
-version = "1.0.5"
+version = "1.0.6"
 description = "An AI Supply Chain security tool that that detects Pickle bombs and generates CycloneDX SBOMs for Machine Learning models."
 authors = ["Ajoy L <lab700xdev@gmail.com>"]
 readme = "README.md"

--- a/tests/test_action_platform_upload.py
+++ b/tests/test_action_platform_upload.py
@@ -68,6 +68,28 @@ def test_compute_run_id_missing_run_id_returns_unknown():
 
 
 # ---------------------------------------------------------------------------
+# compute_ref
+# ---------------------------------------------------------------------------
+
+def test_compute_ref_returns_branch_name():
+    env = {"GITHUB_REF_NAME": "release/v2"}
+    assert platform_upload.compute_ref(env) == "release/v2"
+
+
+def test_compute_ref_strips_whitespace():
+    env = {"GITHUB_REF_NAME": "  main  "}
+    assert platform_upload.compute_ref(env) == "main"
+
+
+def test_compute_ref_missing_returns_none():
+    assert platform_upload.compute_ref({}) is None
+
+
+def test_compute_ref_blank_returns_none():
+    assert platform_upload.compute_ref({"GITHUB_REF_NAME": "   "}) is None
+
+
+# ---------------------------------------------------------------------------
 # summarize_response
 # ---------------------------------------------------------------------------
 
@@ -206,7 +228,48 @@ def test_upload_sets_required_headers(sbom_file: Path):
     assert headers["Content-Type"] == "application/json"
     assert headers["X-Aisbom-Trigger"] == "pull_request"
     assert headers["X-Aisbom-Run-Id"] == "999-3"
+    # No GITHUB_REF_NAME in env above → the ref header must be omitted entirely
+    # (never sent as an empty string).
+    assert "X-Aisbom-Ref" not in headers
     assert captured["url"].endswith("/v1/scan-result")
+
+
+def test_upload_sends_ref_header_when_present(sbom_file: Path):
+    captured = {}
+
+    def fake_post(url, **kwargs):
+        captured["headers"] = kwargs["headers"]
+        return _mock_response(200, "ok")
+
+    with patch("requests.post", side_effect=fake_post):
+        platform_upload.upload(
+            sbom_path=str(sbom_file),
+            token="tok",
+            platform_url="https://app.aisbom.io",
+            trigger="push",
+            fail_on_error=False,
+            env={"GITHUB_REF_NAME": "feature/foo"},
+        )
+    assert captured["headers"]["X-Aisbom-Ref"] == "feature/foo"
+
+
+def test_upload_omits_ref_header_when_absent(sbom_file: Path):
+    captured = {}
+
+    def fake_post(url, **kwargs):
+        captured["headers"] = kwargs["headers"]
+        return _mock_response(200, "ok")
+
+    with patch("requests.post", side_effect=fake_post):
+        platform_upload.upload(
+            sbom_path=str(sbom_file),
+            token="tok",
+            platform_url="https://app.aisbom.io",
+            trigger="push",
+            fail_on_error=False,
+            env={},  # no GITHUB_REF_NAME
+        )
+    assert "X-Aisbom-Ref" not in captured["headers"]
 
 
 def test_upload_emits_log_group_with_disable_hint(sbom_file: Path, capsys):


### PR DESCRIPTION
Adds the public Action half of the branch/ref work. The platform receiver already stores and surfaces `X-Aisbom-Ref` (companion slice, falling back to an honest `—` when absent); this makes real branches flow.

## What changed
- New `compute_ref(env)` helper in `action/platform_upload.py` — sources `GITHUB_REF_NAME`, returns `None` when unset/blank (mirrors `compute_run_id`).
- `upload()` adds `X-Aisbom-Ref: <ref>` to the POST headers **only when present** — no empty-string header, so local/non-Action use is unaffected.
- Tests cover ref-present / whitespace / missing / blank + the upload send/omit paths.
- `pyproject.toml` 1.0.5 → 1.0.6; single neutral CHANGELOG line.

## Verification
- `poetry run pytest --cov=aisbom --cov-fail-under=85` → 197 passed, 87.12% coverage.

Closes the Action side of the cross-repo branch/ref work.