### PR TITLE
feat(remote): authenticated HuggingFace scans (HF-only bearer token)

### DIFF
--- a/aisbom/remote.py
+++ b/aisbom/remote.py
@@ -1,4 +1,34 @@
-from typing import List, Optional, Any
+import os
+from typing import List, Optional, Any, Dict
+from urllib.parse import urlparse
+
+# Per ADR-0001: bearer credentials are sent only to this exact host. HF's
+# resolve endpoint 302-redirects byte fetches to a presigned LFS CDN / S3 host;
+# requests' default cross-host auth-stripping drops the header on that hop, so
+# the token is validated at huggingface.co and never leaks to the CDN.
+_HF_HOST = "huggingface.co"
+
+
+def _hf_token() -> Optional[str]:
+    """Read the HF access token from the environment only (ADR-0001).
+
+    Matches huggingface_hub precedence: HF_TOKEN, then HUGGING_FACE_HUB_TOKEN.
+    The cached ~/.cache/huggingface/token login file is deliberately not read.
+    """
+    return os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+
+
+def _auth_headers(url: str) -> Dict[str, str]:
+    """Per-request Authorization header, gated on an exact huggingface.co host match.
+
+    Returns an empty dict when there is no token or the host is anything other
+    than huggingface.co — the security guard that keeps the token off the CDN /
+    S3 / arbitrary-mirror hosts.
+    """
+    token = _hf_token()
+    if token and urlparse(url).hostname == _HF_HOST:
+        return {"Authorization": f"Bearer {token}"}
+    return {}
 
 
 class _RequestsStub:
@@ -29,7 +59,9 @@ class RemoteStream:
 
     def _fetch_size(self) -> int:
         # Use a range request to learn total size from Content-Range header
-        resp = self.session.get(self.url, headers={"Range": "bytes=0-0"})
+        headers = {"Range": "bytes=0-0"}
+        headers.update(_auth_headers(self.url))
+        resp = self.session.get(self.url, headers=headers)
         resp.raise_for_status()
         content_range = resp.headers.get("Content-Range")
         if content_range and "/" in content_range:
@@ -53,6 +85,7 @@ class RemoteStream:
             end = min(self.pos + size - 1, self.size - 1)
 
         headers = {"Range": f"bytes={self.pos}-{end}"}
+        headers.update(_auth_headers(self.url))
         resp = self.session.get(self.url, headers=headers)
         resp.raise_for_status()
         data = resp.content
@@ -102,7 +135,7 @@ def resolve_huggingface_repo(repo_id: str) -> List[str]:
 
     api_url = f"https://huggingface.co/api/models/{repo_id}/tree/main"
     try:
-        resp = requests.get(api_url)
+        resp = requests.get(api_url, headers=_auth_headers(api_url))
         resp.raise_for_status()
         data = resp.json()
     except Exception:

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -97,3 +97,102 @@ def test_remote_scanner_detects_pickle_threat(monkeypatch, tmp_path):
 
     results = DeepScanner("http://example.com/remote.pt").scan()
     assert results["artifacts"][0]["risk_level"].startswith("CRITICAL")
