### PR TITLE
feat(scan): reactive status-aware fetch-failure handling (#58)

### DIFF
--- a/aisbom/cli.py
+++ b/aisbom/cli.py
@@ -14,6 +14,7 @@ from cyclonedx.output.json import JsonV1Dot5, JsonV1Dot6
 from cyclonedx.factory.license import LicenseFactory
 from .mock_generator import create_mock_malware_file, create_mock_restricted_file, create_mock_gguf, create_demo_diff_sboms, create_mock_broken_file
 from pathlib import Path
+from urllib.parse import urlparse
 import importlib.metadata
 from .scanner import DeepScanner
 from .diff import SBOMDiff
@@ -31,6 +32,9 @@ app = typer.Typer()
 # plain f-strings. Without it, things like "aisbom 1.0.3" or "v1.6" get
 # partial cyan coloring that looks like markup bugs.
 console = Console(highlight=False)
+# Fetch-failure messages (#58) go to stderr so they don't pollute piped stdout
+# (SBOM JSON, markdown) and survive `aisbom scan … > out.json`.
+err_console = Console(stderr=True, highlight=False)
 
 
 @app.callback(invoke_without_command=True)
@@ -158,6 +162,63 @@ def _token_present() -> str:
     """
     has_token = bool(os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN"))
     return "true" if has_token else "false"
+
+
+def _scan_error_payload(exc: BaseException, target: str) -> dict:
+    """Build the `cli_error` telemetry payload for a scan-path failure.
+
+    Single source of truth for the event shape (parent #55) so every emit
+    site — the top-level `except` and the per-target fetch-failure path —
+    sends exactly the same low-cardinality keys and never a URL, repo id,
+    hostname, or response body.
+    """
+    return {
+        "command": "scan",
+        "error_type": type(exc).__name__,
+        "http_status": _classify_http_status(exc),
+        "token_present": _token_present(),
+        "target_type": _classify_target(target),
+    }
+
+
+def _format_fetch_error(exc: BaseException, url: str) -> str:
+    """Status-aware, traceback-free message for a fetch failure.
+
+    Reactive (parent #55, #58): we make the request, then adapt the wording to
+    the *observed* status — the message never claims a cause it can't see. Auth
+    branches additionally split on whether a token was present, so a gated repo
+    with no token and a bad/insufficient token get different remediation.
+    """
+    status = _classify_http_status(exc)
+    if url.startswith("hf://"):
+        # Resolve-time failure: the raw target is a repo id, not a byte URL.
+        host = "huggingface.co"
+        name = url[len("hf://"):] or url
+    else:
+        host = urlparse(url).hostname or "the remote host"
+        name = Path(urlparse(url).path).name or url
+
+    if status in ("401", "403"):
+        if _token_present() == "true":
+            return (
+                f"Authentication failed for {name} despite a token being set. "
+                "Verify HF_TOKEN is valid and has read access — you may need to "
+                "accept the model's license on huggingface.co."
+            )
+        return (
+            f"Authentication failed for {name}; the model appears to be private "
+            "or gated. Set HF_TOKEN with a token that has read access."
+        )
+    if status in ("timeout", "connection_error"):
+        return (
+            f"Network error reaching {host}. In CI, check that egress/firewall "
+            "allows HTTPS to huggingface.co and its LFS CDN."
+        )
+    if status == "404":
+        return f"{name} not found (HTTP 404); check the repo id / URL."
+    if status.isdigit():
+        return f"Failed to fetch {name} (HTTP {status})."
+    return f"Failed to fetch {name}."
 
 
 def _summarize_model_format(artifacts: list[dict]) -> str:
@@ -364,18 +425,12 @@ def scan(
         else:
             results = scanner.scan()
     except Exception as e:
+        # Safety net for unexpected scan crashes. Per-target *fetch* failures are
+        # caught inside the scanner now (recorded as structured errors, no
+        # traceback); anything reaching here is genuinely unexpected.
         err_thread = telemetry.post_event(
             "cli_error",
-            {
-                "command": "scan",
-                "error_type": type(e).__name__,
-                # Diagnostic buckets (parent #55): distinguish auth (401/403),
-                # firewall (timeout/connection_error), and typos (404) in GA4
-                # without ever sending a URL, repo id, hostname, or response body.
-                "http_status": _classify_http_status(e),
-                "token_present": _token_present(),
-                "target_type": _classify_target(target),
-            },
+            _scan_error_payload(e, target),
             scan_id=scan_id,
         )
         _flush_telemetry_threads(telemetry_threads + [err_thread])
@@ -397,6 +452,24 @@ def scan(
         exit_code = max(exit_code, 1)
     if fail_on_risk and highest_risk >= 3:
         exit_code = 2
+
+    # Reactive fetch-failure handling (#58). The scanner caught these per-target
+    # and kept going, so other targets still rendered above. For each one, print
+    # a clean status-aware message to stderr (no traceback) and emit a cli_error
+    # carrying the same diagnostic buckets as the top-level except — so a single
+    # failed scan emits both a cli_error (the failure) and the normal cli_scan
+    # (context) below. Intentional; see the slice notes.
+    fetch_failures = [e for e in results['errors'] if e.get('fetch_failure')]
+    for err in fetch_failures:
+        exc = err.get('exception')
+        err_console.print(
+            f"[bold red]✖[/bold red] {_format_fetch_error(exc, err.get('file', ''))}"
+        )
+        telemetry_threads.append(
+            telemetry.post_event(
+                "cli_error", _scan_error_payload(exc, target), scan_id=scan_id
+            )
+        )
 
     # Telemetry: fire cli_scan plus any conditional follow-ups now that the
     # scan completed and risk is known. Non-blocking; flushed before exit.
@@ -480,9 +553,12 @@ def scan(
     if results['dependencies']:
         console.print(f"\n📦 Found [bold]{len(results['dependencies'])}[/bold] Python libraries.")
 
-    if results['errors']:
+    # Parse errors only — fetch failures already printed their status-aware
+    # message to stderr above and don't fit the "Could not parse" framing.
+    parse_errors = [e for e in results['errors'] if not e.get('fetch_failure')]
+    if parse_errors:
         console.print("\n[bold red]⚠️ Errors Encountered:[/bold red]")
-        for err in results['errors']:
+        for err in parse_errors:
             console.print(f"  - Could not parse [yellow]{err['file']}[/yellow]: {err['error']}")
     
     # 3. Generate CycloneDX SBOM (Standard Compliance)

--- a/aisbom/remote.py
+++ b/aisbom/remote.py
@@ -134,12 +134,14 @@ def resolve_huggingface_repo(repo_id: str) -> List[str]:
         repo_id = repo_id[len("hf://") :]
 
     api_url = f"https://huggingface.co/api/models/{repo_id}/tree/main"
-    try:
-        resp = requests.get(api_url, headers=_auth_headers(api_url))
-        resp.raise_for_status()
-        data = resp.json()
-    except Exception:
-        return []
+    # Let fetch failures propagate (no broad swallow): a 401/403 on a
+    # private/gated repo, a 404 typo, or a network error must surface to the
+    # scanner as a real error with a status-aware hint — returning [] here is
+    # what produced the silent "0 artifacts found" (#58). A successful 200 with
+    # no supported files still returns [] below, which is correct.
+    resp = requests.get(api_url, headers=_auth_headers(api_url))
+    resp.raise_for_status()
+    data = resp.json()
 
     supported_exts = (".pt", ".pth", ".bin", ".safetensors", ".gguf")
     urls = []

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -36,18 +36,31 @@ class DeepScanner:
     def scan(self):
         """Orchestrates the scan of the directory."""
         if self.is_remote:
-            targets = self._resolve_remote_targets(self.root_path)
+            # Resolving the repo is itself a network call; a 401/403/404 here
+            # must surface as a structured error (not a swallowed empty list or
+            # a raw traceback) so the CLI can render a status-aware hint.
+            try:
+                targets = self._resolve_remote_targets(self.root_path)
+            except Exception as e:
+                self._record_fetch_error(self.root_path, e)
+                targets = []
             for url in targets:
                 ext = Path(url).suffix.lower()
-                if ext in PYTORCH_EXTENSIONS:
-                    with RemoteStream(url) as stream:
-                        self.artifacts.append(self._inspect_pytorch(stream, Path(url).name, is_remote=True))
-                elif ext == SAFETENSORS_EXTENSION:
-                    with RemoteStream(url) as stream:
-                        self.artifacts.append(self._inspect_safetensors(stream, Path(url).name, is_remote=True))
-                elif ext == GGUF_EXTENSION:
-                    with RemoteStream(url) as stream:
-                        self.artifacts.append(self._inspect_gguf(stream, Path(url).name, is_remote=True))
+                # Per-target isolation: one gated/missing file in a multi-file
+                # repo records its error and continues, so the rest still scan.
+                try:
+                    if ext in PYTORCH_EXTENSIONS:
+                        with RemoteStream(url) as stream:
+                            self.artifacts.append(self._inspect_pytorch(stream, Path(url).name, is_remote=True))
+                    elif ext == SAFETENSORS_EXTENSION:
+                        with RemoteStream(url) as stream:
+                            self.artifacts.append(self._inspect_safetensors(stream, Path(url).name, is_remote=True))
+                    elif ext == GGUF_EXTENSION:
+                        with RemoteStream(url) as stream:
+                            self.artifacts.append(self._inspect_gguf(stream, Path(url).name, is_remote=True))
+                except Exception as e:
+                    self._record_fetch_error(url, e)
+                    continue
         else:
             root = Path(self.root_path)
             for full_path in root.rglob("*"):
@@ -71,6 +84,22 @@ class DeepScanner:
         if target.startswith("http://") or target.startswith("https://"):
             return [target]
         return []
+
+    def _record_fetch_error(self, target: str, exc: Exception) -> None:
+        """Record a remote fetch failure as a structured, non-fatal error.
+
+        Lands in results['errors'] so the CLI's `errors → exit 1` path fires.
+        Tagged `fetch_failure` (vs. a parse error) and carries the live
+        exception so the CLI can render a status-aware, traceback-free message
+        and emit the enriched cli_error telemetry. The exception object stays
+        in-process — errors are never serialized into the SBOM.
+        """
+        self.errors.append({
+            "file": target,
+            "error": str(exc),
+            "fetch_failure": True,
+            "exception": exc,
+        })
 
     def _calculate_hash(self, path: Path) -> str:
         sha256_hash = hashlib.sha256()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -196,3 +196,86 @@ def test_resolve_huggingface_repo_sends_bearer(monkeypatch):
     monkeypatch.setattr(remote.requests, "get", fake_get)
     resolve_huggingface_repo("org/model")
     assert seen_headers and seen_headers[0].get("Authorization") == "Bearer secret-tok"
+
+
+# ---------------------------------------------------------------------------
+# #58 — Resolve failures surface as real errors (not a swallowed empty list),
+# and per-target fetch failures isolate to that target.
+# ---------------------------------------------------------------------------
+
+import io
+import struct
+import requests as _requests
+import aisbom.scanner as scanner_module
+
+
+def _http_error(status: int) -> _requests.exceptions.HTTPError:
+    resp = _requests.Response()
+    resp.status_code = status
+    return _requests.exceptions.HTTPError(response=resp)
+
+
+def test_resolve_huggingface_repo_propagates_401(monkeypatch):
+    """A private/gated repo must raise (caller surfaces a hint), not return []."""
+
+    def fake_get(url, headers=None):
+        raise _http_error(401)
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    with pytest.raises(_requests.exceptions.HTTPError):
+        resolve_huggingface_repo("acme/private-model")
+
+
+def test_scanner_records_resolve_failure_as_fetch_error(monkeypatch):
+    def boom(target):
+        raise _http_error(403)
+
+    monkeypatch.setattr(scanner_module, "resolve_huggingface_repo", boom)
+    results = DeepScanner("hf://acme/private-model").scan()
+
+    assert results["artifacts"] == []
+    fetch_errors = [e for e in results["errors"] if e.get("fetch_failure")]
+    assert len(fetch_errors) == 1
+    err = fetch_errors[0]
+    assert err["file"] == "hf://acme/private-model"
+    assert isinstance(err["exception"], _requests.exceptions.HTTPError)
+
+
+def _safetensors_stream() -> io.BytesIO:
+    header = b'{"__metadata__":{}}'
+    return io.BytesIO(struct.pack("<Q", len(header)) + header)
+
+
+class _FakeRemoteStream:
+    """Raises on construction for any URL containing 'boom' (mirroring a
+    fetch failure in RemoteStream.__init__), else yields a tiny valid
+    SafeTensors stream."""
+
+    def __init__(self, url):
+        if "boom" in url:
+            raise _http_error(403)
+        self._buf = _safetensors_stream()
+
+    def __enter__(self):
+        return self._buf
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_scanner_isolates_one_gated_file_and_scans_the_rest(monkeypatch):
+    urls = [
+        "https://huggingface.co/o/m/resolve/main/boom.safetensors",
+        "https://huggingface.co/o/m/resolve/main/good.safetensors",
+    ]
+    monkeypatch.setattr(scanner_module, "resolve_huggingface_repo", lambda t: urls)
+    monkeypatch.setattr(scanner_module, "RemoteStream", _FakeRemoteStream)
+
+    results = DeepScanner("hf://o/m").scan()
+
+    # The good file still produced an artifact; the gated one became an error.
+    assert [a["name"] for a in results["artifacts"]] == ["good.safetensors"]
+    fetch_errors = [e for e in results["errors"] if e.get("fetch_failure")]
+    assert len(fetch_errors) == 1
+    assert fetch_errors[0]["file"].endswith("boom.safetensors")

--- a/tests/test_scanner_cli.py
+++ b/tests/test_scanner_cli.py
@@ -573,3 +573,133 @@ def test_cli_error_payload_leaks_no_token_url_or_body(monkeypatch):
         "target_type",
     }
 
+
+# ---------------------------------------------------------------------------
+# #58 — Reactive status-aware fetch-failure messages (no traceback)
+# ---------------------------------------------------------------------------
+
+from aisbom.cli import _format_fetch_error
+
+_HF_FILE_URL = "https://huggingface.co/acme/private-model/resolve/main/model.safetensors"
+
+
+def test_format_fetch_error_401_without_token(monkeypatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    msg = _format_fetch_error(_http_error(401), _HF_FILE_URL)
+    assert "private" in msg or "gated" in msg
+    assert "HF_TOKEN" in msg
+    assert "despite" not in msg  # not the token-present branch
+    assert "model.safetensors" in msg
+
+
+def test_format_fetch_error_403_with_token(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "x")
+    msg = _format_fetch_error(_http_error(403), _HF_FILE_URL)
+    assert "despite a token" in msg
+    assert "read access" in msg
+    assert "license on huggingface.co" in msg
+
+
+def test_format_fetch_error_timeout_names_host():
+    msg = _format_fetch_error(requests.exceptions.Timeout(), _HF_FILE_URL)
+    assert "huggingface.co" in msg
+    assert "egress" in msg or "firewall" in msg
+
+
+def test_format_fetch_error_connection_error_names_host():
+    msg = _format_fetch_error(requests.exceptions.ConnectionError(), _HF_FILE_URL)
+    assert "Network error reaching huggingface.co" in msg
+
+
+def test_format_fetch_error_404():
+    msg = _format_fetch_error(_http_error(404), _HF_FILE_URL)
+    assert "not found" in msg
+    assert "repo id" in msg or "URL" in msg
+
+
+def test_format_fetch_error_other_status_includes_code():
+    msg = _format_fetch_error(_http_error(500), _HF_FILE_URL)
+    assert "Failed to fetch" in msg
+    assert "HTTP 500" in msg
+
+
+def test_format_fetch_error_non_http_has_no_code():
+    msg = _format_fetch_error(ValueError("boom"), _HF_FILE_URL)
+    assert msg == "Failed to fetch model.safetensors."
+
+
+def test_format_fetch_error_hf_resolve_target_uses_repo_id_and_host():
+    # A resolve-time failure passes the raw hf:// target, not a byte URL.
+    msg = _format_fetch_error(_http_error(404), "hf://acme/private-model")
+    assert "acme/private-model not found" in msg
+    timeout_msg = _format_fetch_error(requests.exceptions.Timeout(), "hf://acme/private-model")
+    assert "reaching huggingface.co" in timeout_msg
+
+
+class _FetchFailingScanner:
+    """Real-shaped DeepScanner stub: scan() returns a structured fetch error
+    (mirroring what the patched scanner now does) instead of raising."""
+
+    _exc: BaseException
+    _target: str
+
+    def __init__(self, target, *args, **kwargs):
+        self._target_value = target
+
+    def scan(self):
+        return {
+            "artifacts": [],
+            "dependencies": [],
+            "errors": [
+                {
+                    "file": self._target_value,
+                    "error": str(type(self)._exc),
+                    "fetch_failure": True,
+                    "exception": type(self)._exc,
+                }
+            ],
+        }
+
+
+def _scanner_fetch_failing(exc: BaseException):
+    return type("_FFS", (_FetchFailingScanner,), {"_exc": exc})
+
+
+def test_scan_gated_without_token_prints_clean_message_and_exits_1(monkeypatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    captured = _capture_cli_error(monkeypatch)
+    monkeypatch.setattr(
+        cli_module, "DeepScanner", _scanner_fetch_failing(_http_error(401))
+    )
+
+    result = runner.invoke(app, ["scan", "hf://acme/private-model"])
+
+    # Exit 1 via the errors path; the only exception is the controlled Exit.
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit)
+    assert "Traceback" not in result.output
+    # Status-aware hint (printed via the stderr console; merged into output here).
+    assert "private" in result.output or "gated" in result.output
+    assert "HF_TOKEN" in result.output
+
+
+def test_scan_fetch_failure_emits_both_cli_error_and_cli_scan(monkeypatch):
+    captured_events: list[str] = []
+
+    def _record(event, params=None, scan_id=None):
+        captured_events.append(event)
+        return None
+
+    monkeypatch.setattr("aisbom.telemetry.post_event", _record)
+    monkeypatch.setattr(
+        cli_module, "DeepScanner", _scanner_fetch_failing(_http_error(403))
+    )
+
+    runner.invoke(app, ["scan", "hf://acme/model"])
+
+    # The slice notes: one failed scan emits both a cli_error and a cli_scan.
+    assert "cli_error" in captured_events
+    assert "cli_scan" in captured_events
+


### PR DESCRIPTION
Closes #58.

## What & why
Today a fetch failure (gated/private HF model, no token) bubbles up as a raw **Python traceback**, and `resolve_huggingface_repo` swallows a resolve-time 401 into `[]` → silent "0 artifacts found" with exit 0. This makes failures **reactive**: make the request, then adapt the message to the observed status — never claiming a cause it can't see.

## Changes
- **scanner.py** — catch fetch failures per-target (resolve call + each byte fetch); record a structured `fetch_failure` error into `results['errors']` and **continue**, so one gated file in a multi-file repo doesn't abort the rest. Drives exit 1 via the existing errors path.
- **remote.py** — `resolve_huggingface_repo` stops swallowing failures into `[]`; 401/403/404/network errors propagate so the scanner surfaces a real, status-aware error (the swallowed-`[]` fix).
- **cli.py** — `_format_fetch_error` maps status (+ token presence + host) to a clean, traceback-free **stderr** message: private/gated · auth-despite-token · network/firewall · 404 · generic fallback. Emits one enriched `cli_error` per fetch failure (same #56 payload keys) alongside the normal `cli_scan`. `_scan_error_payload` is now the single source for the telemetry shape.

## Verification
- `poetry run pytest --cov=aisbom --cov-fail-under=85` → **227 passed, coverage 88.72%**
- Manual, against a real private repo (`hf://lab700xdev/aisbom-test`):
  - no token → `✖ …private or gated. Set HF_TOKEN` · **exit 1** (resolve-time, names repo id)
  - valid token → artifact table + SBOM, correctly flags `LEGAL RISK (cc-by-nc-4.0)` · exit 0
  - bad token → `✖ …despite a token being set…`
  - public model (`hf://google-bert/bert-base-uncased`) still scans with no token

**No version bump** — release deferred to #59.
