### PR TITLE
Hosted dashboard is generally available — docs, action.yml, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- The hosted dashboard at <https://app.aisbom.io> is now generally available (previously private early access). The GitHub Action's optional `token` input posts each scan's SBOM to your inventory dashboard — get a per-repo token at <https://app.aisbom.io/connect>. See the README's "Hosted dashboard (optional)" and "Data flow & privacy" sections for exactly what is sent (and how to keep the Action purely local: just leave `token` unset).
+- `action.yml`: the `platform-url` input now shows its default (`https://app.aisbom.io`) instead of resolving it internally; behavior is unchanged.
+
 ## 1.1.0 — 2026-06-05
 
 - Scan private and gated Hugging Face models by setting `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN`; the token is sent only to `huggingface.co` and is never logged or included in telemetry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.2.0 — 2026-06-11
+
 - The hosted dashboard at <https://app.aisbom.io> is now generally available (previously private early access). The GitHub Action's optional `token` input posts each scan's SBOM to your inventory dashboard — get a per-repo token at <https://app.aisbom.io/connect>. See the README's "Hosted dashboard (optional)" and "Data flow & privacy" sections for exactly what is sent (and how to keep the Action purely local: just leave `token` unset).
 - `action.yml`: the `platform-url` input now shows its default (`https://app.aisbom.io`) instead of resolving it internally; behavior is unchanged.
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,23 @@ When the scan is clean, the comment collapses to a one-line ✅:
 
 Re-runs update the same comment in place via a hidden `<!-- aisbom-action -->` marker — you'll never see stacked AIsbom comments on the same PR.
 
