### PR TITLE
feat(scan): enrich cli_error telemetry with http_status + token_present (#56)

### DIFF
--- a/aisbom/cli.py
+++ b/aisbom/cli.py
@@ -128,6 +128,38 @@ def _classify_target(target: str) -> str:
     return "local"
 
 
+def _classify_http_status(exc: BaseException) -> str:
+    """Bucket a fetch exception into a low-cardinality status label.
+
+    Returns the numeric HTTP status as a string for an HTTPError (e.g. "401",
+    "404"), "timeout" / "connection_error" for the corresponding network
+    failures, or "other" for anything else. Never includes a response body or
+    any URL — only the diagnostic bucket. Timeout is checked before
+    ConnectionError so a ConnectTimeout (a subclass of both) buckets as a
+    timeout.
+    """
+    if isinstance(exc, requests.exceptions.HTTPError):
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status_code", None)
+        if status is not None:
+            return str(status)
+        return "other"
+    if isinstance(exc, requests.exceptions.Timeout):
+        return "timeout"
+    if isinstance(exc, requests.exceptions.ConnectionError):
+        return "connection_error"
+    return "other"
+
+
+def _token_present() -> str:
+    """Report whether an HF token env var is set, as "true"/"false".
+
+    Only presence is reported — the token value is never read into telemetry.
+    """
+    has_token = bool(os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN"))
+    return "true" if has_token else "false"
+
+
 def _summarize_model_format(artifacts: list[dict]) -> str:
     """Reduce per-artifact `framework` values to a single label.
 
@@ -334,7 +366,16 @@ def scan(
     except Exception as e:
         err_thread = telemetry.post_event(
             "cli_error",
-            {"command": "scan", "error_type": type(e).__name__},
+            {
+                "command": "scan",
+                "error_type": type(e).__name__,
+                # Diagnostic buckets (parent #55): distinguish auth (401/403),
+                # firewall (timeout/connection_error), and typos (404) in GA4
+                # without ever sending a URL, repo id, hostname, or response body.
+                "http_status": _classify_http_status(e),
+                "token_present": _token_present(),
+                "target_type": _classify_target(target),
+            },
             scan_id=scan_id,
         )
         _flush_telemetry_threads(telemetry_threads + [err_thread])

--- a/tests/test_scanner_cli.py
+++ b/tests/test_scanner_cli.py
@@ -433,3 +433,143 @@ def test_cli_scan_share_yes_uploads_and_prints_url(tmp_path, monkeypatch):
     assert "application/json" in kwargs["headers"]["Content-Type"]
     assert "data" in kwargs
 
+
+# ---------------------------------------------------------------------------
+# Slice #56 — cli_error telemetry enrichment (http_status / token_present /
+# target_type). The diagnostic must make auth vs firewall vs typo
+# distinguishable in GA4 without ever leaking a URL, repo id, token, or body.
+# ---------------------------------------------------------------------------
+
+import pytest
+import requests
+from aisbom.cli import _classify_http_status, _token_present
+
+
+def _http_error(status: int) -> requests.exceptions.HTTPError:
+    resp = requests.Response()
+    resp.status_code = status
+    return requests.exceptions.HTTPError(response=resp)
+
+
+class _RaisingScanner:
+    """Stub DeepScanner whose scan() raises a preset exception."""
+
+    _exc: BaseException
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def scan(self):
+        raise type(self)._exc
+
+
+def _scanner_raising(exc: BaseException):
+    return type("_RS", (_RaisingScanner,), {"_exc": exc})
+
+
+def _capture_cli_error(monkeypatch):
+    """Patch telemetry.post_event to record cli_error payloads; return the list."""
+    captured: list[dict] = []
+
+    def _record(event, params=None, scan_id=None):
+        if event == "cli_error":
+            captured.append(dict(params or {}))
+        return None
+
+    monkeypatch.setattr("aisbom.telemetry.post_event", _record)
+    return captured
+
+
+def test_classify_http_status_buckets_http_error_by_status():
+    assert _classify_http_status(_http_error(401)) == "401"
+    assert _classify_http_status(_http_error(403)) == "403"
+    assert _classify_http_status(_http_error(404)) == "404"
+
+
+def test_classify_http_status_buckets_timeout_and_connection_error():
+    assert _classify_http_status(requests.exceptions.Timeout()) == "timeout"
+    assert _classify_http_status(requests.exceptions.ConnectionError()) == "connection_error"
+    # ConnectTimeout is a subclass of both — must bucket as timeout, not connection_error.
+    assert _classify_http_status(requests.exceptions.ConnectTimeout()) == "timeout"
+
+
+def test_classify_http_status_falls_back_to_other():
+    assert _classify_http_status(ValueError("boom")) == "other"
+    # HTTPError with no usable response also degrades to the generic bucket.
+    assert _classify_http_status(requests.exceptions.HTTPError()) == "other"
+
+
+def test_token_present_reflects_env(monkeypatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    assert _token_present() == "false"
+    monkeypatch.setenv("HF_TOKEN", "x")
+    assert _token_present() == "true"
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "y")
+    assert _token_present() == "true"
+
+
+def test_scan_fetch_failure_emits_enriched_cli_error(tmp_path, monkeypatch):
+    captured = _capture_cli_error(monkeypatch)
+    monkeypatch.setattr(cli_module, "DeepScanner", _scanner_raising(_http_error(401)))
+    monkeypatch.setenv("HF_TOKEN", "secret-token-value")
+
+    result = runner.invoke(app, ["scan", "hf://acme/private-model"])
+
+    assert result.exit_code != 0
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["command"] == "scan"
+    assert payload["error_type"] == "HTTPError"
+    assert payload["http_status"] == "401"
+    assert payload["token_present"] == "true"
+    assert payload["target_type"] == "huggingface"
+
+
+def test_scan_fetch_failure_buckets_timeout(monkeypatch):
+    captured = _capture_cli_error(monkeypatch)
+    monkeypatch.setattr(cli_module, "DeepScanner", _scanner_raising(requests.exceptions.Timeout()))
+
+    runner.invoke(app, ["scan", "https://example.com/model.safetensors"])
+
+    assert captured and captured[0]["http_status"] == "timeout"
+    assert captured[0]["target_type"] == "https"
+
+
+def test_scan_fetch_failure_buckets_connection_error(monkeypatch):
+    captured = _capture_cli_error(monkeypatch)
+    monkeypatch.setattr(
+        cli_module, "DeepScanner", _scanner_raising(requests.exceptions.ConnectionError())
+    )
+
+    runner.invoke(app, ["scan", "hf://acme/model"])
+
+    assert captured and captured[0]["http_status"] == "connection_error"
+
+
+def test_cli_error_payload_leaks_no_token_url_or_body(monkeypatch):
+    captured = _capture_cli_error(monkeypatch)
+    secret_token = "hf_supersecrettokenvalue"
+    monkeypatch.setenv("HF_TOKEN", secret_token)
+    body = "<html>internal error trace at 10.0.0.1</html>"
+    err = _http_error(403)
+    err.response._content = body.encode()  # attach a body the bucket must ignore
+    monkeypatch.setattr(cli_module, "DeepScanner", _scanner_raising(err))
+
+    runner.invoke(app, ["scan", "hf://secret-org/secret-repo"])
+
+    assert captured
+    joined = " ".join(str(v) for v in captured[0].values())
+    # No token value, repo id, URL, hostname, or response body may appear.
+    for leak in (secret_token, "secret-org", "secret-repo", "hf://", body, "10.0.0.1"):
+        assert leak not in joined
+    # Only the agreed-upon keys are present.
+    assert set(captured[0]) == {
+        "command",
+        "error_type",
+        "http_status",
+        "token_present",
+        "target_type",
+    }
+


### PR DESCRIPTION
## Summary

When a `scan` raises during fetch, the `cli_error` telemetry event now carries three diagnostic buckets so the next HTTPError surge (parent #55) is explainable in GA4 — distinguishing auth (401/403), firewall (timeout/connection), and typos (404) — **without presuming a cause** and without leaking any identifying data.

- **`http_status`** — numeric status string for `HTTPError` (`"401"`/`"404"`…), `"timeout"` / `"connection_error"` for the network failures, `"other"` otherwise. `Timeout` is checked before `ConnectionError` so a `ConnectTimeout` buckets as a timeout.
- **`token_present`** — `"true"`/`"false"` for `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` presence. The token **value** is never read into telemetry.
- **`target_type`** — reuses the existing `_classify_target` bucket.

Excluded from the payload: URL, repo id, hostname, response body. The `diff` `cli_error` path is unchanged (not a fetch path).

## Tests

8 new tests in `tests/test_scanner_cli.py`, including a leak test asserting no token value / repo id / URL / hostname / response body appears and that the payload keys are exactly the 5 agreed fields.

- `poetry run pytest --cov=aisbom --cov-fail-under=85` → **209 passed, coverage 87.97%**

No version bump / release in this slice (deferred to #59).