+
+
+# --- HF token auth (ADR-0001) ---
+
+import aisbom.remote as remote
+
+
+def test_auth_headers_attached_only_for_huggingface_host(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "secret-tok")
+    # Exact HF host -> header present
+    hf = remote._auth_headers("https://huggingface.co/org/model/resolve/main/model.pt")
+    assert hf["Authorization"] == "Bearer secret-tok"
+    # CDN / presigned LFS host -> NO header (the 302 redirect target)
+    assert remote._auth_headers("https://cdn-lfs.huggingface.co/repos/x/y") == {}
+    assert remote._auth_headers("https://abc.s3.amazonaws.com/blob") == {}
+    # Arbitrary mirror / non-HF host -> NO header
+    assert remote._auth_headers("https://example.com/model.pt") == {}
+
+
+def test_auth_headers_token_precedence_and_env_only(monkeypatch):
+    # HF_TOKEN wins over HUGGING_FACE_HUB_TOKEN
+    monkeypatch.setenv("HF_TOKEN", "primary")
+    monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "fallback")
+    assert remote._hf_token() == "primary"
+    # Fallback when HF_TOKEN absent
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    assert remote._hf_token() == "fallback"
+    # Neither -> no token, no header even on HF host
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    assert remote._hf_token() is None
+    assert remote._auth_headers("https://huggingface.co/org/model/resolve/main/x.pt") == {}
+
+
+def test_remote_stream_sends_bearer_per_request_to_hf(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "secret-tok")
+    data = b"HelloRemoteWorld"
+    seen_headers = []
+
+    def fake_get(url, headers=None):
+        seen_headers.append(headers or {})
+        rng = (headers or {}).get("Range", "bytes=0-0")
+        start_end = rng.split("=")[1]
+        start, end = start_end.split("-")
+        start = int(start)
+        end = int(end) if end else len(data) - 1
+        slice_bytes = data[start : end + 1]
+        hdrs = {"Content-Range": f"bytes {start}-{end}/{len(data)}", "Content-Length": str(len(slice_bytes))}
+        return _mock_response(slice_bytes, headers=hdrs)
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+
+    url = "https://huggingface.co/org/model/resolve/main/model.pt"
+    stream = RemoteStream(url)
+    stream.read(5)
+    # Header attached per-request on the size probe + the read
+    assert len(seen_headers) >= 2
+    for h in seen_headers:
+        assert h.get("Authorization") == "Bearer secret-tok"
+        assert "Range" in h  # auth is merged with the per-request Range header
+
+
+def test_remote_stream_no_bearer_on_non_hf_host(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "secret-tok")
+    data = b"data"
+    seen_headers = []
+
+    def fake_get(url, headers=None):
+        seen_headers.append(headers or {})
+        rng = (headers or {}).get("Range", "bytes=0-0")
+        start_end = rng.split("=")[1]
+        start, end = start_end.split("-")
+        start = int(start)
+        end = int(end) if end else len(data) - 1
+        slice_bytes = data[start : end + 1]
+        hdrs = {"Content-Range": f"bytes {start}-{end}/{len(data)}", "Content-Length": str(len(slice_bytes))}
+        return _mock_response(slice_bytes, headers=hdrs)
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+
+    RemoteStream("https://cdn-lfs.huggingface.co/blob").read(2)
+    for h in seen_headers:
+        assert "Authorization" not in h
+
+
+def test_resolve_huggingface_repo_sends_bearer(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "secret-tok")
+    tree = [{"path": "model.pt", "type": "file"}]
+    seen_headers = []
+
+    def fake_get(url, headers=None):
+        seen_headers.append(headers or {})
+        return _mock_response(json.dumps(tree).encode(), status=200)
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    resolve_huggingface_repo("org/model")
+    assert seen_headers and seen_headers[0].get("Authorization") == "Bearer secret-tok"


### PR DESCRIPTION
Implements **ADR-0001** — lets users scan private/gated HuggingFace models by attaching an env-sourced bearer token, scoped tightly to the `huggingface.co` host.

Closes the product fix behind the dominant CI `HTTPError` signal (parent #55). Backlog slice **#57** (`Lab700xOrg/aisbom-ops`).

## What changed
- `aisbom/remote.py`:
  - `_hf_token()` — reads `HF_TOKEN`, falling back to `HUGGING_FACE_HUB_TOKEN` (matching `huggingface_hub` precedence). **Env only** — the cached `~/.cache/huggingface/token` login file is never read.
  - `_auth_headers(url)` — returns `Authorization: Bearer <token>` **only** when a token exists *and* `urlparse(url).hostname == "huggingface.co"` (exact match); `{}` otherwise.
  - Merged per-request into `_fetch_size`, `read` (alongside `Range`), and `resolve_huggingface_repo`.
- No `Session.auth`, no `rebuild_auth` override — relies on `requests`' default cross-host auth-stripping so the token is validated at `huggingface.co` and never leaks to the presigned LFS CDN / S3 host on the 302 hop.

## Security guard
The host-isolation test asserts the header is attached for `huggingface.co` and **never** for CDN (`cdn-lfs.huggingface.co`), S3, or arbitrary-mirror hosts — the regression guard that the bearer token can't reach a third-party host.

## Verification
- `poetry run pytest --cov=aisbom --cov-fail-under=85` → 214 passed, 88.10% coverage.
- Live unauthenticated public-model scan (`hf://google-bert/bert-base-uncased`) still works — no regression.

No version bump / no release in this slice (release deferred to #59).