### PR TITLE
Stale-loop nudge: warn after 3 consecutive identical fetch failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ jobs:
 
 > **Egress note:** hosted/firewalled CI runners must allow outbound HTTPS to `huggingface.co` **and** its LFS CDN (`cdn-lfs.huggingface.co` and the presigned object-storage hosts it redirects to). A blocked CDN hop surfaces as a network/timeout error, not an auth failure.
 
+If the **same scan keeps failing identically** (common in unattended cron/CI jobs pointed at a gated repo with no token), AIsbom notices: from the third consecutive identical failure it prints a loud stderr warning with the likely fix — set `HF_TOKEN` as above, or upgrade if a newer CLI has fixes for that failure mode. The counter lives in a small local state file; see [Telemetry & Privacy](#telemetry--privacy).
+
 ### Share a scan with your team
 
 ```bash
@@ -322,7 +324,11 @@ If you explicitly use `--share`: the generated `sbom.json` document is uploaded 
 
 Per `aisbom diff`: a `cli_diff` event with `has_drift=true|false`.
 
-On a scan fetch failure or unhandled exception: a `cli_error` event records the exception class name only (e.g. `JSONDecodeError`), a low-cardinality `http_status` bucket (e.g. `401`, `timeout`), and a `token_present` boolean (whether an `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` was set) — never the token value, the message, the traceback, a URL, or any file content.
+On a scan fetch failure or unhandled exception: a `cli_error` event records the exception class name only (e.g. `JSONDecodeError`), a low-cardinality `http_status` bucket (e.g. `401`, `timeout`), a `token_present` boolean (whether an `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` was set), and a `consecutive_failures` bucket (`1`–`9` or `10+` — how many runs in a row hit the same failure shape) — never the token value, the message, the traceback, a URL, or any file content.
+
+### Local state (no network)
+
+To detect failure loops (see [Authentication](#authentication-private--gated-hugging-face-models)), AIsbom keeps `~/.aisbom/loop_state.json`: the failure *shape* of the last failing scan (exception class name, HTTP status bucket, target-type bucket — never a URL, repo id, or path), a consecutive-run counter, and a timestamp. This file is purely local UX state and involves no network, so it is written **even when `AISBOM_NO_TELEMETRY` is set**; it is cleared automatically when a scan of the same target class succeeds, and deleting it is always safe.
 
 Each event carries an anonymous `user_id` — a SHA-256 of your machine's MAC address plus an app salt, truncated to 16 hex chars. Stored in `~/.aisbom/config.json`. Lets us see returning users without identifying anyone.
 
@@ -332,7 +338,7 @@ File paths, directory contents, model names, target URLs, file hashes from your 
 
 ### Opt out
 
-Set `AISBOM_NO_TELEMETRY=1`. This wins over every other setting — telemetry will not fire and `~/.aisbom/config.json` will not be written.
+Set `AISBOM_NO_TELEMETRY=1`. This wins over every other setting — telemetry will not fire and `~/.aisbom/config.json` will not be written. (The [local, network-free `loop_state.json`](#local-state-no-network) is the one file still maintained, since it never leaves your machine.)
 
 ```bash
 # Permanent

--- a/action/README_ACTION.md
+++ b/action/README_ACTION.md
@@ -119,9 +119,15 @@ To disable 1 and 3, set `AISBOM_NO_TELEMETRY=1` in your workflow's `env:` block.
 
 ## Troubleshooting
 
-**"Resource not accessible by integration"** — the workflow is missing `pull-requests: write`. See the Permissions section above.
+### Why isn't the Action posting comments on my PRs?
 
-**Comment didn't appear** — the Action only comments on `pull_request` events. On `push` / `schedule` / `workflow_dispatch` triggers, the SBOM artifact is produced but no comment is posted (there's no PR to comment on).
+Three known causes, all distinguishable from the Action's own log output:
+
+1. **The workflow isn't triggered on `pull_request`.** On `push` / `schedule` / `workflow_dispatch` triggers there is no PR to comment on — the SBOM artifact is still produced, but commenting is impossible. The log shows `Cannot post PR comment — missing: pr_number …` (reported as `no_pr_context`). Fix: add a `pull_request:` trigger to the workflow.
+
+2. **The PR comes from a fork.** GitHub restricts `${{ github.token }}` to **read-only** on `pull_request` events from forked repositories, regardless of what your `permissions:` block requests. The scan runs and the SBOM is produced; the comment post fails with a permission error in the log. This is a GitHub security policy, not a configuration issue — there is no safe way around it with the default token.
+
+3. **The workflow is missing `permissions: pull-requests: write`.** The log shows `Could not post PR comment … Check the workflow has pull-requests: write permission` (you may also see GitHub's "Resource not accessible by integration"). Fix: add the Permissions block shown above. The job still succeeds — the Action never fails your CI over a comment-permission issue.
 
 **Re-runs create duplicate comments** — please file an issue. The marker-based idempotency is meant to be unbreakable, but if you're seeing duplicates we want to know.
 

--- a/aisbom/cli.py
+++ b/aisbom/cli.py
@@ -24,6 +24,7 @@ import threading
 import time
 import uuid
 from .version_check import check_latest_version
+from . import loop_state
 from . import telemetry
 import requests
 
@@ -179,6 +180,51 @@ def _scan_error_payload(exc: BaseException, target: str) -> dict:
         "token_present": _token_present(),
         "target_type": _classify_target(target),
     }
