### PR TITLE
security: bump setuptools to 83.0.0 (GHSA-h35f-9h28-mq5c)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -872,25 +872,25 @@ doc = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "setuptools"
-version = "81.0.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
+version = "83.0.0"
+description = "Most extensible Python build backend with support for C/C++ extension modules"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 markers = "python_version < \"3.15\""
 files = [
-    {file = "setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6"},
-    {file = "setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a"},
+    {file = "setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3"},
+    {file = "setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef"},
 ]
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
-core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
+core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-enabler = ["pytest-enabler (>=2.2)"]
+enabler = ["pytest-enabler (>=3.4)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [[package]]
 name = "shellingham"


### PR DESCRIPTION
Closes the one open Dependabot alert on this repo: [#35](https://github.com/Lab700xOrg/aisbom/security/dependabot/35), `setuptools < 83.0.0` (**GHSA-h35f-9h28-mq5c**, medium).

## The vulnerability

`MANIFEST.in` exclusion directives (`exclude`, `global-exclude`, `recursive-exclude`, `prune`) are matched against on-disk filenames byte-for-byte, with no Unicode normalization. On macOS APFS/HFS+ a rule saved in NFC does not match a filename written in NFD even though the filesystem treats them as the same file, so a file the maintainer meant to exclude gets packed into the sdist and, if published, uploaded to the immutable PyPI index. Pure-ASCII rules are unaffected.

## The change

`poetry.lock` only — setuptools `81.0.0` → `83.0.0`. setuptools is a transitive **dev-group** dependency (pyinstaller requires `>=42.0.0`) used when building the standalone binaries; it is not shipped to CLI users. No `pyproject.toml` constraint was added because `83.0.0` already satisfies pyinstaller's existing range.

## Verification (no regression)

- `poetry check --lock` clean; lock diff is isolated to the setuptools block (no other package, no `content-hash`/`lock-version` churn).
- Full suite green: **253 passed**, coverage **88.64%** (gate is 85%).
- CLI output diffed against a pre-bump baseline across `--help`/`--version`/`info`, `scan` in terminal/markdown/JSON/SPDX form, `--strict`, `--lint`, `--no-fail-on-risk`, `diff`, and the missing-target and bad-flag error paths — **byte-identical** after normalizing inherently volatile fields (timestamps, random `bom-ref`s, SPDX ids).
- Since setuptools is pyinstaller's dependency, the risk is the binary build rather than the test suite, so `scripts/build_binaries.sh` was run end-to-end: 17M arm64 binary produced, and the frozen binary still flags `mock_malware.pt` as `CRITICAL (RCE posix.system)` and exits `2`.