+### Hosted dashboard (optional)
+
+The PR comment shows you each scan; the hosted dashboard at [app.aisbom.io](https://app.aisbom.io) keeps the history. Set the optional `token` input and every scan's SBOM is posted to your inventory dashboard, where you can browse artifacts across repos and branches, track drift over time, and share an executive view with compliance stakeholders:
+
+```yaml
+      - uses: Lab700xOrg/aisbom@v1
+        with:
+          directory: models/
+          token: ${{ secrets.AISBOM_TOKEN }}
+```
+
+Get a per-repo token at <https://app.aisbom.io/connect> (sign in with GitHub). Leave `token` unset and the Action stays purely local — nothing is sent to the dashboard.
+
+#### Data flow & privacy
+
+When (and only when) `token` is set, the Action POSTs the generated CycloneDX SBOM JSON to `https://app.aisbom.io/v1/scan-result`, along with the branch/tag name (`GITHUB_REF_NAME`) so the dashboard can attribute results to the right ref. That's the entire payload: the SBOM describes the *structure and findings* of your model files (names, hashes, licenses, risk levels) — never the weights or file contents, which don't leave the GitHub runner. Data is stored in the EU (Cloudflare R2/D1, EU jurisdiction). Every upload is announced in a loud log group in your CI output, so your logs always show when a network call happened and where the data went. To stop uploading, remove the `token` input — there is no background or implicit sending.
+
 See [`action/README_ACTION.md`](action/README_ACTION.md) for the full inputs/outputs reference, permissions block, and troubleshooting.
 
 ---

--- a/action.yml
+++ b/action.yml
@@ -33,13 +33,13 @@ inputs:
     required: false
     default: 'true'
   token:
-    description: 'Optional. Per-repo API token for posting the generated SBOM to a persistent inventory dashboard. Leave unset for purely local PR-comment behavior. (The dashboard is in private early access.)'
+    description: 'Optional. Per-repo API token for posting the generated SBOM to your hosted inventory dashboard at app.aisbom.io. Leave unset for purely local PR-comment behavior. Get a token at https://app.aisbom.io/connect.'
     required: false
     default: ''
   platform-url:
-    description: 'Override for the platform webhook URL. Leave blank to use the default. Only meaningful when `token:` is set.'
+    description: 'Override for the platform webhook URL. Only meaningful when `token:` is set.'
     required: false
-    default: ''
+    default: 'https://app.aisbom.io'
   fail-on-platform-error:
     description: 'Default false. When true, a failed upload fails the CI job.'
     required: false

--- a/action/README_ACTION.md
+++ b/action/README_ACTION.md
@@ -69,7 +69,8 @@ When there are no CRITICAL or HIGH findings, the comment collapses to a one-line
 | `max-rows` | `10` | Maximum rows shown in the findings table; overflow collapses into a "+ N more" line. |
 | `comment-on-clean` | `true` | Post a comment when no CRITICAL/HIGH findings detected. Set to `"false"` for silence on clean PRs. |
 | `fail-on-risk` | `true` | Exit non-zero on CRITICAL findings. Set to `"false"` to make scans informational. |
-| `token` | _(empty)_ | Optional. Per-repo API token for posting the generated SBOM to a persistent inventory dashboard. Leave unset for purely local PR-comment behavior. (The dashboard is in private early access.) |
+| `token` | _(empty)_ | Optional. Per-repo API token for posting the generated SBOM to your hosted inventory dashboard at app.aisbom.io. Leave unset for purely local PR-comment behavior. Get a token at <https://app.aisbom.io/connect>. |
+| `platform-url` | `https://app.aisbom.io` | Override for the platform webhook URL. Only meaningful when `token` is set. |
 | `fail-on-platform-error` | `false` | Default false. When true, a failed upload fails the CI job. |
 
 ## Outputs
@@ -108,12 +109,13 @@ The Action embeds a hidden `<!-- aisbom-action -->` marker in the comment body. 
 
 ## Privacy
 
-Scans run inside the Action container; the model files themselves never leave the GitHub runner. Two things are sent over the wire:
+Scans run inside the Action container; the model files themselves never leave the GitHub runner. Three things can be sent over the wire:
 
 1. **SBOM upload (`--share`):** the rendered CycloneDX JSON is POSTed to `aisbom.io/api/sbom-share` so the comment can link to a hosted viewer. The SBOM is publicly viewable to anyone with the URL and expires after 30 days. The unguessable 12-char URL token is the only access control.
-2. **Anonymous telemetry:** two events (`github_action_run` and `github_action_comment_posted`) are POSTed to `api.aisbom.io/v1/telemetry`. No repo identifier, no file paths, no findings content — just severity buckets and whether the comment was created vs updated.
+2. **Hosted dashboard upload (opt-in via `token`):** when you set the `token` input, the same CycloneDX JSON is POSTed to `https://app.aisbom.io/v1/scan-result` (or your `platform-url` override) along with the branch/tag name (`GITHUB_REF_NAME`), so your dashboard at [app.aisbom.io](https://app.aisbom.io) can track the repo's SBOM history. Data is stored in the EU. The upload is logged loudly in your CI output every time it happens. Remove the token (or the input) to stop. Without a token, nothing is sent to the dashboard.
+3. **Anonymous telemetry:** two events (`github_action_run` and `github_action_comment_posted`) are POSTed to `api.aisbom.io/v1/telemetry`. No repo identifier, no file paths, no findings content — just severity buckets and whether the comment was created vs updated.
 
-To disable both, set `AISBOM_NO_TELEMETRY=1` in your workflow's `env:` block. The Action still posts the comment and produces the SBOM; the upload and telemetry pings are skipped.
+To disable 1 and 3, set `AISBOM_NO_TELEMETRY=1` in your workflow's `env:` block. The Action still posts the comment and produces the SBOM; the share upload and telemetry pings are skipped. The dashboard upload (2) is controlled solely by whether `token` is set.
 
 ## Troubleshooting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aisbom-cli"
-version = "1.1.0"
+version = "1.2.0"
 description = "An AI Supply Chain security tool that that detects Pickle bombs and generates CycloneDX SBOMs for Machine Learning models."
 authors = ["Ajoy L <lab700xdev@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
The hosted dashboard at app.aisbom.io is now generally available.

- `action.yml`: `token` description now names the dashboard and onboarding URL (https://app.aisbom.io/connect); `platform-url` default made visible (`https://app.aisbom.io`) — behavior unchanged (matches the helper's internal default)
- README: new "Hosted dashboard (optional)" section + "Data flow & privacy" section (exact payload, EU storage, loud CI logs, token-only opt-in)
- `action/README_ACTION.md`: missing `platform-url` input row added; Privacy section now covers the dashboard upload
- CHANGELOG: 1.2.0 entry; version bumped

No scanner/code changes. 227 tests pass, coverage 88.72% (gate 85%).