+
+
+def _maybe_print_loop_warning(count: int, http_status: str) -> None:
+    """Stale-loop nudge (#99): warn once the same failure repeats N runs.
+
+    Printed to stderr only, after the per-file error messages, so CI log
+    parsers and `--output` consumers are unaffected. The upgrade line rides
+    on the background version check that scan already started — when that
+    thread hasn't reported a newer version, the line is simply omitted (no
+    extra network call, no blocking).
+    """
+    if count < loop_state.LOOP_WARN_THRESHOLD:
+        return
+    # Wording note: the fingerprint is target-blind by design (no URLs/repo
+    # ids on disk), so consecutive failures on *different* models with the
+    # same error shape share one counter — say "your scans", not "this scan".
+    lines = [
+        f"[bold yellow]⚠ Your scans have hit the same error "
+        f"{count} times in a row.[/bold yellow]"
+    ]
+    if http_status in ("401", "403"):
+        if _token_present() == "true":
+            lines.append(
+                "• A token is set but authentication keeps failing — verify "
+                "HF_TOKEN is valid and the model's license is accepted "
+                '(see README "Authentication").'
+            )
+        else:
+            lines.append(
+                "• If this is a gated/private Hugging Face repo: set HF_TOKEN "
+                '(see README "Authentication").'
+            )
+    newer = update_result.get("version")
+    if newer:
+        try:
+            curr = importlib.metadata.version("aisbom-cli")
+        except Exception:
+            curr = "unknown"
+        lines.append(
+            f"• You are on v{curr}; v{newer} includes fixes for repeated "
+            "fetch failures — run: pip install --upgrade aisbom-cli"
+        )
+    err_console.print(
+        Panel("\n".join(lines), border_style="yellow", expand=False)
+    )
 
 
 def _format_fetch_error(exc: BaseException, url: str) -> str:
