### PR TITLE
fix(spdx): real filenames, deterministic IDs, and checksums in SPDX export (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 1.2.1 — 2026-08-08
+
+- SPDX export (`--format spdx`) now reports each model's real filename instead of labelling every artifact `unknown-model`, and its real format (`pickle` / `safetensors` / `gguf`) instead of `unknown`.
+- SPDX packages now carry the SHA256 checksum of the scanned file. Remotely-scanned artifacts, whose bytes are never fully read, omit the field rather than asserting a placeholder.
+- SPDX identifiers are now derived from file content instead of a process memory address, so scanning unchanged inputs twice produces identical documents and SPDX SBOMs can be diffed meaningfully in CI.
+- SPDX documents now report the running CLI version in `creators` (previously hardcoded to `aisbom-cli-0.1.0`).
+- Fixed `--format spdx` crashing on a `requirements.txt` that repeats a pin or uses a wildcard version (e.g. `torch>=2.0.*`), and on a scan that finds no models and no requirements. All three produced an invalid document and an unhandled traceback.
+- CycloneDX output is byte-for-byte unchanged.
+
 ## 1.2.0 — 2026-06-11
 
 - The hosted dashboard at <https://app.aisbom.io> is now generally available (previously private early access). The GitHub Action's optional `token` input posts each scan's SBOM to your inventory dashboard — get a per-repo token at <https://app.aisbom.io/connect>. See the README's "Hosted dashboard (optional)" and "Data flow & privacy" sections for exactly what is sent (and how to keep the Action purely local: just leave `token` unset).

--- a/aisbom/spdx_gen.py
+++ b/aisbom/spdx_gen.py
@@ -1,4 +1,6 @@
+import importlib.metadata
 import json
+import re
 from datetime import datetime, timezone
 import hashlib
 from typing import Dict, List, Any
@@ -14,48 +16,102 @@ from spdx_tools.spdx.model import (
     Relationship,
     RelationshipType,
     SpdxNoAssertion,
+    SpdxNone,
     Checksum,
     ChecksumAlgorithm
 )
 from spdx_tools.spdx.writer.json import json_writer
+
+from .properties import _format_for
+
+# A SHA256 hexdigest, as produced by ``DeepScanner._calculate_hash``. The
+# scanner also stores the sentinels ``remote_unhashed`` (range-request scans,
+# where the bytes are never fully read) and ``hash_error`` (unreadable file) in
+# the same field, so every consumer here has to distinguish a real digest from
+# a placeholder rather than trusting the field to hold one.
+_SHA256_RE = re.compile(r"[0-9a-fA-F]{64}")
+
+# SPDXID payloads are restricted to ``[a-zA-Z0-9.-]`` by the 2.3 spec.
+_SPDX_ID_SAFE_RE = re.compile(r"[^a-zA-Z0-9.\-]")
+
+
+def _tool_version() -> str:
+    """Version of the running CLI, for the document's ``creators`` field.
+
+    Mirrors ``cli.py``'s ``--version`` lookup. The PyInstaller binary ships
+    without distribution metadata, so the lookup must not be load-bearing.
+    """
+    try:
+        return importlib.metadata.version("aisbom-cli")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _sanitize(value: str) -> str:
+    """Reduce arbitrary text to characters an SPDXID may carry."""
+    return _SPDX_ID_SAFE_RE.sub("-", str(value))
+
+
+def _sha256_or_none(value: Any) -> str | None:
+    """Return ``value`` as a lowercase SHA256 hexdigest, or None if it isn't one."""
+    if isinstance(value, str) and _SHA256_RE.fullmatch(value):
+        return value.lower()
+    return None
+
 
 class SPDX2Generator:
     def __init__(self, creation_time=None):
         self.creation_time = creation_time or datetime.now(timezone.utc)
         self.packages = []
         self.relationships = []
-        
+        # SPDXIDs must be unique within a document. IDs are derived from
+        # content so they stay stable across runs, but content alone cannot
+        # guarantee uniqueness (the same file under the same basename in two
+        # directories; every artifact of a remote scan sharing one sentinel
+        # hash), so collisions are resolved by suffix in emission order.
+        self._used_ids = set()
+
     def generate(self, results: Dict[str, Any]) -> str:
         """
         Converts AISBOM scan results to SPDX 2.3 JSON string.
         """
         doc_namespace = f"http://spdx.org/spdxdocs/aisbom-scan-{self.creation_time.timestamp()}"
         doc_spdx_id = "SPDXRef-DOCUMENT"
-        
+
         # 1. Creation Info
         creation_info = CreationInfo(
             spdx_version="SPDX-2.3",
             spdx_id=doc_spdx_id,
             name="AIsbom-Scan",
             document_namespace=doc_namespace,
-            creators=[Actor(ActorType.TOOL, "aisbom-cli-0.1.0")],
+            creators=[Actor(ActorType.TOOL, f"aisbom-cli-{_tool_version()}")],
             created=self.creation_time,
             data_license="CC0-1.0"
         )
-        
+
         document = Document(creation_info=creation_info)
 
         # 2. Process Artifacts (AI Models)
         artifacts = results.get("artifacts", [])
-        for art in artifacts:
-            self._process_artifact(art, doc_spdx_id)
+        for index, art in enumerate(artifacts):
+            self._process_artifact(art, doc_spdx_id, index)
 
         # 3. Process Dependencies (Libraries)
         dependencies = results.get("dependencies", [])
         for dep in dependencies:
             self._process_dependency(dep, doc_spdx_id)
-            
+
         # 4. Assemble Document
+        # SPDX requires an explicit DESCRIBES relationship unless the document
+        # holds exactly one package, so a scan that turned up neither models
+        # nor requirements has to say it describes NONE. Without this the
+        # writer's validator rejects the document and the CLI dies on what is
+        # a perfectly ordinary result.
+        if not self.relationships:
+            self.relationships.append(Relationship(
+                doc_spdx_id, RelationshipType.DESCRIBES, SpdxNone()
+            ))
+
         document.packages = self.packages
         document.relationships = self.relationships
 
@@ -64,20 +120,44 @@ class SPDX2Generator:
         output = StringIO()
         json_writer.write_document_to_stream(document, output)
         return output.getvalue()
-        
-    def _process_artifact(self, artifact: Dict, doc_spdx_id: str):
+
+    def _claim_id(self, base: str) -> str:
+        """Return ``base``, or the first free ``base-N`` if it's already taken."""
+        candidate = base
+        suffix = 2
+        while candidate in self._used_ids:
+            candidate = f"{base}-{suffix}"
+            suffix += 1
+        self._used_ids.add(candidate)
+        return candidate
+
+    def _process_artifact(self, artifact: Dict, doc_spdx_id: str, index: int = 0):
         """Map AI model artifact to SPDX Package."""
-        name = artifact.get("filename", "unknown-model")
-        # Sanitize name for ID
-        safe_name = "".join(c if c.isalnum() else "-" for c in name)
-        spdx_id = f"SPDXRef-Artifact-{safe_name}-{id(artifact)}"
-        
-        # Risk / Format details
+        # The scanner emits ``name``; ``filename`` is accepted as a fallback
+        # for callers still building artifacts the old way.
+        name = artifact.get("name") or artifact.get("filename") or "unknown-model"
+        safe_name = _sanitize(name)
+
+        # Prefer a content-derived discriminator so unchanged inputs yield
+        # byte-identical documents. Artifacts without a real digest (remote
+        # scans, read failures) fall back to position, which is stable for a
+        # given scan but carries no content meaning.
+        digest = _sha256_or_none(artifact.get("hash"))
+        discriminator = digest[:12] if digest else str(index)
+        spdx_id = self._claim_id(f"SPDXRef-Artifact-{safe_name}-{discriminator}")
+
+        # Risk / Format details. The format token comes from the same helper
+        # the CycloneDX path uses, so the two exports cannot drift apart.
         comment = (
-            f"Type: {artifact.get('format', 'unknown')}\n"
+            f"Type: {_format_for(artifact) or 'unknown'}\n"
             f"Risk: {artifact.get('risk_level', 'UNKNOWN')}\n"
             f"Framework: {artifact.get('framework', 'unknown')}"
         )
+
+        # Emit a checksum only when there is a genuine digest to report —
+        # asserting nothing is correct for a remote artifact, whereas writing
+        # the sentinel into the field would be a falsehood in a security SBOM.
+        checksums = [Checksum(ChecksumAlgorithm.SHA256, digest)] if digest else []
 
         pkg = Package(
             name=name,
@@ -85,14 +165,15 @@ class SPDX2Generator:
             download_location=SpdxNoAssertion(),
             files_analyzed=False,
             version="unknown", # Model version usually not in scan
+            checksums=checksums,
             comment=comment,
             license_concluded=SpdxNoAssertion(),
              license_declared=SpdxNoAssertion(),
              copyright_text=SpdxNoAssertion()
         )
-            
+
         self.packages.append(pkg)
-        
+
         # Relationship: DOCUMENT DESCRIBES Package
         self.relationships.append(Relationship(
             doc_spdx_id, RelationshipType.DESCRIBES, spdx_id
@@ -102,9 +183,13 @@ class SPDX2Generator:
         """Map library dependency to SPDX Package."""
         name = dep.get("name", "unknown-lib")
         version = dep.get("version", "unknown")
-        safe_name = "".join(c if c.isalnum() else "-" for c in name)
-        spdx_id = f"SPDXRef-Lib-{safe_name}-{version}"
-        
+        # Versions reach here straight off a requirements specifier, so they
+        # can carry characters an SPDXID may not (``2.0.*``); and the same pin
+        # listed in two requirements files would otherwise claim one ID twice.
+        spdx_id = self._claim_id(
+            f"SPDXRef-Lib-{_sanitize(name)}-{_sanitize(version)}"
+        )
+
         pkg = Package(
             name=name,
             spdx_id=spdx_id,
@@ -115,7 +200,7 @@ class SPDX2Generator:
             license_declared=SpdxNoAssertion(),
             copyright_text=SpdxNoAssertion()
         )
-        
+
         self.packages.append(pkg)
         self.relationships.append(Relationship(
             doc_spdx_id, RelationshipType.DESCRIBES, spdx_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aisbom-cli"
-version = "1.2.0"
+version = "1.2.1"
 description = "An AI Supply Chain security tool that that detects Pickle bombs and generates CycloneDX SBOMs for Machine Learning models."
 authors = ["Ajoy L <lab700xdev@gmail.com>"]
 readme = "README.md"

--- a/tests/test_spdx.py
+++ b/tests/test_spdx.py
@@ -1,6 +1,44 @@
 import pytest
 import json
+import importlib.metadata
 from aisbom.spdx_gen import generate_spdx_sbom
+
+# A real 64-hex SHA256, the shape ``DeepScanner._calculate_hash`` returns.
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+
+
+def _pytorch_artifact(name="model.pt", artifact_hash=SHA_A, **overrides):
+    """Build an artifact dict shaped like the one ``DeepScanner`` emits.
+
+    Constructed fresh on each call so two "runs" produce equal-but-distinct
+    dicts — which is what makes the determinism test meaningful.
+    """
+    art = {
+        "name": name,
+        "type": "machine-learning-model",
+        "framework": "PyTorch",
+        "risk_level": "MEDIUM (Pickle Present)",
+        "license": "Unknown",
+        "legal_status": "UNKNOWN",
+        "hash": artifact_hash,
+        "details": {},
+    }
+    art.update(overrides)
+    return art
+
+
+def _generate(artifacts=None, dependencies=None):
+    return json.loads(generate_spdx_sbom({
+        "artifacts": artifacts or [],
+        "dependencies": dependencies or [],
+        "errors": [],
+    }))
+
+
+def _artifact_packages(data):
+    return [p for p in data["packages"] if p["SPDXID"].startswith("SPDXRef-Artifact-")]
+
 
 def test_spdx_generation():
     # Mock Results
@@ -24,26 +62,246 @@ def test_spdx_generation():
         ],
         "errors": []
     }
-    
+
     # Generate SPDX
     spdx_json_str = generate_spdx_sbom(results)
-    
+
     # Verify it is valid JSON
     data = json.loads(spdx_json_str)
-    
+
     # Verify Structure
     assert "SPDXID" in data
     assert data["name"] == "AIsbom-Scan"
     assert len(data.get("packages", [])) == 2
-    
+
     # Check Artifact Mapping
     pkgs = data["packages"]
     model_pkg = next(p for p in pkgs if "model" in p["name"])
     assert model_pkg["name"] == "model.pkl"
     assert "SPDXRef-Artifact-" in model_pkg["SPDXID"]
     assert "PyTorch" in model_pkg.get("comment", "")
-    
+
     # Check Dependency Mapping
     lib_pkg = next(p for p in pkgs if p["name"] == "requests")
     assert lib_pkg["versionInfo"] == "2.28.1"
     assert "SPDXRef-Lib-" in lib_pkg["SPDXID"]
+
+
+# --- Artifact naming -------------------------------------------------------
+
+def test_artifact_uses_scanner_name_key():
+    """The scanner emits ``name``; the exporter used to read ``filename``, so
+    every artifact in every emitted document was called ``unknown-model``."""
+    data = _generate([_pytorch_artifact(name="mock_malware.pt")])
+    pkg = _artifact_packages(data)[0]
+    assert pkg["name"] == "mock_malware.pt"
+    assert "unknown-model" not in pkg["SPDXID"]
+
+
+def test_artifact_falls_back_to_filename_then_placeholder():
+    data = _generate([
+        {"filename": "legacy.pt", "framework": "PyTorch", "hash": SHA_A},
+        {"framework": "PyTorch", "hash": SHA_B},
+    ])
+    names = [p["name"] for p in _artifact_packages(data)]
+    assert names == ["legacy.pt", "unknown-model"]
+
+
+# --- SPDXID determinism and uniqueness -------------------------------------
+
+def test_spdxids_deterministic_across_runs():
+    """Two scans of unchanged inputs must yield byte-identical package IDs and
+    relationship refs. The old ID was built from ``id(artifact)`` — a memory
+    address — so this failed."""
+    def run():
+        return _generate(
+            [_pytorch_artifact(name="model.pt"),
+             _pytorch_artifact(name="other.safetensors", artifact_hash=SHA_B,
+                               framework="SafeTensors")],
+            [{"name": "requests", "version": "2.28.1"}],
+        )
+
+    first, second = run(), run()
+
+    assert [p["SPDXID"] for p in first["packages"]] == \
+           [p["SPDXID"] for p in second["packages"]]
+    assert [r["relatedSpdxElement"] for r in first["relationships"]] == \
+           [r["relatedSpdxElement"] for r in second["relationships"]]
+
+
+def test_spdxid_derived_from_content_hash():
+    """Same name, different bytes -> different IDs. Different name, same bytes
+    -> different IDs. Neither may depend on object identity."""
+    data = _generate([
+        _pytorch_artifact(name="model.pt", artifact_hash=SHA_A),
+        _pytorch_artifact(name="model.pt", artifact_hash=SHA_B),
+    ])
+    ids = [p["SPDXID"] for p in _artifact_packages(data)]
+    assert ids[0] != ids[1]
+    assert SHA_A[:12] in ids[0]
+    assert SHA_B[:12] in ids[1]
+
+
+def test_spdxids_unique_for_identical_name_and_hash():
+    """The same file content under the same basename in two directories still
+    needs two distinct package IDs."""
+    data = _generate([
+        _pytorch_artifact(name="model.pt", artifact_hash=SHA_A),
+        _pytorch_artifact(name="model.pt", artifact_hash=SHA_A),
+        _pytorch_artifact(name="model.pt", artifact_hash=SHA_A),
+    ])
+    ids = [p["SPDXID"] for p in _artifact_packages(data)]
+    assert len(set(ids)) == 3
+
+
+def test_spdxids_unique_when_names_sanitize_identically():
+    """``safe_name`` maps every non-alphanumeric char to ``-``, so ``model.pt``
+    and ``model-pt`` collapse to the same token."""
+    data = _generate([
+        _pytorch_artifact(name="model.pt", artifact_hash=SHA_A),
+        _pytorch_artifact(name="model-pt", artifact_hash=SHA_A),
+    ])
+    ids = [p["SPDXID"] for p in _artifact_packages(data)]
+    assert len(set(ids)) == 2
+
+
+def test_spdxids_unique_when_every_artifact_is_remote_unhashed():
+    """Remote scans set ``hash`` to the literal ``remote_unhashed``, so a
+    hash-only ID would collapse every remote artifact onto one package."""
+    data = _generate([
+        _pytorch_artifact(name="model.pt", artifact_hash="remote_unhashed"),
+        _pytorch_artifact(name="model.pt", artifact_hash="remote_unhashed"),
+        _pytorch_artifact(name="weights.pt", artifact_hash="remote_unhashed"),
+    ])
+    ids = [p["SPDXID"] for p in _artifact_packages(data)]
+    assert len(set(ids)) == 3
+    assert not any("remote_unhashed" in i for i in ids)
+
+
+def test_spdxids_match_the_spdx_ref_pattern():
+    import re
+    data = _generate(
+        [_pytorch_artifact(name="odd name!@#$.pt")],
+        [{"name": "some-lib", "version": "2.0.*"}],
+    )
+    for pkg in data["packages"]:
+        assert re.fullmatch(r"SPDXRef-[a-zA-Z0-9.\-]+", pkg["SPDXID"]), pkg["SPDXID"]
+
+
+# --- Checksums -------------------------------------------------------------
+
+def test_checksum_emitted_for_local_artifact():
+    data = _generate([_pytorch_artifact(artifact_hash=SHA_A)])
+    pkg = _artifact_packages(data)[0]
+    assert pkg["checksums"] == [{"algorithm": "SHA256", "checksumValue": SHA_A}]
+
+
+@pytest.mark.parametrize("sentinel", ["remote_unhashed", "hash_error", "", None])
+def test_checksum_omitted_not_faked_for_non_digest_hashes(sentinel):
+    """Sentinels are not digests. Omitting the field is correct; emitting the
+    sentinel as a checksum value would be a lie in a security SBOM."""
+    art = _pytorch_artifact(artifact_hash=sentinel)
+    if sentinel is None:
+        del art["hash"]
+    data = _generate([art])
+    pkg = _artifact_packages(data)[0]
+    assert not pkg.get("checksums")
+
+
+def test_checksum_omitted_for_malformed_digest():
+    data = _generate([_pytorch_artifact(artifact_hash="abcdef123456")])
+    pkg = _artifact_packages(data)[0]
+    assert not pkg.get("checksums")
+
+
+# --- Package comment format ------------------------------------------------
+
+@pytest.mark.parametrize("framework,expected", [
+    ("PyTorch", "pickle"),
+    ("SafeTensors", "safetensors"),
+    ("GGUF", "gguf"),
+])
+def test_comment_reports_real_format(framework, expected):
+    data = _generate([_pytorch_artifact(framework=framework)])
+    assert f"Type: {expected}" in _artifact_packages(data)[0]["comment"]
+
+
+def test_comment_falls_back_to_unknown_for_unrecognised_framework():
+    data = _generate([_pytorch_artifact(framework="Klingon")])
+    assert "Type: unknown" in _artifact_packages(data)[0]["comment"]
+
+
+def test_comment_retains_risk_and_framework():
+    data = _generate([_pytorch_artifact(risk_level="CRITICAL (RCE Detected)")])
+    comment = _artifact_packages(data)[0]["comment"]
+    assert "Risk: CRITICAL (RCE Detected)" in comment
+    assert "Framework: PyTorch" in comment
+
+
+# --- Creators --------------------------------------------------------------
+
+def test_creators_reports_running_cli_version():
+    data = _generate([_pytorch_artifact()])
+    version = importlib.metadata.version("aisbom-cli")
+    assert data["creationInfo"]["creators"] == [f"Tool: aisbom-cli-{version}"]
+
+
+def test_creators_falls_back_when_distribution_missing(monkeypatch):
+    """The PyInstaller binary has no installed distribution metadata; the
+    exporter must not crash there."""
+    def boom(_name):
+        raise importlib.metadata.PackageNotFoundError("aisbom-cli")
+
+    monkeypatch.setattr(importlib.metadata, "version", boom)
+    data = _generate([_pytorch_artifact()])
+    creators = data["creationInfo"]["creators"]
+    assert len(creators) == 1
+    assert creators[0].startswith("Tool: aisbom-cli")
+
+
+# --- Dependencies ----------------------------------------------------------
+
+def test_dependency_spdxids_unique_for_repeated_pins():
+    """The same pin listed in two requirements.txt files must not produce two
+    packages sharing one SPDXID."""
+    data = _generate(dependencies=[
+        {"name": "requests", "version": "2.28.1"},
+        {"name": "requests", "version": "2.28.1"},
+    ])
+    ids = [p["SPDXID"] for p in data["packages"]]
+    assert len(set(ids)) == 2
+
+
+# --- Whole-document validity ----------------------------------------------
+
+def test_empty_scan_emits_a_valid_document():
+    """A scan that finds no models and no requirements still has to produce a
+    document. SPDX requires a DESCRIBES relationship whenever there isn't
+    exactly one package, so an empty document must describe NONE explicitly —
+    otherwise the writer's own validator rejects it and the CLI crashes."""
+    data = _generate([], [])
+    assert data["relationships"] == [{
+        "spdxElementId": "SPDXRef-DOCUMENT",
+        "relatedSpdxElement": "NONE",
+        "relationshipType": "DESCRIBES",
+    }]
+
+
+def test_document_validates_as_spdx_2_3():
+    from spdx_tools.spdx.parser.jsonlikedict.json_like_dict_parser import JsonLikeDictParser
+    from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
+
+    data = _generate(
+        [
+            _pytorch_artifact(name="mock_malware.pt", artifact_hash=SHA_A),
+            _pytorch_artifact(name="mock_restricted.safetensors",
+                              artifact_hash=SHA_B, framework="SafeTensors"),
+            _pytorch_artifact(name="remote.pt", artifact_hash="remote_unhashed"),
+        ],
+        [
+            {"name": "requests", "version": "2.28.1"},
+            {"name": "torch", "version": "2.0.*"},
+        ],
+    )
+    document = JsonLikeDictParser().parse(data)
+    assert validate_full_spdx_document(document) == []


### PR DESCRIPTION
Fixes the SPDX export, which was substantially less correct than the CycloneDX export from the same scan. `spdx_gen.py` read three keys off each artifact that the scanner never emits (`filename`, `format`) and built package identifiers from `id(artifact)` — a process memory address.

Tracked as `aisbom-ops` issue #101.

## Old vs. new — same scan, same fixture

Four mock artifacts from `generate-test-artifacts` plus a two-line `requirements.txt`. "Before" was generated from `main`, "after" from this branch.

**Before**

```
unknown-model   SPDXRef-Artifact-unknown-model-4483385024   (no checksum)   Type: unknown
unknown-model   SPDXRef-Artifact-unknown-model-4489736256   (no checksum)   Type: unknown
unknown-model   SPDXRef-Artifact-unknown-model-4489806656   (no checksum)   Type: unknown
unknown-model   SPDXRef-Artifact-unknown-model-4489806464   (no checksum)   Type: unknown
requests        SPDXRef-Lib-requests-2.28.1
numpy           SPDXRef-Lib-numpy-1.26.0

creators: ['Tool: aisbom-cli-0.1.0']
```

**After**

```
mock_broken.pt                SPDXRef-Artifact-mock-broken.pt-d520b896cf55                d520b896cf55641a…   Type: pickle
mock_restricted.safetensors   SPDXRef-Artifact-mock-restricted.safetensors-72fb466bbb0f   72fb466bbb0f4770…   Type: safetensors
mock_restricted.gguf          SPDXRef-Artifact-mock-restricted.gguf-0808c1167c0b           0808c1167c0b2e0a…   Type: gguf
mock_malware.pt               SPDXRef-Artifact-mock-malware.pt-9e519d282e71                9e519d282e71b6c5…   Type: pickle
requests                      SPDXRef-Lib-requests-2.28.1
numpy                         SPDXRef-Lib-numpy-1.26.0

creators: ['Tool: aisbom-cli-1.2.1']
```

**This is a strict improvement — nothing previously correct is lost:**

- Every `Risk:` line is identical before and after (`CRITICAL (RCE Detected: posix.system)`, `MEDIUM (Pickle Present)`, `LOW`, `LOW`).
- Dependency package IDs are unchanged for well-formed pins.
- Both documents validate with **zero** messages from `validate_full_spdx_document`.
- The four emitted checksums match `shasum -a 256` of the scanned files byte-for-byte.
- CycloneDX output is **byte-for-byte identical** (modulo the library's pre-existing random `BomRef`s) — this change is SPDX-only.

## What changed

1. **Real filenames.** Read the scanner's `name` key, falling back to `filename` then a placeholder.
2. **Deterministic, unique SPDXIDs.** Derived from the artifact's SHA256 rather than its memory address. Artifacts with no real digest (remote scans, where `hash` is the sentinel `remote_unhashed`) fall back to position; collisions are resolved with a suffix, so IDs stay unique when two artifacts share a name and content, or when every artifact in the document is remote.
3. **Package-level SHA256 checksums**, emitted for locally-scanned artifacts and *omitted rather than faked* for remote ones — writing a sentinel into a checksum field would be a falsehood in a security SBOM.
4. **Real format token** in the package comment, via `properties._format_for` — the same helper the CycloneDX path uses, so the two exports cannot drift apart again.
5. **Correct tool version** in `creators` via `importlib.metadata`, with a fallback so the frozen PyInstaller binary doesn't crash.

## Also fixed: three crashes

All three predate this PR and reproduce on `main`. Each produced an invalid document and an unhandled `ValueError` traceback out of the writer:

- A `requirements.txt` that repeats a pin → duplicate SPDXID.
- A wildcard version such as `torch>=2.0.*` → `*` is outside the required `SPDXRef-[a-zA-Z0-9.-]+` pattern.
- A scan finding neither models nor requirements → SPDX requires an explicit `DESCRIBES` relationship whenever a document doesn't hold exactly one package; an empty document now describes `NONE`.

## Deliberately out of scope

`document_namespace` keeps its timestamp (SPDX wants namespaces unique per document, so time-derived is defensible), and `license_declared` stays `NoAssertion` — mapping our license strings to valid SPDX expressions is its own slice, and emitting an invalid expression is worse than asserting nothing.

## Verification

- `poetry run pytest --cov=aisbom --cov-fail-under=85` → **277 passed**, 88.87% total, `spdx_gen.py` at **100%**.
- 24 new tests in `tests/test_spdx.py`, covering determinism across runs, uniqueness under shared names and all-remote documents, checksum presence/absence, the format token, the `creators` fallback, and whole-document SPDX 2.3 validity.
- Two consecutive `aisbom scan … --format spdx` runs now differ only in `created` and `documentNamespace`.

Version bumped to **1.2.1** (patch: bug fixes, no new surface) with a `CHANGELOG.md` entry.
