### PR TITLE
chore(deps): bump demo_data pins to clear Dependabot alerts

### DIFF
--- a/demo_data/requirements.txt
+++ b/demo_data/requirements.txt
@@ -1,3 +1,3 @@
-torch==2.12.0
+torch==2.13.0
 numpy
-transformers==5.2.0
+transformers==5.13.1


### PR DESCRIPTION
## Summary

Bumps the pinned versions in `demo_data/requirements.txt` — the demo/scan fixture file that `aisbom scan ./demo_data` parses. These dependencies are **never installed** by the project, but the old pins keep Dependabot alerts open on the default branch:

- `transformers` 5.2.0 → 5.13.1 — clears alert #33 (CVE-2026-4372 / GHSA-29pf-2h5f-8g72, high, RCE, patched in 5.3.0)
- `torch` 2.12.0 → 2.13.0 — clears alert #31 (CVE-2025-3000 / GHSA-rrmf-rvhw-rf47, low; vulnerable range is `<= 2.12.0`, no official patched version listed)

## Why bump fixture pins at all

Dependabot alerts follow the auto-detected dependency graph and can't exclude fixture paths, so stale pins here generate a new alert for every future CVE against these packages. Current versions keep the demo identical in behavior (the scanner demos dependency *extraction*, not CVE matching) while eliminating the recurring alert noise on a public security-tool repo.

## Verification

Ran `aisbom scan ./demo_data` locally — the generated SBOM picks up `torch 2.13.0` and `transformers 5.13.1`, and the mock-malware CRITICAL detection (exit code 2) still works as expected.

## Not addressed here

Alerts #32/#34 claim the same packages exist in `poetry.lock` — they never have (verified across full git history). Those are dependency-graph mis-attributions and will be dismissed as inaccurate separately.