@@ -427,10 +473,17 @@ def scan(
     except Exception as e:
         # Safety net for unexpected scan crashes. Per-target *fetch* failures are
         # caught inside the scanner now (recorded as structured errors, no
-        # traceback); anything reaching here is genuinely unexpected.
+        # traceback); anything reaching here is genuinely unexpected. Crashes
+        # still feed the loop detector (#99) — a repeating crash is a loop too.
+        payload = _scan_error_payload(e, target)
+        crash_count = loop_state.record_failure(
+            payload["error_type"], payload["http_status"], payload["target_type"]
+        )
+        payload["consecutive_failures"] = loop_state.bucket_count(crash_count)
+        _maybe_print_loop_warning(crash_count, payload["http_status"])
         err_thread = telemetry.post_event(
             "cli_error",
-            _scan_error_payload(e, target),
+            payload,
             scan_id=scan_id,
         )
         _flush_telemetry_threads(telemetry_threads + [err_thread])
@@ -460,16 +513,42 @@ def scan(
     # failed scan emits both a cli_error (the failure) and the normal cli_scan
     # (context) below. Intentional; see the slice notes.
     fetch_failures = [e for e in results['errors'] if e.get('fetch_failure')]
+    # Loop detection (#99) works at scan granularity ("N runs in a row"): the
+    # first fetch failure's fingerprint represents the invocation. A scan with
+    # no fetch failures breaks any recorded loop for this target class.
+    if fetch_failures:
+        first_payload = _scan_error_payload(fetch_failures[0].get('exception'), target)
+        loop_count = loop_state.record_failure(
+            first_payload["error_type"],
+            first_payload["http_status"],
+            first_payload["target_type"],
+        )
+    else:
+        loop_state.record_success(_classify_target(target))
+        loop_count = 0
+    # Sharded models fail one-per-shard with near-identical messages (12
+    # shards → 12 lines differing only in filename). Group by status bucket
+    # and print each distinct failure mode once, naming the first file and
+    # counting the rest. Telemetry below stays per-file (#58 semantics).
+    failures_by_status: dict[str, list[dict]] = {}
     for err in fetch_failures:
-        exc = err.get('exception')
-        err_console.print(
-            f"[bold red]✖[/bold red] {_format_fetch_error(exc, err.get('file', ''))}"
-        )
+        status = _classify_http_status(err.get('exception'))
+        failures_by_status.setdefault(status, []).append(err)
+    for group in failures_by_status.values():
+        first = group[0]
+        msg = _format_fetch_error(first.get('exception'), first.get('file', ''))
+        if len(group) > 1:
+            plural = "file" if len(group) == 2 else "files"
+            msg += f" [dim](+{len(group) - 1} more {plural} with the same error)[/dim]"
+        err_console.print(f"[bold red]✖[/bold red] {msg}")
+    for err in fetch_failures:
+        payload = _scan_error_payload(err.get('exception'), target)
+        payload["consecutive_failures"] = loop_state.bucket_count(loop_count)
         telemetry_threads.append(
-            telemetry.post_event(
-                "cli_error", _scan_error_payload(exc, target), scan_id=scan_id
-            )
+            telemetry.post_event("cli_error", payload, scan_id=scan_id)
         )
+    if fetch_failures:
+        _maybe_print_loop_warning(loop_count, first_payload["http_status"])
 
     # Telemetry: fire cli_scan plus any conditional follow-ups now that the
     # scan completed and risk is known. Non-blocking; flushed before exit.

--- a/aisbom/loop_state.py
+++ b/aisbom/loop_state.py
@@ -1,0 +1,128 @@
+"""
+Local failure-loop detection for `aisbom scan`.
+
+Parent: aisbom-ops #99. The 2026-07-11 cli_error investigation found the
+fleet error rate dominated by single machines running automated scans that
+fail identically every day (gated HF repo, no token, old CLI). The only
+channel to reach such an operator is their own logs — so the CLI keeps a
+consecutive-failure counter and prints a loud stderr nudge once the same
+failure has happened LOOP_WARN_THRESHOLD times in a row.
+
+The state is a fingerprint of the *shape* of the failure — the same
+low-cardinality buckets `cli.py:_scan_error_payload()` computes
+(error_type, http_status bucket, target_type). No URLs, repo ids, paths,
+or messages are ever stored.
+
+Privacy note: the state file (~/.aisbom/loop_state.json) is local-only UX
+state and involves no network, so it is written even when
+AISBOM_NO_TELEMETRY is set. Documented in the README's Telemetry & Privacy
+section.
+
+PyInstaller constraint: stdlib only (see telemetry.py header).
+Contract: never raise, never block the scan flow.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from . import telemetry
+
+STATE_FILENAME = "loop_state.json"
+
+# 3rd consecutive identical failure triggers the stderr nudge.
+LOOP_WARN_THRESHOLD = 3
+
+
+def _state_path():
+    home = telemetry.get_config_dir()
+    if home is None:
+        return None
+    return home / STATE_FILENAME
+
+
+def _load_state() -> dict | None:
+    path = _state_path()
+    if path is None:
+        return None
+    try:
+        state = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return state if isinstance(state, dict) else None
+
+
+def _save_state(state: dict) -> None:
+    # Atomic write-tmp-then-rename, same idiom as telemetry.save_config, so
+    # concurrent CLI invocations cannot corrupt the file.
+    path = _state_path()
+    if path is None:
+        return
+    tmp = path.with_suffix(".json.tmp")
+    try:
+        tmp.write_text(json.dumps(state, separators=(",", ":")))
+        tmp.replace(path)
+    except (OSError, PermissionError):
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def record_failure(error_type: str, http_status: str, target_type: str) -> int:
+    """Record one scan-path fetch failure; return the consecutive count.
+
+    Increments when the fingerprint matches the stored one, resets to 1 when
+    it changed or no state exists. When the config dir is unwritable the
+    count is not persisted and every call reports 1 (the warning simply
+    never fires there — acceptable, since that environment also has no
+    stable identity to loop on).
+    """
+    try:
+        state = _load_state()
+        count = 1
+        if (
+            state is not None
+            and state.get("error_type") == error_type
+            and state.get("http_status") == http_status
+            and state.get("target_type") == target_type
+        ):
+            try:
+                count = int(state.get("count", 0)) + 1
+            except (TypeError, ValueError):
+                count = 1
+        _save_state({
+            "error_type": error_type,
+            "http_status": http_status,
+            "target_type": target_type,
+            "count": count,
+            "last_seen": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        })
+        return count
+    except Exception:
+        # Never let loop bookkeeping break a scan.
+        return 1
+
+
+def record_success(target_type: str) -> None:
+    """Clear the counter when a scan of the same target class succeeds.
+
+    A passing scan of a *different* target class says nothing about the
+    failing loop (e.g. a local scan succeeding doesn't mean the gated HF
+    repo started working), so the state is kept in that case.
+    """
+    try:
+        state = _load_state()
+        if state is None or state.get("target_type") != target_type:
+            return
+        path = _state_path()
+        if path is not None:
+            path.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def bucket_count(count: int) -> str:
+    """Low-cardinality string bucket for the telemetry dimension."""
+    return str(count) if count < 10 else "10+"

--- a/tests/test_loop_state.py
+++ b/tests/test_loop_state.py
@@ -1,0 +1,284 @@
+"""Unit tests for aisbom.loop_state — the consecutive-failure loop detector.
+
+Parent: aisbom-ops #99 (CLI stale-loop nudge). The module persists a local,
+privacy-neutral consecutive-failure counter in ~/.aisbom/loop_state.json so
+`aisbom scan` can warn an operator whose automated scans fail identically
+run after run. State is local-only UX state (no network), so it is written
+even when AISBOM_NO_TELEMETRY is set.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aisbom import loop_state
+
+
+@pytest.fixture
+def state_dir(tmp_path, monkeypatch):
+    """Writable config dir for loop state, overriding the conftest stub."""
+    monkeypatch.setattr("aisbom.telemetry.get_config_dir", lambda: tmp_path)
+    return tmp_path
+
+
+# ============================================================================
+# record_failure()
+# ============================================================================
+
+class TestRecordFailure:
+    def test_first_failure_returns_one_and_persists(self, state_dir):
+        count = loop_state.record_failure("HTTPError", "401", "huggingface")
+        assert count == 1
+        state = json.loads((state_dir / "loop_state.json").read_text())
+        assert state["error_type"] == "HTTPError"
+        assert state["http_status"] == "401"
+        assert state["target_type"] == "huggingface"
+        assert state["count"] == 1
+        assert "last_seen" in state
+
+    def test_identical_failure_increments(self, state_dir):
+        for expected in (1, 2, 3):
+            count = loop_state.record_failure("HTTPError", "401", "huggingface")
+            assert count == expected
+
+    def test_different_fingerprint_resets_to_one(self, state_dir):
+        loop_state.record_failure("HTTPError", "401", "huggingface")
+        loop_state.record_failure("HTTPError", "401", "huggingface")
+        # status changed 401 -> timeout: not the same loop
+        count = loop_state.record_failure("ConnectTimeout", "timeout", "huggingface")
+        assert count == 1
+        state = json.loads((state_dir / "loop_state.json").read_text())
+        assert state["http_status"] == "timeout"
+        assert state["count"] == 1
+
+    def test_corrupt_state_file_treated_as_fresh(self, state_dir):
+        (state_dir / "loop_state.json").write_text("{not json")
+        count = loop_state.record_failure("HTTPError", "401", "huggingface")
+        assert count == 1
+
+    def test_unwritable_dir_is_silent_noop(self, monkeypatch):
+        monkeypatch.setattr("aisbom.telemetry.get_config_dir", lambda: None)
+        # No dir: nothing persisted, but the call still reports this failure.
+        assert loop_state.record_failure("HTTPError", "401", "huggingface") == 1
+        assert loop_state.record_failure("HTTPError", "401", "huggingface") == 1
+
+    def test_works_with_telemetry_opted_out(self, state_dir, monkeypatch):
+        # Loop state is local-only UX state: AISBOM_NO_TELEMETRY must NOT
+        # disable it (documented in README Telemetry & Privacy).
+        monkeypatch.setenv("AISBOM_NO_TELEMETRY", "1")
+        assert loop_state.record_failure("HTTPError", "401", "huggingface") == 1
+        assert loop_state.record_failure("HTTPError", "401", "huggingface") == 2
+        assert (state_dir / "loop_state.json").exists()
+
+    def test_state_survives_across_invocations(self, state_dir):
+        # Simulates two separate CLI processes sharing the state file.
+        loop_state.record_failure("HTTPError", "401", "huggingface")
+        loop_state.record_failure("HTTPError", "401", "huggingface")
+        # A "new process" reads the same file fresh from disk.
+        assert loop_state.record_failure("HTTPError", "401", "huggingface") == 3
+
+
+# ============================================================================
+# record_success()
+# ============================================================================
+
+class TestRecordSuccess:
+    def test_success_on_same_target_type_clears_state(self, state_dir):
+        loop_state.record_failure("HTTPError", "401", "huggingface")
+        loop_state.record_failure("HTTPError", "401", "huggingface")
+        loop_state.record_success("huggingface")
+        assert not (state_dir / "loop_state.json").exists()
+        assert loop_state.record_failure("HTTPError", "401", "huggingface") == 1
+
+    def test_success_on_other_target_type_keeps_state(self, state_dir):
+        # A passing *local* scan says nothing about the failing HF loop.
+        loop_state.record_failure("HTTPError", "401", "huggingface")
+        loop_state.record_success("local")
+        assert loop_state.record_failure("HTTPError", "401", "huggingface") == 2
+
+    def test_success_with_no_state_is_noop(self, state_dir):
+        loop_state.record_success("huggingface")  # must not raise
+
+    def test_unwritable_dir_is_silent_noop(self, monkeypatch):
+        monkeypatch.setattr("aisbom.telemetry.get_config_dir", lambda: None)
+        loop_state.record_success("huggingface")  # must not raise
+
+
+# ============================================================================
+# bucket_count()
+# ============================================================================
+
+class TestBucketCount:
+    @pytest.mark.parametrize("count,expected", [
+        (1, "1"), (2, "2"), (9, "9"), (10, "10+"), (133, "10+"),
+    ])
+    def test_low_cardinality_buckets(self, count, expected):
+        assert loop_state.bucket_count(count) == expected
+
+
+# ============================================================================
+# CLI wiring — the stderr nudge and the telemetry dimension
+# ============================================================================
+
+import requests
+from typer.testing import CliRunner
+
+import aisbom.cli as cli_module
+from aisbom.cli import app
+
+runner = CliRunner()
+
+
+def _http_error(status: int) -> requests.exceptions.HTTPError:
+    resp = requests.Response()
+    resp.status_code = status
+    return requests.exceptions.HTTPError(response=resp)
+
+
+class _FetchFailingScanner:
+    """DeepScanner stub returning a structured fetch failure (the #58 shape)."""
+
+    _exc: BaseException
+
+    def __init__(self, target, *args, **kwargs):
+        self._target_value = target
+
+    def scan(self):
+        return {
+            "artifacts": [],
+            "dependencies": [],
+            "errors": [
+                {
+                    "file": self._target_value,
+                    "error": str(type(self)._exc),
+                    "fetch_failure": True,
+                    "exception": type(self)._exc,
+                }
+            ],
+        }
+
+
+class _CleanScanner:
+    """DeepScanner stub that succeeds with nothing found."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def scan(self):
+        return {"artifacts": [], "dependencies": [], "errors": []}
+
+
+def _scanner_fetch_failing(exc: BaseException):
+    return type("_FFS", (_FetchFailingScanner,), {"_exc": exc})
+
+
+@pytest.fixture
+def cli_env(state_dir, tmp_path, monkeypatch):
+    """Loop-state-enabled CLI environment: writable state dir, no version
+    check network call, cwd pinned to tmp so sbom.json lands there."""
+    monkeypatch.setattr(cli_module, "run_version_check_wrapper", lambda: None)
+    monkeypatch.setattr(cli_module, "update_result", {"version": None})
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    monkeypatch.chdir(tmp_path)
+    return state_dir
+
+
+class TestLoopWarningCli:
+    def test_no_warning_before_third_failure(self, cli_env, monkeypatch):
+        monkeypatch.setattr(
+            cli_module, "DeepScanner", _scanner_fetch_failing(_http_error(401))
+        )
+        for _ in range(2):
+            result = runner.invoke(app, ["scan", "hf://acme/private-model"])
+            assert "times in a row" not in result.output
+
+    def test_third_identical_failure_prints_nudge_with_token_hint(
+        self, cli_env, monkeypatch
+    ):
+        monkeypatch.setattr(
+            cli_module, "DeepScanner", _scanner_fetch_failing(_http_error(401))
+        )
+        for _ in range(2):
+            runner.invoke(app, ["scan", "hf://acme/private-model"])
+        result = runner.invoke(app, ["scan", "hf://acme/private-model"])
+        assert "3 times in a row" in result.output
+        assert "HF_TOKEN" in result.output
+
+    def test_upgrade_hint_only_when_newer_version_known(self, cli_env, monkeypatch):
+        monkeypatch.setattr(
+            cli_module, "DeepScanner", _scanner_fetch_failing(_http_error(401))
+        )
+        for _ in range(2):
+            runner.invoke(app, ["scan", "hf://acme/private-model"])
+        # Version check already knows a newer version (no extra network call).
+        monkeypatch.setattr(cli_module, "update_result", {"version": "99.0.0"})
+        result = runner.invoke(app, ["scan", "hf://acme/private-model"])
+        assert "99.0.0" in result.output
+        assert "pip install --upgrade aisbom-cli" in result.output
+
+    def test_success_resets_counter(self, cli_env, monkeypatch):
+        monkeypatch.setattr(
+            cli_module, "DeepScanner", _scanner_fetch_failing(_http_error(401))
+        )
+        for _ in range(2):
+            runner.invoke(app, ["scan", "hf://acme/private-model"])
+        # A successful scan of the same target class breaks the loop...
+        monkeypatch.setattr(cli_module, "DeepScanner", _CleanScanner)
+        runner.invoke(app, ["scan", "hf://acme/private-model"])
+        # ...so the next failure is #1 again, not #3: no warning.
+        monkeypatch.setattr(
+            cli_module, "DeepScanner", _scanner_fetch_failing(_http_error(401))
+        )
+        result = runner.invoke(app, ["scan", "hf://acme/private-model"])
+        assert "times in a row" not in result.output
+
+    def test_non_auth_failure_omits_token_hint(self, cli_env, monkeypatch):
+        monkeypatch.setattr(
+            cli_module,
+            "DeepScanner",
+            _scanner_fetch_failing(requests.exceptions.Timeout()),
+        )
+        for _ in range(2):
+            runner.invoke(app, ["scan", "hf://acme/model"])
+        result = runner.invoke(app, ["scan", "hf://acme/model"])
+        assert "3 times in a row" in result.output
+        assert "HF_TOKEN" not in result.output
+
+
+class TestConsecutiveFailuresTelemetry:
+    def _capture_cli_error(self, monkeypatch):
+        captured: list[dict] = []
+
+        def _record(event, params=None, scan_id=None):
+            if event == "cli_error":
+                captured.append(dict(params or {}))
+            return None
+
+        monkeypatch.setattr("aisbom.telemetry.post_event", _record)
+        return captured
+
+    def test_fetch_failure_payload_carries_bucketed_count(self, cli_env, monkeypatch):
+        captured = self._capture_cli_error(monkeypatch)
+        monkeypatch.setattr(
+            cli_module, "DeepScanner", _scanner_fetch_failing(_http_error(401))
+        )
+        for _ in range(3):
+            runner.invoke(app, ["scan", "hf://acme/private-model"])
+        assert [p["consecutive_failures"] for p in captured] == ["1", "2", "3"]
+
+    def test_crash_path_payload_carries_count(self, cli_env, monkeypatch):
+        captured = self._capture_cli_error(monkeypatch)
+
+        class _Raising:
+            def __init__(self, *a, **kw):
+                pass
+
+            def scan(self):
+                raise _http_error(500)
+
+        monkeypatch.setattr(cli_module, "DeepScanner", _Raising)
+        runner.invoke(app, ["scan", "hf://acme/model"])
+        assert captured and captured[0]["consecutive_failures"] == "1"

--- a/tests/test_scanner_cli.py
+++ b/tests/test_scanner_cli.py
@@ -571,7 +571,12 @@ def test_cli_error_payload_leaks_no_token_url_or_body(monkeypatch):
         "http_status",
         "token_present",
         "target_type",
+        "consecutive_failures",
     }
+    # The loop-detector dimension (#99) is a bucketed count, never raw data.
+    assert captured[0]["consecutive_failures"] in (
+        [str(n) for n in range(1, 10)] + ["10+"]
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -683,6 +688,74 @@ def test_scan_gated_without_token_prints_clean_message_and_exits_1(monkeypatch):
     # Status-aware hint (printed via the stderr console; merged into output here).
     assert "private" in result.output or "gated" in result.output
     assert "HF_TOKEN" in result.output
+
+
+class _MultiFetchFailingScanner:
+    """DeepScanner stub returning several structured fetch failures at once
+    (the sharded-model case: model-0000N-of-00012.safetensors × N)."""
+
+    _errors: list[dict]
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def scan(self):
+        return {"artifacts": [], "dependencies": [], "errors": list(type(self)._errors)}
+
+
+def _scanner_multi_failing(errors: list[dict]):
+    return type("_MFS", (_MultiFetchFailingScanner,), {"_errors": errors})
+
+
+def _shard_error(i: int, exc: BaseException) -> dict:
+    url = (
+        "https://huggingface.co/acme/model/resolve/main/"
+        f"model-{i:05d}-of-00012.safetensors"
+    )
+    return {"file": url, "error": str(exc), "fetch_failure": True, "exception": exc}
+
+
+def test_sharded_identical_fetch_failures_print_one_deduped_line(monkeypatch):
+    # 12 shards, all 401: one ✖ line naming the first shard + a count,
+    # not 12 near-identical lines (verification feedback on #99).
+    errors = [_shard_error(i, _http_error(401)) for i in range(1, 13)]
+    monkeypatch.setattr(cli_module, "DeepScanner", _scanner_multi_failing(errors))
+
+    result = runner.invoke(app, ["scan", "hf://acme/model"])
+
+    # Rich wraps at the test terminal width; normalize before matching.
+    flat = " ".join(result.output.split())
+    assert flat.count("Authentication failed") == 1
+    assert "model-00001-of-00012.safetensors" in flat
+    assert "11 more files with the same error" in flat
+
+
+def test_mixed_failure_modes_print_one_line_each(monkeypatch):
+    # Distinct failure modes must NOT collapse together.
+    errors = [
+        _shard_error(1, _http_error(401)),
+        _shard_error(2, _http_error(401)),
+        _shard_error(3, requests.exceptions.Timeout()),
+    ]
+    monkeypatch.setattr(cli_module, "DeepScanner", _scanner_multi_failing(errors))
+
+    result = runner.invoke(app, ["scan", "hf://acme/model"])
+
+    flat = " ".join(result.output.split())
+    assert flat.count("Authentication failed") == 1
+    assert "1 more file with the same error" in flat
+    assert flat.count("Network error") == 1
+
+
+def test_sharded_failures_still_emit_one_cli_error_per_file(monkeypatch):
+    # Display is deduped; telemetry emission stays per-file (#58 semantics).
+    captured = _capture_cli_error(monkeypatch)
+    errors = [_shard_error(i, _http_error(401)) for i in range(1, 13)]
+    monkeypatch.setattr(cli_module, "DeepScanner", _scanner_multi_failing(errors))
+
+    runner.invoke(app, ["scan", "hf://acme/model"])
+
+    assert len(captured) == 12
 
 
 def test_scan_fetch_failure_emits_both_cli_error_and_cli_scan(monkeypatch):


### PR DESCRIPTION
Implements aisbom-ops #99 (CLI stale-loop nudge).

## What

- **New `aisbom/loop_state.py`** — persists `~/.aisbom/loop_state.json` with the failure *shape* of the last failing scan (`error_type` / `http_status` bucket / `target_type` — never a URL, repo id, or path), a consecutive-run counter, and a timestamp. Atomic writes, never raises, silent no-op when `~/.aisbom` is unwritable. Local-only UX state: maintained even under `AISBOM_NO_TELEMETRY`, cleared when a scan of the same target class succeeds.
- **CLI wiring** — both failure paths (structured fetch failures and unexpected crashes) feed the detector. From the 3rd consecutive identical failure, a stderr-only panel prints status-aware remediation: HF_TOKEN hint on 401/403 (token-aware wording), upgrade hint only when the background version check already knows a newer release (no extra network call). `cli_error` telemetry gains `consecutive_failures`, bucketed `1`–`9` / `10+`.
- **Sharded-model display dedupe** — 12 shards failing with the same 401 now print one `✖` line with `(+11 more files with the same error)` instead of 12 near-identical lines. Telemetry emission stays per-file (#58 semantics unchanged).
- **Docs** — README: "Local state (no network)" privacy subsection, `consecutive_failures` in the `cli_error` description, loop-nudge note under Authentication. `action/README_ACTION.md`: troubleshooting reworked into "Why isn't the Action posting comments on my PRs?" covering the three log-distinguished causes (`no_pr_context` trigger, fork-PR read-only token, missing `pull-requests: write`).

## Why

The 2026-07-11 cli_error investigation traced the fleet error rate to one machine on CLI 0.10.0 running ~daily automated scans of a gated HF repo with no token (133 of 212 errors in 25 days). The operator of an anonymous cron machine has exactly one reachable channel: their own logs.

## Verification

- 253 tests pass, coverage 88.64% (gate 85%)
- Live E2E against `hf://google/gemma-3-27b-it` (gated, no token): runs 1–2 normal errors only; run 3 prints the nudge; state file carries only buckets + count; exit codes unchanged; founder-verified including token-present wording and counter persistence
