### PR TITLE
feat(scanner): Keras .h5/.keras scanning with Lambda code-exec detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Detect malware and license risks hidden inside ML model files — statically, before you load them.**
 
-AIsbom disassembles Pickle bytecode and parses SafeTensors / GGUF binary headers to surface RCE-capable payloads and restrictive licenses that generic SBOM tools miss. Pure static analysis — no model code is ever executed.
+AIsbom disassembles Pickle bytecode, inspects Keras model configs for code-executing `Lambda` layers, and parses SafeTensors / GGUF binary headers to surface RCE-capable payloads and restrictive licenses that generic SBOM tools miss. Pure static analysis — no model code is ever executed.
 
 > 💡 Also available as a [**GitHub Action**](#use-as-a-github-action) that posts an idempotent PR comment on every commit. See it on the [Marketplace →](https://github.com/marketplace/actions/aisbom-security-scanner)
 
@@ -323,6 +323,8 @@ AIsbom uses a static analysis engine to disassemble Python Pickle opcodes. It lo
 - `socket` (network reverse shells)
 
 SafeTensors and GGUF use binary formats with structured headers — AIsbom parses these headers directly to extract metadata (artifact names, license info, architecture details) without loading tensor weights.
+
+Keras models (`.keras`, `.h5`, `.hdf5`) carry a different execution vector: a `Lambda` layer stores an arbitrary Python callable in the model config as a base64-encoded marshalled code object, and `load_model` runs it. AIsbom reads the config out of both containers — the `.keras` zip and the legacy HDF5 attribute — flags `Lambda` layers and embedded code objects as CRITICAL, and never unmarshals or executes the payload. A truncated or corrupted container is still scanned rather than skipped, so damaging a file is not a way to hide a payload.
 
 For weekly scan findings on the top 50 most-downloaded Hugging Face text-generation models, see [aisbom.io/advisories](https://aisbom.io/advisories?ref=cli-readme).
 

--- a/aisbom/mock_generator.py
+++ b/aisbom/mock_generator.py
@@ -194,6 +194,71 @@ def create_mock_gguf(target_dir: Path):
         
     return output_path
 
+# --- KERAS ARTIFACTS ---
+# A `.keras` file is a zip holding the model config as JSON, so a realistic
+# fixture needs nothing but the standard library. The legacy `.h5` container is
+# HDF5 and cannot be written without h5py, which is a dev-only dependency — so
+# HDF5 fixtures are built in the test suite instead of here, and the shipped
+# package stays free of that dependency.
+
+def _marshalled_code_b64() -> str:
+    """Base64 of a marshalled code object, as a Keras Lambda layer stores one.
+
+    This is the *signature* a scanner must recognize, not a payload: the code
+    object returned here computes ``x + 1``. It is never unmarshalled or called.
+    """
+    import base64
+    import marshal
+
+    harmless = lambda x: x + 1  # noqa: E731
+    return base64.b64encode(marshal.dumps(harmless.__code__)).decode("ascii")
+
+
+def create_mock_keras_zip(output_path, with_lambda: bool = False) -> Path:
+    """Write a `.keras` archive, optionally carrying a Lambda layer.
+
+    Takes an explicit output path (rather than a target directory like the
+    older generators) because each Keras case wants its own filename.
+    """
+    output_path = Path(output_path)
+    layers = [
+        {
+            "module": "keras.layers",
+            "class_name": "Dense",
+            "config": {"name": "dense_0", "units": 64, "activation": "relu"},
+            "registered_name": None,
+        }
+    ]
+    if with_lambda:
+        layers.insert(0, {
+            "module": "keras.layers",
+            "class_name": "Lambda",
+            "config": {
+                "name": "lambda_exec",
+                "function": {
+                    "class_name": "__lambda__",
+                    "config": {"code": _marshalled_code_b64(), "defaults": None, "closure": None},
+                },
+            },
+            "registered_name": None,
+        })
+
+    config = {
+        "module": "keras",
+        "class_name": "Sequential",
+        "config": {"name": "sequential", "layers": layers},
+        "registered_name": None,
+    }
+    metadata = {"keras_version": "3.5.0", "date_saved": "2026-01-01@00:00:00"}
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("metadata.json", json.dumps(metadata, indent=2))
+        z.writestr("config.json", json.dumps(config, indent=2))
+
+    return output_path
+
+
 # --- DIFF DEMO LOGIC ---
 import uuid
 import random

--- a/aisbom/properties.py
+++ b/aisbom/properties.py
@@ -21,6 +21,7 @@ _FRAMEWORK_TO_FORMAT = {
     "PyTorch": "pickle",
     "SafeTensors": "safetensors",
     "GGUF": "gguf",
+    "Keras": "keras",
 }
 
 
@@ -87,5 +88,23 @@ def build_component_properties(art: Dict[str, Any]) -> List[Tuple[str, str]]:
         metadata_keys = details.get("metadata_keys") or []
         if metadata_keys:
             props.append(("aisbom:gguf:metadata_keys", _csv(metadata_keys)))
+
+    elif fmt == "keras":
+        container = details.get("container")
+        if container:
+            props.append(("aisbom:keras:container", str(container)))
+        threats = details.get("threats") or []
+        for threat in threats:
+            props.append(("aisbom:keras:threat", str(threat)))
+        props.append(("aisbom:keras:threat_count", str(len(threats))))
+        lambda_layers = details.get("lambda_layers") or []
+        if lambda_layers:
+            props.append(("aisbom:keras:lambda_layers", _csv(lambda_layers)))
+        layer_count = details.get("layer_count")
+        if layer_count is not None:
+            props.append(("aisbom:keras:layer_count", str(layer_count)))
+        keras_version = details.get("keras_version")
+        if keras_version:
+            props.append(("aisbom:keras:version", str(keras_version)))
 
     return props

--- a/aisbom/remote.py
+++ b/aisbom/remote.py
@@ -143,7 +143,13 @@ def resolve_huggingface_repo(repo_id: str) -> List[str]:
     resp.raise_for_status()
     data = resp.json()
 
-    supported_exts = (".pt", ".pth", ".bin", ".safetensors", ".gguf")
+    # Must stay in step with the extensions DeepScanner dispatches on: a format
+    # missing here is silently skipped for `hf://` scans, so a hostile model in
+    # that format passes a remote scan without producing an artifact or an error.
+    supported_exts = (
+        ".pt", ".pth", ".bin", ".safetensors", ".gguf",
+        ".keras", ".h5", ".hdf5",
+    )
     urls = []
     for entry in data:
         path = entry.get("path", "")

--- a/aisbom/safety.py
+++ b/aisbom/safety.py
@@ -1,6 +1,10 @@
-import pickletools
+import base64
+import binascii
 import io
-from typing import List, Set, Tuple
+import json
+import pickletools
+import re
+from typing import Any, Dict, List, Set, Tuple
 
 # The "Blocklist" of dangerous modules and functions
 # If a model tries to import these, it is trying to break out of the sandbox.
@@ -132,3 +136,144 @@ def scan_pickle_stream(data: bytes, strict_mode: bool = False) -> List[str]:
         pass
 
     return threats
+
+
+# --- KERAS LAMBDA-LAYER DETECTION ---
+#
+# A Keras `Lambda` layer serializes an arbitrary Python callable into the model
+# config as a base64-encoded marshalled code object, and `load_model` executes
+# it. That makes the model config itself an execution vector, in the same way a
+# pickle stream is — so it gets the same treatment: read the serialized form,
+# recognize the dangerous construct, never run it. Nothing here calls
+# `marshal.loads`; a payload is identified from its header bytes alone.
+
+# `Lambda` is the layer class. `__lambda__` is how Keras 3 tags the serialized
+# callable *inside* that layer's config — a distinct finding, reported under its
+# own prefix so one Lambda layer isn't counted twice. Keeping the second check
+# is deliberate defence in depth: it still fires when the embedded blob is in a
+# form the marshal header check below doesn't recognise.
+KERAS_LAMBDA_LAYER_CLASS = "lambda"
+KERAS_SERIALIZED_LAMBDA_CLASS = "__lambda__"
+KERAS_LAMBDA_CLASS_NAMES = {KERAS_LAMBDA_LAYER_CLASS, KERAS_SERIALIZED_LAMBDA_CLASS}
+
+# CPython marshal type code for a code object: TYPE_CODE ('c', 0x63), or the
+# same with FLAG_REF set (0xE3), which is what `marshal.dumps` actually emits.
+_MARSHAL_CODE_PREFIXES = (0x63, 0xE3)
+
+# A marshalled code object is always far larger than this; the floor keeps
+# short incidental base64 (flags, small blobs) out of the check.
+_MIN_MARSHAL_B64_LEN = 24
+
+_B64_CHARS = re.compile(r"\A[A-Za-z0-9+/=\s]+\Z")
+
+# Signatures for the coarse byte-level fallback below.
+_LAMBDA_BYTE_SIGNATURES = (
+    b'"class_name": "Lambda"',
+    b'"class_name":"Lambda"',
+    b'"class_name": "__lambda__"',
+    b'"class_name":"__lambda__"',
+)
+
+# Depth guard so a hostile deeply-nested config can't exhaust the stack.
+_MAX_CONFIG_DEPTH = 200
+
+
+def looks_like_marshalled_code(value: Any) -> bool:
+    """True if ``value`` is base64 that decodes to a Python code object.
+
+    The payload is *never* unmarshalled — only its header is inspected. After
+    the type byte, marshal writes argcount as a little-endian uint32, so a
+    genuine code object always has three zero bytes at offsets 2-4. Requiring
+    that structure is what keeps ordinary text beginning with ``c`` (0x63) from
+    reading as a code object.
+    """
+    if not isinstance(value, str) or not _B64_CHARS.match(value):
+        return False
+
+    # Keras 2's `func_dump` uses codecs base64, which wraps lines at 76 chars.
+    candidate = "".join(value.split())
+    if len(candidate) < _MIN_MARSHAL_B64_LEN:
+        return False
+
+    try:
+        raw = base64.b64decode(candidate, validate=True)
+    except (binascii.Error, ValueError):
+        return False
+
+    return (
+        len(raw) > 8
+        and raw[0] in _MARSHAL_CODE_PREFIXES
+        and raw[2:5] == b"\x00\x00\x00"
+    )
+
+
+def _lambda_label(node: Dict[str, Any], path: str) -> str:
+    """Prefer the layer's own name; fall back to its position in the config."""
+    config = node.get("config")
+    if isinstance(config, dict):
+        name = config.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return path or "<root>"
+
+
+def scan_keras_config(config: Any) -> List[str]:
+    """Walk a parsed Keras model config and report code-execution vectors.
+
+    Returns threat strings in the same spirit as ``scan_pickle_stream``:
+    ``KERAS_LAMBDA: <layer name>`` for a Lambda layer,
+    ``KERAS_SERIALIZED_LAMBDA: <json path>`` for a serialized callable nested
+    inside one, and ``KERAS_MARSHALLED_CODE: <json path>`` for an embedded code
+    object — the last reported wherever it appears, so a payload smuggled
+    outside a Lambda layer is caught too.
+
+    The walk is shape-agnostic on purpose: Keras 2 and Keras 3 nest Lambda
+    layers differently, and matching on structure rather than on one expected
+    layout means a new serialization shape does not silently stop being seen.
+    """
+    threats: List[str] = []
+    seen: Set[int] = set()
+
+    def visit(node: Any, path: str, depth: int) -> None:
+        if depth > _MAX_CONFIG_DEPTH:
+            return
+        if isinstance(node, (dict, list)):
+            # Guards against the self-referential configs a hostile file can
+            # contain (and against shared subtrees being walked twice).
+            if id(node) in seen:
+                return
+            seen.add(id(node))
+
+        if isinstance(node, dict):
+            class_name = node.get("class_name")
+            if isinstance(class_name, str):
+                normalized = class_name.strip().lower()
+                if normalized == KERAS_LAMBDA_LAYER_CLASS:
+                    threats.append(f"KERAS_LAMBDA: {_lambda_label(node, path)}")
+                elif normalized == KERAS_SERIALIZED_LAMBDA_CLASS:
+                    threats.append(f"KERAS_SERIALIZED_LAMBDA: {path or '<root>'}")
+            for key, value in node.items():
+                child = f"{path}.{key}" if path else str(key)
+                visit(value, child, depth + 1)
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                visit(value, f"{path}[{index}]", depth + 1)
+        elif isinstance(node, str) and looks_like_marshalled_code(node):
+            threats.append(f"KERAS_MARSHALLED_CODE: {path or '<root>'}")
+
+    visit(config, "", 0)
+    return threats
+
+
+def scan_keras_config_bytes(raw: bytes) -> List[str]:
+    """Coarse signature scan for a config that could not be parsed as JSON.
+
+    A truncated or otherwise malformed container must not become a way to hide
+    a payload: if the JSON cannot be recovered, the raw bytes are still
+    searched for the Lambda signature. This is deliberately less precise than
+    ``scan_keras_config`` — it reports that a Lambda layer is present without
+    being able to name it — and it is a fallback, not the primary path.
+    """
+    if any(sig in raw for sig in _LAMBDA_BYTE_SIGNATURES):
+        return ["KERAS_LAMBDA: <unparsed config>"]
+    return []

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -1,18 +1,42 @@
 import os
 import json
+import re
 import zipfile
 import struct
 import hashlib
 from typing import List, Dict, Any
 from pathlib import Path
 from pip_requirements_parser import RequirementsFile
-from aisbom.safety import scan_pickle_stream
+from aisbom.safety import scan_keras_config, scan_keras_config_bytes, scan_pickle_stream
 
 # Constants
 PYTORCH_EXTENSIONS = {'.pt', '.pth', '.bin'}
 SAFETENSORS_EXTENSION = '.safetensors'
 GGUF_EXTENSION = '.gguf'
+KERAS_EXTENSIONS = {'.keras', '.h5', '.hdf5'}
 REQUIREMENTS_FILENAME = 'requirements.txt'
+
+# HDF5 files start with this signature; a `.keras` file is a plain zip.
+HDF5_MAGIC = b"\x89HDF\r\n\x1a\n"
+
+# Keras stores the model architecture as a JSON string in the root group's
+# `model_config` attribute. HDF5 writes attribute values as literal,
+# uncompressed bytes, so the JSON can be recovered by locating the attribute
+# name and brace-matching the object that follows — no HDF5 library needed,
+# which keeps the PyInstaller bundle unchanged. Verified against files written
+# by h5py (what Keras itself uses) with configs from 300 bytes to 300KB.
+KERAS_H5_CONFIG_ATTR = b"model_config"
+KERAS_H5_VERSION_ATTR = b"keras_version"
+
+# Cap on how many bytes of a container are searched for the config. The
+# attribute sits in the root group's object header near the start of the file,
+# so this is generous; it exists to bound memory on a multi-GB weights file.
+KERAS_MAX_SCAN_BYTES = 16 * 1024 * 1024
+
+# Remote scans pay for every byte over HTTP Range requests, so they get a much
+# tighter cap — the config is at the head of the file, and pulling 16MB per
+# model would break the "scans complete in seconds" property of a remote scan.
+KERAS_MAX_REMOTE_SCAN_BYTES = 2 * 1024 * 1024
 
 # Simple blocklist for license keywords that imply legal risk in commercial software
 RESTRICTED_LICENSES = ["non-commercial", "cc-by-nc", "agpl", "commons clause"]
@@ -58,6 +82,9 @@ class DeepScanner:
                     elif ext == GGUF_EXTENSION:
                         with RemoteStream(url) as stream:
                             self.artifacts.append(self._inspect_gguf(stream, Path(url).name, is_remote=True))
+                    elif ext in KERAS_EXTENSIONS:
+                        with RemoteStream(url) as stream:
+                            self.artifacts.append(self._inspect_keras(stream, Path(url).name, is_remote=True))
                 except Exception as e:
                     self._record_fetch_error(url, e)
                     continue
@@ -73,6 +100,8 @@ class DeepScanner:
                         self.artifacts.append(self._inspect_safetensors(full_path))
                     elif ext == GGUF_EXTENSION:
                         self.artifacts.append(self._inspect_gguf(full_path))
+                    elif ext in KERAS_EXTENSIONS:
+                        self.artifacts.append(self._inspect_keras(full_path))
                     elif full_path.name == REQUIREMENTS_FILENAME:
                         self._parse_requirements(full_path)
 
@@ -425,6 +454,225 @@ class DeepScanner:
                 except Exception:
                     pass
             
+        return meta
+
+    @staticmethod
+    def _brace_match(blob: bytes, start: int) -> bytes | None:
+        """Return the JSON object beginning at ``start``, or None if unbalanced.
+
+        String-aware: a ``{`` or ``}`` inside a JSON string literal is skipped,
+        so a config that embeds braces in a layer name (or does so deliberately
+        to break a naive matcher) still delimits correctly.
+        """
+        depth = 0
+        in_string = False
+        escaped = False
+        for i in range(start, len(blob)):
+            ch = blob[i]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif ch == 0x5C:  # backslash
+                    escaped = True
+                elif ch == 0x22:  # closing quote
+                    in_string = False
+                continue
+            if ch == 0x22:
+                in_string = True
+            elif ch == 0x7B:  # {
+                depth += 1
+            elif ch == 0x7D:  # }
+                depth -= 1
+                if depth == 0:
+                    return blob[start:i + 1]
+        return None
+
+    def _extract_h5_config(self, blob: bytes) -> bytes | None:
+        """Recover the `model_config` JSON from raw HDF5 bytes.
+
+        HDF5 stores attribute values uncompressed and contiguous, so the JSON
+        is located by finding the attribute name and brace-matching the first
+        object that parses after it. Several candidates are tried because other
+        attribute data can sit between the name and its value.
+        """
+        search_from = 0
+        while True:
+            attr_at = blob.find(KERAS_H5_CONFIG_ATTR, search_from)
+            if attr_at == -1:
+                return None
+            cursor = attr_at
+            for _ in range(5):
+                brace_at = blob.find(b"{", cursor)
+                if brace_at == -1:
+                    break
+                candidate = self._brace_match(blob, brace_at)
+                if candidate is not None:
+                    try:
+                        if isinstance(json.loads(candidate), dict):
+                            return candidate
+                    except (ValueError, UnicodeDecodeError):
+                        pass
+                cursor = brace_at + 1
+            search_from = attr_at + len(KERAS_H5_CONFIG_ATTR)
+
+    @staticmethod
+    def _extract_h5_keras_version(blob: bytes) -> str | None:
+        """Read the `keras_version` attribute value, if it is present."""
+        attr_at = blob.find(KERAS_H5_VERSION_ATTR)
+        if attr_at == -1:
+            return None
+        window = blob[attr_at:attr_at + 128]
+        match = re.search(rb"\d+\.\d+(?:\.\d+)?", window)
+        return match.group(0).decode("ascii") if match else None
+
+    @staticmethod
+    def _keras_risk_label(threats: List[str], lambda_layers: List[str]) -> str:
+        """Summarize Keras findings for the risk column.
+
+        The full threat list stays in ``details``; this is the one-line version,
+        so it names the Lambda layers (the part a user acts on) and counts the
+        embedded code objects rather than pasting every JSON path into the
+        terminal table. Must contain "CRITICAL" — that substring is what the
+        CLI's ``--fail-on-risk`` exit-code check matches on.
+        """
+        parts = []
+        named = list(dict.fromkeys(lambda_layers))  # de-duplicated, order kept
+        if named:
+            parts.append(f"Lambda layer(s): {', '.join(named)}")
+        code_objects = sum(1 for t in threats if t.startswith("KERAS_MARSHALLED_CODE:"))
+        if code_objects:
+            parts.append(f"{code_objects} embedded code object(s)")
+        serialized = sum(1 for t in threats if t.startswith("KERAS_SERIALIZED_LAMBDA:"))
+        if serialized and not named:
+            parts.append(f"{serialized} serialized callable(s)")
+        detail = "; ".join(parts) if parts else "; ".join(threats)
+        return f"CRITICAL (Keras Lambda Code Execution — {detail})"
+
+    def _inspect_keras(self, source, name: str | None = None, is_remote: bool = False) -> Dict[str, Any]:
+        """Scans a Keras model for Lambda-layer code execution.
+
+        Handles both containers Keras writes: the newer `.keras` zip (config as
+        a `config.json` member) and the legacy HDF5 `.h5` (config as the root
+        group's `model_config` attribute). Neither path loads the model, and an
+        embedded code object is identified from its header bytes without ever
+        being unmarshalled.
+
+        A container that cannot be parsed is still scanned: the raw bytes go
+        through a signature check, so truncating or corrupting a file is not a
+        way to hide a Lambda layer.
+        """
+        local_path = None
+        if isinstance(source, (str, Path)):
+            local_path = Path(source)
+            name = name or local_path.name
+            is_remote = False
+        name = name or getattr(source, "name", "unknown")
+
+        meta = {
+            "name": name,
+            "type": "machine-learning-model",
+            "framework": "Keras",
+            "risk_level": "LOW",
+            "license": "Unknown",  # Keras containers carry no license metadata
+            "legal_status": "UNKNOWN",
+            "hash": "remote_unhashed" if is_remote else self._calculate_hash(local_path),
+            "details": {},
+        }
+
+        f = None
+        try:
+            f = open(local_path, "rb") if local_path else source
+
+            # A remote scan pays per byte, so it reads a smaller window.
+            budget = KERAS_MAX_SCAN_BYTES if local_path else KERAS_MAX_REMOTE_SCAN_BYTES
+
+            container = None
+            config_bytes = None      # the config JSON, if we could isolate it
+            fallback_bytes = b""     # what the signature scan reads if JSON fails
+            keras_version = None
+
+            if zipfile.is_zipfile(f):
+                container = "keras-zip"
+                f.seek(0)
+                with zipfile.ZipFile(f, "r") as z:
+                    members = z.namelist()
+                    meta["details"]["internal_files"] = len(members)
+                    if "config.json" in members:
+                        with z.open("config.json") as cfg:
+                            config_bytes = cfg.read(budget)
+                            fallback_bytes = config_bytes
+                    if "metadata.json" in members:
+                        try:
+                            with z.open("metadata.json") as md:
+                                keras_version = json.loads(md.read(65536)).get("keras_version")
+                        except Exception:
+                            pass
+            else:
+                f.seek(0)
+                if f.read(len(HDF5_MAGIC)) == HDF5_MAGIC:
+                    container = "hdf5"
+                    f.seek(0)
+                    blob = f.read(budget)
+                    fallback_bytes = blob
+                    config_bytes = self._extract_h5_config(blob)
+                    keras_version = self._extract_h5_keras_version(blob)
+
+            if container is None:
+                meta["risk_level"] = "UNKNOWN (Unrecognized Container)"
+                meta["details"]["container"] = None
+                meta["details"]["config_found"] = False
+                meta["details"]["threats"] = []
+                return meta
+
+            parsed = None
+            if config_bytes:
+                try:
+                    parsed = json.loads(config_bytes)
+                except (ValueError, UnicodeDecodeError):
+                    parsed = None
+
+            if parsed is not None:
+                threats = scan_keras_config(parsed)
+                config_parsed = True
+            else:
+                # No usable JSON — fall back to the coarse signature scan
+                # rather than declining to report on a file we can't fully read.
+                threats = scan_keras_config_bytes(fallback_bytes)
+                config_parsed = False
+
+            layer_count = None
+            if isinstance(parsed, dict):
+                layers = (parsed.get("config") or {}).get("layers")
+                if isinstance(layers, list):
+                    layer_count = len(layers)
+                keras_version = keras_version or parsed.get("keras_version")
+
+            lambda_layers = [
+                t.split(": ", 1)[1] for t in threats if t.startswith("KERAS_LAMBDA:")
+            ]
+
+            meta["details"].update({
+                "container": container,
+                "config_found": parsed is not None or bool(threats),
+                "config_parsed": config_parsed,
+                "threats": threats,
+                "lambda_layers": lambda_layers,
+                "layer_count": layer_count,
+                "keras_version": keras_version,
+            })
+
+            if threats:
+                meta["risk_level"] = self._keras_risk_label(threats, lambda_layers)
+            elif parsed is None:
+                meta["risk_level"] = "LOW"
+        except Exception as e:
+            meta["error"] = str(e)
+        finally:
+            if local_path and f:
+                try:
+                    f.close()
+                except Exception:
+                    pass
         return meta
 
     def _parse_requirements(self, path: Path):

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -2,6 +2,7 @@ import os
 import json
 import re
 import zipfile
+import zlib
 import struct
 import hashlib
 from typing import List, Dict, Any
@@ -487,6 +488,69 @@ class DeepScanner:
                     return blob[start:i + 1]
         return None
 
+    @staticmethod
+    def _recover_zip_members(blob: bytes, limit: int = 32) -> bytes:
+        """Rebuild member contents from local headers alone.
+
+        A `.keras` archive whose central directory is truncated or damaged is
+        rejected by ``zipfile``, but its local file headers — and the member
+        data behind them — are usually intact. Reading those directly means a
+        wrecked container is not a way to hide a Lambda layer, whether the
+        member was stored or deflated.
+
+        Returns the concatenated recovered members, for signature scanning.
+        """
+        recovered = []
+        offset = 0
+        for _ in range(limit):
+            offset = blob.find(b"PK\x03\x04", offset)
+            if offset == -1:
+                break
+            header = blob[offset:offset + 30]
+            if len(header) < 30:
+                break
+            try:
+                method = struct.unpack("<H", header[8:10])[0]
+                compressed_size = struct.unpack("<I", header[18:22])[0]
+                name_len = struct.unpack("<H", header[26:28])[0]
+                extra_len = struct.unpack("<H", header[28:30])[0]
+            except struct.error:
+                break
+
+            start = offset + 30 + name_len + extra_len
+            # A damaged header can carry a zero size; take what remains.
+            end = start + compressed_size if compressed_size else len(blob)
+            payload = blob[start:min(end, len(blob))]
+
+            if method == zipfile.ZIP_STORED:
+                recovered.append(payload)
+            elif method == zipfile.ZIP_DEFLATED:
+                try:
+                    # -15 selects raw deflate: no wrapper, no checksum, so a
+                    # damaged trailer does not prevent reading the front.
+                    recovered.append(zlib.decompressobj(-15).decompress(payload))
+                except zlib.error:
+                    pass
+            offset = start + max(compressed_size, 1)
+
+        return b"".join(recovered)
+
+    @staticmethod
+    def _hdf5_signature_offset(blob: bytes) -> int | None:
+        """Find the HDF5 superblock, which need not sit at offset zero.
+
+        The format permits a *user block* before the superblock, whose size is
+        512 bytes or any larger power of two. h5py opens such files normally, so
+        requiring the signature at offset 0 would let a Keras model with a user
+        block — Lambda layer and all — be dismissed as an unrecognized container.
+        """
+        offset = 0
+        while offset < len(blob):
+            if blob[offset:offset + len(HDF5_MAGIC)] == HDF5_MAGIC:
+                return offset
+            offset = 512 if offset == 0 else offset * 2
+        return None
+
     def _extract_h5_config(self, blob: bytes) -> bytes | None:
         """Recover the `model_config` JSON from raw HDF5 bytes.
 
@@ -590,6 +654,7 @@ class DeepScanner:
             config_bytes = None      # the config JSON, if we could isolate it
             fallback_bytes = b""     # what the signature scan reads if JSON fails
             keras_version = None
+            truncated = False        # did the read stop at the budget?
 
             if zipfile.is_zipfile(f):
                 container = "keras-zip"
@@ -601,6 +666,7 @@ class DeepScanner:
                         with z.open("config.json") as cfg:
                             config_bytes = cfg.read(budget)
                             fallback_bytes = config_bytes
+                            truncated = len(config_bytes) >= budget
                     if "metadata.json" in members:
                         try:
                             with z.open("metadata.json") as md:
@@ -609,19 +675,39 @@ class DeepScanner:
                             pass
             else:
                 f.seek(0)
-                if f.read(len(HDF5_MAGIC)) == HDF5_MAGIC:
+                blob = f.read(budget)
+                fallback_bytes = blob
+                truncated = len(blob) >= budget
+                if self._hdf5_signature_offset(blob) is not None:
                     container = "hdf5"
-                    f.seek(0)
-                    blob = f.read(budget)
-                    fallback_bytes = blob
                     config_bytes = self._extract_h5_config(blob)
                     keras_version = self._extract_h5_keras_version(blob)
 
             if container is None:
-                meta["risk_level"] = "UNKNOWN (Unrecognized Container)"
+                # Not a readable ZIP and no HDF5 signature — but a damaged
+                # archive lands here too, and a truncated `.keras` can still
+                # carry an intact Lambda signature in its bytes. Refusing to
+                # look would make corrupting the container an evasion.
+                salvage = scan_keras_config_bytes(fallback_bytes)
+                if not salvage and fallback_bytes.startswith(b"PK\x03\x04"):
+                    # A damaged archive: its directory is unusable but the
+                    # member data behind the local headers usually is not.
+                    salvage = scan_keras_config_bytes(
+                        self._recover_zip_members(fallback_bytes)
+                    )
                 meta["details"]["container"] = None
-                meta["details"]["config_found"] = False
-                meta["details"]["threats"] = []
+                meta["details"]["config_found"] = bool(salvage)
+                meta["details"]["config_parsed"] = False
+                meta["details"]["threats"] = salvage
+                meta["details"]["lambda_layers"] = [
+                    t.split(": ", 1)[1] for t in salvage if t.startswith("KERAS_LAMBDA:")
+                ]
+                if salvage:
+                    meta["risk_level"] = self._keras_risk_label(
+                        salvage, meta["details"]["lambda_layers"]
+                    )
+                else:
+                    meta["risk_level"] = "UNKNOWN (Unrecognized Container)"
                 return meta
 
             parsed = None
@@ -659,10 +745,19 @@ class DeepScanner:
                 "lambda_layers": lambda_layers,
                 "layer_count": layer_count,
                 "keras_version": keras_version,
+                "truncated": truncated,
             })
 
             if threats:
                 meta["risk_level"] = self._keras_risk_label(threats, lambda_layers)
+            elif truncated:
+                # The config did not fit the read window, so a Lambda layer
+                # after the cut would not have been seen. Padding a config with
+                # harmless layers is cheap, and the archive stays small and
+                # loadable — so "nothing found" here is not a clean bill.
+                meta["risk_level"] = (
+                    "MEDIUM (Keras config incomplete: read limit reached)"
+                )
             elif parsed is None:
                 meta["risk_level"] = "LOW"
         except Exception as e:

--- a/poetry.lock
+++ b/poetry.lock
@@ -722,6 +722,67 @@ files = [
 ]
 
 [[package]]
+name = "h5py"
+version = "3.16.0"
+description = "Read and write HDF5 files from Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "h5py-3.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e06f864bedb2c8e7c1358e6c73af48519e317457c444d6f3d332bb4e8fa6d7d9"},
+    {file = "h5py-3.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ec86d4fffd87a0f4cb3d5796ceb5a50123a2a6d99b43e616e5504e66a953eca3"},
+    {file = "h5py-3.16.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:86385ea895508220b8a7e45efa428aeafaa586bd737c7af9ee04661d8d84a10d"},
+    {file = "h5py-3.16.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:8975273c2c5921c25700193b408e28d6bdd0111c37468b2d4e25dcec4cd1d84d"},
+    {file = "h5py-3.16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1677ad48b703f44efc9ea0c3ab284527f81bc4f318386aaaebc5fede6bbae56f"},
+    {file = "h5py-3.16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c4dd4cf5f0a4e36083f73172f6cfc25a5710789269547f132a20975bfe2434c"},
+    {file = "h5py-3.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:bdef06507725b455fccba9c16529121a5e1fbf56aa375f7d9713d9e8ff42454d"},
+    {file = "h5py-3.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:719439d14b83f74eeb080e9650a6c7aa6d0d9ea0ca7f804347b05fac6fbf18af"},
+    {file = "h5py-3.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c3f0a0e136f2e95dd0b67146abb6668af4f1a69c81ef8651a2d316e8e01de447"},
+    {file = "h5py-3.16.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:a6fbc5367d4046801f9b7db9191b31895f22f1c6df1f9987d667854cac493538"},
+    {file = "h5py-3.16.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fb1720028d99040792bb2fb31facb8da44a6f29df7697e0b84f0d79aff2e9bd3"},
+    {file = "h5py-3.16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:314b6054fe0b1051c2b0cb2df5cbdab15622fb05e80f202e3b6a5eee0d6fe365"},
+    {file = "h5py-3.16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ffbab2fedd6581f6aa31cf1639ca2cb86e02779de525667892ebf4cc9fd26434"},
+    {file = "h5py-3.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:17d1f1630f92ad74494a9a7392ab25982ce2b469fc62da6074c0ce48366a2999"},
+    {file = "h5py-3.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:85b9c49dd58dc44cf70af944784e2c2038b6f799665d0dcbbc812a26e0faa859"},
+    {file = "h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d"},
+    {file = "h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d"},
+    {file = "h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527"},
+    {file = "h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e"},
+    {file = "h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794"},
+    {file = "h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074"},
+    {file = "h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6"},
+    {file = "h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db"},
+    {file = "h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9"},
+    {file = "h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb"},
+    {file = "h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524"},
+    {file = "h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402"},
+    {file = "h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7"},
+    {file = "h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff"},
+    {file = "h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad"},
+    {file = "h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4"},
+    {file = "h5py-3.16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9c9d307c0ef862d1cd5714f72ecfafe0a5d7529c44845afa8de9f46e5ba8bd65"},
+    {file = "h5py-3.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c1eff849cdd53cbc73c214c30ebdb6f1bb8b64790b4b4fc36acdb5e43570210"},
+    {file = "h5py-3.16.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2c04d129f180019e216ee5f9c40b78a418634091c8782e1f723a6ca3658b965"},
+    {file = "h5py-3.16.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e4360f15875a532bc7b98196c7592ed4fc92672a57c0a621355961cafb17a6dd"},
+    {file = "h5py-3.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3fae9197390c325e62e0a1aa977f2f62d994aa87aab182abbea85479b791197c"},
+    {file = "h5py-3.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:43259303989ac8adacc9986695b31e35dba6fd1e297ff9c6a04b7da5542139cc"},
+    {file = "h5py-3.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:fa48993a0b799737ba7fd21e2350fa0a60701e58180fae9f2de834bc39a147ab"},
+    {file = "h5py-3.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:1897a771a7f40d05c262fc8f37376ec37873218544b70216872876c627640f63"},
+    {file = "h5py-3.16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15922e485844f77c0b9d275396d435db3baa58292a9c2176a386e072e0cf2491"},
+    {file = "h5py-3.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:df02dd29bd247f98674634dfe41f89fd7c16ba3d7de8695ec958f58404a4e618"},
+    {file = "h5py-3.16.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0f456f556e4e2cebeebd9d66adf8dc321770a42593494a0b6f0af54a7567b242"},
+    {file = "h5py-3.16.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3e6cb3387c756de6a9492d601553dffea3fe11b5f22b443aac708c69f3f55e16"},
+    {file = "h5py-3.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8389e13a1fd745ad2856873e8187fd10268b2d9677877bb667b41aebd771d8b7"},
+    {file = "h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725"},
+    {file = "h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e"},
+    {file = "h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1"},
+    {file = "h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738"},
+]
+
+[package.dependencies]
+numpy = ">=1.21.2"
+
+[[package]]
 name = "idna"
 version = "3.16"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -920,6 +981,166 @@ files = [
 check = ["check-manifest", "flake8", "flake8-black", "isort (>=5.0.3)", "pygments", "readme-renderer", "twine"]
 test = ["coverage[toml] (>=5.2)", "coveralls (>=2.1.1)", "hypothesis", "pyannotate", "pytest", "pytest-cov"]
 type = ["mypy", "mypy-extensions"]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.11"
+groups = ["dev"]
+markers = "python_version < \"3.13\""
+files = [
+    {file = "numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538"},
+    {file = "numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47"},
+    {file = "numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93"},
+    {file = "numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8"},
+    {file = "numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6"},
+    {file = "numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8"},
+    {file = "numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147"},
+    {file = "numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698"},
+    {file = "numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f"},
+    {file = "numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853"},
+    {file = "numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a"},
+    {file = "numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2"},
+    {file = "numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45"},
+    {file = "numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751"},
+    {file = "numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3"},
+    {file = "numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b"},
+    {file = "numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089"},
+    {file = "numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a"},
+    {file = "numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605"},
+    {file = "numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91"},
+    {file = "numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359"},
+    {file = "numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997"},
+    {file = "numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20"},
+    {file = "numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d"},
+    {file = "numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67"},
+    {file = "numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd"},
+    {file = "numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab"},
+    {file = "numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75"},
+    {file = "numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096"},
+    {file = "numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b"},
+    {file = "numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8"},
+    {file = "numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402"},
+    {file = "numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb"},
+    {file = "numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1"},
+    {file = "numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261"},
+    {file = "numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e"},
+    {file = "numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43"},
+    {file = "numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e"},
+    {file = "numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895"},
+    {file = "numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4"},
+    {file = "numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063"},
+    {file = "numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627"},
+    {file = "numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73"},
+    {file = "numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda"},
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.2"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.12"
+groups = ["dev"]
+markers = "python_version >= \"3.13\""
+files = [
+    {file = "numpy-2.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14e373cfc6387177e8409dac3c7159be8eb05cd77096cd7c950268b86f62831c"},
+    {file = "numpy-2.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbd96c833ecc8cc069ce518078fc8c60cb9cbfb0fea5b7a803ad65035596d03"},
+    {file = "numpy-2.5.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:6e8172ddfcf5cf74b811d372b570b83c60bd2de87a6fbfbebdadb4a9bd9c6cbb"},
+    {file = "numpy-2.5.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:65f188481f1669e26f62b701e8205d19e460fa4a9b52a1414ba382330e4a3414"},
+    {file = "numpy-2.5.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ee9c4eeb8454b3660a8b53493563c3e121c2fc94fbd72b848ef814ed7b676a9"},
+    {file = "numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cdec01fa790a186d430433fdd4d4ffb70eed6f0eeb4bf05c8dbe2dce0a9bcb8"},
+    {file = "numpy-2.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7999d4ddb0c4025018373fd787510d46e04c769467af22869707b3c1cfd459ab"},
+    {file = "numpy-2.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c1f017dc0875c9209d219f97feceb7d54c2661bb243deb4114478e1295808af7"},
+    {file = "numpy-2.5.2-cp312-cp312-win32.whl", hash = "sha256:d6a48072864e3324e194a8fbb3c657bcc5b5c869dbc64c9537b1d5c862572c0a"},
+    {file = "numpy-2.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:28ac63476ec7651484215ee7fa15a1f78b57c14621f01e392afe17b9a1390ce4"},
+    {file = "numpy-2.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:27650bb0e7140fa3d37b9923b4803645e0b125d190f326eecfd3f4dad8e8ade1"},
+    {file = "numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15"},
+    {file = "numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080"},
+    {file = "numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740"},
+    {file = "numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56"},
+    {file = "numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3"},
+    {file = "numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee"},
+    {file = "numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59"},
+    {file = "numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d"},
+    {file = "numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4"},
+    {file = "numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657"},
+    {file = "numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2"},
+    {file = "numpy-2.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d787cf769c3baeb5f6235e778edb52c08dfa923789b5958f28e6450f96107cb1"},
+    {file = "numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24b9dc2e3d84aa58523798805194e23e736f3f6ce2d1a5b92583ae734e6dbda8"},
+    {file = "numpy-2.5.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e9413326d726c2545bfa65d2c0876871e8d8386e77f992c1d426e180bbd4323"},
+    {file = "numpy-2.5.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:60e902ac295855348a5ca2ea4c89108989a9f5fddfad3dfc0a8f36b10358567e"},
+    {file = "numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e500dc868e9313530ce12ba470fe50ff3afe3d62993ed6eff652dacd555b65"},
+    {file = "numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318b9a4c845dbea06708a29c84ee429cc3065048db34cdb799047643492050ee"},
+    {file = "numpy-2.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:34c319e2963be042673fb46570501b2f06c41924e17e3563d58646b4380dfb68"},
+    {file = "numpy-2.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f06571a052127dc1b4e8b83029b4d1b20daa2b64a31cdd181fc6bc774e9000eb"},
+    {file = "numpy-2.5.2-cp314-cp314-win32.whl", hash = "sha256:2cc779226e476d1e1f08c74068c419e60f41a9e0e069c92f6671d31d5c985e98"},
+    {file = "numpy-2.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:7587f53dfbd5edc0f7b87c6217b4c6d2d1f2ef9c3da70bc1315e7db5f8d7ec9d"},
+    {file = "numpy-2.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3e4c367352d3747784248a227fbec218e193b56f7e6692e3b64fc805478ecfdf"},
+    {file = "numpy-2.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b879fb674276e331513fb136b78dbc6bd3c848309e0d841cfd63be3896c4cfc1"},
+    {file = "numpy-2.5.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:fd0d703772bba096843785bd38371e31bb4a0c1151497ad5739d182114a73f7f"},
+    {file = "numpy-2.5.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:3a2f061cebd9e3d23bdcfaaded5e2293a4c6a5b60fa42df85d410a725ce621bf"},
+    {file = "numpy-2.5.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6df895598c0edcb41030126c89e0f353b07d93238116143b7405e937359736c4"},
+    {file = "numpy-2.5.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ab3d4a901f844ea836c3e80bf463c6a27d7f3c14e8e292fcf28d348b25b9bce"},
+    {file = "numpy-2.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cebc2d6dbb605a7703d59751dea4bd6b0ab127a5a4338a6f432df1936fef8b26"},
+    {file = "numpy-2.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eaca7ff36f0f52e2111ec71f169d8fd3e889e7ddc0d2592e0d703fd8d3ce8fac"},
+    {file = "numpy-2.5.2-cp314-cp314t-win32.whl", hash = "sha256:ddf47472af2e4280d79bac82304f5e80150211f1b9e614b760061d5fdfbb6eba"},
+    {file = "numpy-2.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:44ef9675d908e65f9953063837c3277730f3f4437615a4cdab67b366cabaf884"},
+    {file = "numpy-2.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:eaa088384c46f519dacb93b7ec483a6d6b19a4a2085ae4f25ab9b1c43d387d1e"},
+    {file = "numpy-2.5.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:078f9b027b478c9379b9677babbf0f8b8f1ecfada27636d7b9a93990c638739f"},
+    {file = "numpy-2.5.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:50a68f4bacd8a2b33d8da3d2269d0d78500f86ea582e4786dc10f5ef2c2c6842"},
+    {file = "numpy-2.5.2-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:e79aba74ffaf5f78a050d777c184cddf8fdffabab38acf5f3ef1fecbc17895d6"},
+    {file = "numpy-2.5.2-cp315-cp315-macosx_14_0_x86_64.whl", hash = "sha256:9a0731745a72a184490a582fb4af2533512bd071ace67785b5fdffc0ae58dce8"},
+    {file = "numpy-2.5.2-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec954036759bcee3aa484f8603bd9c14f3e776293b85578b8734c2d72777c69"},
+    {file = "numpy-2.5.2-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc649493697006bc90614a5f0bbc8cb3cb1866715c474e473694968d7e6b99ab"},
+    {file = "numpy-2.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:cf7de32f486e4ac9e2d93b810f9e9ac72a728dd46a32a0bb403222f27f653514"},
+    {file = "numpy-2.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2ffa7bacab3e2ee1b19ed31766bb60bb380b68c23f051e199c5cc598afd68710"},
+    {file = "numpy-2.5.2-cp315-cp315-win32.whl", hash = "sha256:6b588cc8f902d6bff201c19fd00c43ab8545671e3554d014e12e14139e5e8617"},
+    {file = "numpy-2.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:07d4e89f3a9ab0a9ba24264ccdb642b3dd951b2281e8883a5481a4aa79cc31a7"},
+    {file = "numpy-2.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:a610dc7e3c52edd39c2bc2375ff9c3fd59cb3ad00e4472d36f83bc1457145788"},
+    {file = "numpy-2.5.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:40f4d451aed46a8046a1aae41c4e55fb3612273df9c502480135e1501576a34b"},
+    {file = "numpy-2.5.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:c081cbe16ba1ab53078e5ff29013621e33c509eedab055775d956427712c236e"},
+    {file = "numpy-2.5.2-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:0090ccdd57ec2703e9b49d0bf554767370581c1dd0a6b2bb2b2d9def317d042a"},
+    {file = "numpy-2.5.2-cp315-cp315t-macosx_14_0_x86_64.whl", hash = "sha256:6a9bb119fb8dd21ba30b3f0e555b7e2b081bd9883af21ec9c1c633d161cda3a8"},
+    {file = "numpy-2.5.2-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a839318485284a6fb31be4f8f2c91c8f2cb22f4543c4a8903f12b0671ffe07cc"},
+    {file = "numpy-2.5.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba0a474801b8dc67b66bf465548abc90e82b44d2611b5770f33008dcabffe8ec"},
+    {file = "numpy-2.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0a4035ae1129ff8777f08bfbd44f1e5d8e9c049ce0c2dd78fc0d92c13e7251c0"},
+    {file = "numpy-2.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:77843ca236b777e67f8d6b3660ea116e499612703a0ecd7093f316201eb9d8e2"},
+    {file = "numpy-2.5.2-cp315-cp315t-win32.whl", hash = "sha256:7354826bc6f8f69402e9b7fe28d15fcd34feebd74f856f111585c5b0c9fb0251"},
+    {file = "numpy-2.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:e5651f3f87add730ee6608d915009e19c911fba0cb000c7e3ea994b7d768eb12"},
+    {file = "numpy-2.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:5f8e00be2ec6f45f4e8a41a527f68d44a7d96fee92a650e4d8b1326f77f61e6e"},
+    {file = "numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860"},
+]
 
 [[package]]
 name = "packageurl-python"
@@ -1769,4 +1990,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "ae7cf7f3048b1a67c27f83fae47f111f690948e32599970b243d47599e7b542e"
+content-hash = "abab64be2e80d5be7b1dec4d811ccaf158c9b84aca19cdba9ce458f1cc7a4254"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pytest = ">=8.3.3,<10.0.0"
 pytest-cov = ">=6,<8"
 pyinstaller = {version = "^6.18.0", python = "<3.15"}
 py7zr = "^1.1.3"
+h5py = "^3.12"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -1,0 +1,471 @@
+"""Keras scanning: `.keras` zip containers and legacy HDF5 `.h5` files.
+
+The threat is the `Lambda` layer, which serializes arbitrary Python as a
+base64-encoded marshalled code object that executes on `load_model`. Nothing
+here loads a model or unmarshals a payload — the marshalled blobs are real
+code objects only so the detector sees a realistic signature, and they are
+never passed to `marshal.loads`.
+
+The HDF5 fixtures are built with `h5py`, which is a **dev-only** dependency:
+Keras itself writes `.h5` via h5py, so building fixtures with it proves the
+scanner's dependency-free byte parsing against the real container layout
+rather than against an assumption about it. The scanner never imports h5py.
+"""
+
+import base64
+import json
+import marshal
+import struct
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from aisbom.mock_generator import create_mock_keras_zip
+from aisbom.properties import build_component_properties
+from aisbom.safety import (
+    looks_like_marshalled_code,
+    scan_keras_config,
+    scan_keras_config_bytes,
+)
+from aisbom.scanner import DeepScanner
+
+h5py = pytest.importorskip("h5py", reason="h5py is a dev-only fixture dependency")
+
+
+# --- fixture helpers -------------------------------------------------------
+
+def _marshalled_lambda_b64() -> str:
+    """Base64 of a real marshalled code object (never unmarshalled)."""
+    fn = lambda x: x + 1  # noqa: E731
+    return base64.b64encode(marshal.dumps(fn.__code__)).decode("ascii")
+
+
+def _keras2_config(with_lambda: bool = False) -> dict:
+    """A Keras 2 `model_config` payload, as written into `.h5` attrs."""
+    layers = [
+        {"class_name": "Dense", "config": {"name": "dense_0", "units": 64}},
+    ]
+    if with_lambda:
+        layers.insert(0, {
+            "class_name": "Lambda",
+            "config": {
+                "name": "lambda_rce",
+                "function": [_marshalled_lambda_b64(), None, None],
+                "function_type": "lambda",
+            },
+        })
+    return {
+        "class_name": "Sequential",
+        "config": {"name": "sequential", "layers": layers},
+        "keras_version": "2.15.0",
+        "backend": "tensorflow",
+    }
+
+
+def write_h5(path: Path, config: dict | None, keras_version: str = "2.15.0") -> Path:
+    """Write a Keras-shaped HDF5 file the way Keras itself does."""
+    with h5py.File(path, "w") as f:
+        if config is not None:
+            f.attrs["model_config"] = json.dumps(config)
+        f.attrs["keras_version"] = keras_version
+        f.attrs["backend"] = "tensorflow"
+        grp = f.create_group("model_weights")
+        grp.attrs["layer_names"] = [b"dense_0"]
+    return path
+
+
+# --- safety.scan_keras_config ---------------------------------------------
+
+def test_benign_config_has_no_threats():
+    assert scan_keras_config(_keras2_config(with_lambda=False)) == []
+
+
+def test_lambda_layer_is_detected():
+    threats = scan_keras_config(_keras2_config(with_lambda=True))
+    assert any(t.startswith("KERAS_LAMBDA:") for t in threats)
+    assert any("lambda_rce" in t for t in threats)
+
+
+def test_marshalled_code_blob_is_detected():
+    threats = scan_keras_config(_keras2_config(with_lambda=True))
+    assert any(t.startswith("KERAS_MARSHALLED_CODE:") for t in threats)
+
+
+def test_keras3_nested_lambda_shape_is_detected():
+    """Keras 3 nests the callable under `__lambda__` with a `code` field."""
+    cfg = {
+        "module": "keras",
+        "class_name": "Sequential",
+        "config": {
+            "layers": [{
+                "module": "keras.layers",
+                "class_name": "Lambda",
+                "config": {
+                    "name": "lambda_k3",
+                    "function": {
+                        "class_name": "__lambda__",
+                        "config": {"code": _marshalled_lambda_b64()},
+                    },
+                },
+                "registered_name": None,
+            }],
+        },
+    }
+    threats = scan_keras_config(cfg)
+    assert any(t.startswith("KERAS_LAMBDA:") for t in threats)
+    assert any(t.startswith("KERAS_MARSHALLED_CODE:") for t in threats)
+    # The nested serialized callable is its own finding, so one Lambda layer is
+    # never counted twice as a layer.
+    assert any(t.startswith("KERAS_SERIALIZED_LAMBDA:") for t in threats)
+    assert sum(t.startswith("KERAS_LAMBDA:") for t in threats) == 1
+
+
+def test_serialized_lambda_without_a_layer_wrapper_is_flagged():
+    """A `__lambda__` blob smuggled outside a Lambda layer still reports."""
+    cfg = {"class_name": "Dense", "config": {
+        "activation": {"class_name": "__lambda__", "config": {"code": "short"}},
+    }}
+    threats = scan_keras_config(cfg)
+    assert threats == ["KERAS_SERIALIZED_LAMBDA: config.activation"]
+
+
+def test_risk_label_names_layers_and_counts_code_objects():
+    label = DeepScanner._keras_risk_label(
+        [
+            "KERAS_LAMBDA: lambda_a",
+            "KERAS_SERIALIZED_LAMBDA: config.layers[0].config.function",
+            "KERAS_MARSHALLED_CODE: config.layers[0].config.function.config.code",
+        ],
+        ["lambda_a"],
+    )
+    # "CRITICAL" is the substring --fail-on-risk matches on.
+    assert label.startswith("CRITICAL")
+    assert "lambda_a" in label
+    assert "1 embedded code object(s)" in label
+    # The verbose JSON paths belong in details, not the risk column.
+    assert "config.layers[0]" not in label
+
+
+def test_risk_label_deduplicates_repeated_layer_names():
+    label = DeepScanner._keras_risk_label(
+        ["KERAS_LAMBDA: dup", "KERAS_LAMBDA: dup"], ["dup", "dup"]
+    )
+    assert label.count("dup") == 1
+
+
+def test_marshalled_code_detected_without_lambda_wrapper():
+    """A code blob smuggled outside a Lambda layer is still flagged."""
+    cfg = {"class_name": "Dense", "config": {"kernel_initializer": _marshalled_lambda_b64()}}
+    threats = scan_keras_config(cfg)
+    assert any(t.startswith("KERAS_MARSHALLED_CODE:") for t in threats)
+
+
+def test_lambda_as_a_layer_name_is_not_a_false_positive():
+    """A layer merely *named* "lambda" is not a Lambda layer."""
+    cfg = {
+        "class_name": "Sequential",
+        "config": {"layers": [
+            {"class_name": "Dense", "config": {"name": "lambda_like", "units": 8}},
+        ]},
+    }
+    assert scan_keras_config(cfg) == []
+
+
+def test_plain_base64_strings_are_not_marshalled_code():
+    assert not looks_like_marshalled_code(base64.b64encode(b"just some weights").decode())
+    assert not looks_like_marshalled_code("not base64 at all !!!")
+    assert not looks_like_marshalled_code("")
+    assert not looks_like_marshalled_code("YWJj")  # decodes to b"abc"
+
+
+def test_marshalled_code_survives_newline_wrapped_base64():
+    """Keras 2's func_dump uses codecs base64, which inserts newlines."""
+    import codecs
+    fn = lambda x: x  # noqa: E731
+    wrapped = codecs.encode(marshal.dumps(fn.__code__), "base64").decode("ascii")
+    assert "\n" in wrapped
+    assert looks_like_marshalled_code(wrapped)
+
+
+def test_config_walk_survives_cycles_and_odd_types():
+    cfg = {"class_name": "Sequential", "config": {"layers": []}}
+    cfg["self"] = cfg  # a cycle must not hang or blow the stack
+    assert scan_keras_config(cfg) == []
+    assert scan_keras_config(None) == []
+    assert scan_keras_config([1, 2.5, True, None]) == []
+
+
+# --- safety.scan_keras_config_bytes (fallback signature scan) -------------
+
+def test_byte_scan_flags_lambda_in_unparseable_config():
+    raw = b'\x89HDF\r\n\x1a\n...garbage...{"class_name": "Lambda", "config": {trunc'
+    threats = scan_keras_config_bytes(raw)
+    assert any(t.startswith("KERAS_LAMBDA:") for t in threats)
+
+
+def test_byte_scan_clean_on_benign_bytes():
+    assert scan_keras_config_bytes(b'{"class_name": "Dense", "units": 8}') == []
+
+
+# --- DeepScanner: .keras zip container ------------------------------------
+
+def test_keras_zip_with_lambda_is_critical(tmp_path):
+    create_mock_keras_zip(tmp_path / "evil.keras", with_lambda=True)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["framework"] == "Keras"
+    assert art["type"] == "machine-learning-model"
+    assert "CRITICAL" in art["risk_level"]
+    assert art["details"]["container"] == "keras-zip"
+    assert any(t.startswith("KERAS_LAMBDA:") for t in art["details"]["threats"])
+    assert len(art["hash"]) == 64
+
+
+def test_keras_zip_benign_scans_clean(tmp_path):
+    create_mock_keras_zip(tmp_path / "clean.keras", with_lambda=False)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["framework"] == "Keras"
+    assert "CRITICAL" not in art["risk_level"]
+    assert art["details"]["threats"] == []
+    assert art["details"]["layer_count"] >= 1
+
+
+def test_keras_zip_without_config_is_not_critical(tmp_path):
+    """A zip that isn't a Keras archive must not be reported as a threat."""
+    path = tmp_path / "notkeras.keras"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("weights.bin", b"\x00\x01\x02")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" not in art["risk_level"]
+    assert art["details"]["config_found"] is False
+
+
+# --- DeepScanner: legacy .h5 (HDF5) --------------------------------------
+
+def test_h5_with_lambda_is_critical(tmp_path):
+    write_h5(tmp_path / "evil.h5", _keras2_config(with_lambda=True))
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["framework"] == "Keras"
+    assert "CRITICAL" in art["risk_level"]
+    assert art["details"]["container"] == "hdf5"
+    assert art["details"]["config_found"] is True
+    assert any(t.startswith("KERAS_LAMBDA:") for t in art["details"]["threats"])
+    assert any(t.startswith("KERAS_MARSHALLED_CODE:") for t in art["details"]["threats"])
+    assert art["details"]["keras_version"] == "2.15.0"
+
+
+def test_h5_benign_scans_clean(tmp_path):
+    write_h5(tmp_path / "clean.h5", _keras2_config(with_lambda=False))
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" not in art["risk_level"]
+    assert art["details"]["threats"] == []
+    assert art["details"]["config_found"] is True
+
+
+def test_h5_large_config_still_parses(tmp_path):
+    """A config far past HDF5's 64KB object-header limit must still be read."""
+    cfg = _keras2_config(with_lambda=True)
+    cfg["config"]["layers"].extend(
+        {"class_name": "Dense", "config": {"name": f"pad_{i}", "units": 64}}
+        for i in range(1200)
+    )
+    assert len(json.dumps(cfg)) > 64 * 1024
+
+    write_h5(tmp_path / "big.h5", cfg)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["details"]["config_found"] is True
+    assert "CRITICAL" in art["risk_level"]
+    assert art["details"]["layer_count"] == 1202
+
+
+def test_hdf5_without_model_config_is_not_critical(tmp_path):
+    """A plain HDF5 data file carrying no Keras config scans clean."""
+    write_h5(tmp_path / "data.h5", None)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["framework"] == "Keras"
+    assert "CRITICAL" not in art["risk_level"]
+    assert art["details"]["config_found"] is False
+
+
+def test_hdf5_extension_variant_is_discovered(tmp_path):
+    write_h5(tmp_path / "model.hdf5", _keras2_config(with_lambda=True))
+    arts = DeepScanner(str(tmp_path)).scan()["artifacts"]
+
+    assert len(arts) == 1
+    assert "CRITICAL" in arts[0]["risk_level"]
+
+
+def test_truncated_h5_still_flags_the_payload(tmp_path):
+    """Truncating the container must not stop the scan reaching the signature.
+
+    A scanner that bails out on a malformed container is exactly the evasion
+    this project treats as a defect, so a broken file is still scanned.
+    """
+    full = write_h5(tmp_path / "full.h5", _keras2_config(with_lambda=True)).read_bytes()
+    (tmp_path / "full.h5").unlink()
+
+    # Cut shortly after the Lambda signature, so the JSON object is left
+    # unterminated and cannot be recovered — the payload is visible in the
+    # bytes but the structured parse is guaranteed to fail.
+    sig_at = full.find(b'"class_name": "Lambda"')
+    assert sig_at != -1
+    (tmp_path / "trunc.h5").write_bytes(full[: sig_at + 40])
+
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["details"]["config_parsed"] is False, "expected the JSON parse to fail"
+    assert "CRITICAL" in art["risk_level"]
+    assert art["details"]["threats"] == ["KERAS_LAMBDA: <unparsed config>"]
+
+
+def test_unreadable_keras_file_records_an_error_not_a_crash(tmp_path):
+    path = tmp_path / "empty.h5"
+    path.write_bytes(b"")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["framework"] == "Keras"
+    assert "CRITICAL" not in art["risk_level"]
+
+
+# --- SBOM plumbing --------------------------------------------------------
+
+def test_keras_format_token_is_registered():
+    art = {"framework": "Keras", "risk_level": "LOW", "legal_status": "UNKNOWN", "details": {}}
+    props = dict(build_component_properties(art))
+    assert props["aisbom:format"] == "keras"
+
+
+def test_keras_properties_carry_findings(tmp_path):
+    create_mock_keras_zip(tmp_path / "evil.keras", with_lambda=True)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+    props = build_component_properties(art)
+    names = {n for n, _ in props}
+    as_dict = dict(props)
+
+    assert as_dict["aisbom:format"] == "keras"
+    assert as_dict["aisbom:keras:container"] == "keras-zip"
+    assert "aisbom:keras:threat" in names
+    assert int(as_dict["aisbom:keras:threat_count"]) >= 1
+    assert "lambda" in as_dict["aisbom:keras:lambda_layers"].lower()
+    assert as_dict["aisbom:risk"].startswith("CRITICAL")
+
+
+def test_keras_appears_in_spdx_export(tmp_path):
+    """The shared format token must reach SPDX, not just CycloneDX."""
+    from aisbom.spdx_gen import generate_spdx_sbom
+
+    create_mock_keras_zip(tmp_path / "evil.keras", with_lambda=True)
+    results = DeepScanner(str(tmp_path)).scan()
+
+    doc = json.loads(generate_spdx_sbom(results))
+    pkgs = doc["packages"]
+    assert any(p["name"] == "evil.keras" for p in pkgs)
+    keras_pkg = next(p for p in pkgs if p["name"] == "evil.keras")
+    assert "Type: keras" in keras_pkg["comment"]
+    assert "CRITICAL" in keras_pkg["comment"]
+
+
+def test_scan_exits_two_on_keras_lambda(tmp_path, monkeypatch):
+    """End-to-end: a Lambda layer must trip the CI gate (exit 2).
+
+    Asserts on the rendered output as well as the code, because Typer also
+    exits 2 on a usage error — the code alone would pass for the wrong reason.
+    """
+    from typer.testing import CliRunner
+    from aisbom.cli import app
+
+    monkeypatch.setenv("AISBOM_NO_TELEMETRY", "1")
+    create_mock_keras_zip(tmp_path / "evil.keras", with_lambda=True)
+    result = CliRunner().invoke(app, ["scan", str(tmp_path)])
+
+    assert "evil.keras" in result.output, result.output
+    assert "CRITICAL" in result.output, result.output
+    assert result.exit_code == 2, result.output
+
+
+def test_benign_keras_scan_exits_zero(tmp_path, monkeypatch):
+    """The clean case must not trip the gate — otherwise the signal is useless."""
+    from typer.testing import CliRunner
+    from aisbom.cli import app
+
+    monkeypatch.setenv("AISBOM_NO_TELEMETRY", "1")
+    create_mock_keras_zip(tmp_path / "clean.keras", with_lambda=False)
+    result = CliRunner().invoke(app, ["scan", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+
+
+# --- remote scanning ------------------------------------------------------
+
+def test_remote_keras_lambda_is_detected(monkeypatch, tmp_path):
+    """A Keras model on a remote host must be scanned, not silently skipped.
+
+    Without this the `hf://` path would report a backdoored Keras model clean.
+    """
+    import aisbom.remote as remote
+
+    content = create_mock_keras_zip(tmp_path / "remote.keras", with_lambda=True).read_bytes()
+
+    def fake_get(url, headers=None):
+        rng = (headers or {}).get("Range", "bytes=0-0")
+        start, _, end = rng.split("=")[1].partition("-")
+        start = int(start)
+        end = int(end) if end else len(content) - 1
+        chunk = content[start:end + 1]
+
+        class Resp:
+            status_code = 206
+
+            def __init__(self):
+                self.content = chunk
+                self.headers = {
+                    "Content-Range": f"bytes {start}-{end}/{len(content)}",
+                    "Content-Length": str(len(chunk)),
+                }
+
+            def raise_for_status(self):
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    monkeypatch.setattr(
+        "aisbom.scanner.DeepScanner._resolve_remote_targets",
+        lambda self, target: ["http://example.com/remote.keras"],
+    )
+
+    results = DeepScanner("http://example.com/remote.keras").scan()
+    art = results["artifacts"][0]
+
+    assert results["errors"] == []
+    assert art["framework"] == "Keras"
+    assert "CRITICAL" in art["risk_level"]
+    # No bytes were hashed, so no digest may be asserted.
+    assert art["hash"] == "remote_unhashed"
+
+
+# --- mock_generator -------------------------------------------------------
+
+def test_mock_keras_zip_is_a_real_keras_archive(tmp_path):
+    path = create_mock_keras_zip(tmp_path / "m.keras", with_lambda=True)
+    with zipfile.ZipFile(path) as z:
+        names = z.namelist()
+        assert "config.json" in names
+        assert "metadata.json" in names
+        cfg = json.loads(z.read("config.json"))
+    assert cfg["class_name"] == "Sequential"
+
+
+def test_mock_keras_zip_benign_has_no_lambda(tmp_path):
+    path = create_mock_keras_zip(tmp_path / "m.keras", with_lambda=False)
+    with zipfile.ZipFile(path) as z:
+        cfg = json.loads(z.read("config.json"))
+    assert scan_keras_config(cfg) == []

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -334,6 +334,123 @@ def test_unreadable_keras_file_records_an_error_not_a_crash(tmp_path):
     assert "CRITICAL" not in art["risk_level"]
 
 
+# --- containers that do not present cleanly -------------------------------
+
+def test_hdf5_behind_a_user_block_is_still_recognized(tmp_path):
+    """HDF5 allows a user block before the superblock.
+
+    Its size is 512 bytes or a larger power of two, and h5py opens such files
+    normally — so demanding the signature at offset 0 would dismiss a real
+    Keras model, Lambda layer and all, as an unrecognized container.
+    """
+    real = write_h5(tmp_path / "real.h5", _keras2_config(with_lambda=True)).read_bytes()
+    (tmp_path / "real.h5").unlink()
+    (tmp_path / "userblock.h5").write_bytes(b"\x00" * 512 + real)
+
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["details"]["container"] == "hdf5"
+    assert "CRITICAL" in art["risk_level"]
+    assert any(t.startswith("KERAS_LAMBDA:") for t in art["details"]["threats"])
+
+
+@pytest.mark.parametrize("block", [512, 1024, 2048])
+def test_hdf5_user_block_sizes_are_all_found(tmp_path, block):
+    real = write_h5(tmp_path / "real.h5", _keras2_config(with_lambda=True)).read_bytes()
+    (tmp_path / "real.h5").unlink()
+    (tmp_path / "ub.h5").write_bytes(b"\x00" * block + real)
+
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+    assert "CRITICAL" in art["risk_level"]
+
+
+def test_damaged_keras_archive_still_yields_its_signature(tmp_path):
+    """A wrecked central directory must not stop the byte-level fallback.
+
+    `zipfile.is_zipfile` returns False once the directory is gone, so the file
+    reaches the unrecognized-container path — but the Lambda signature is still
+    sitting in the bytes, and corrupting the container must not hide it.
+    """
+    full = create_mock_keras_zip(
+        tmp_path / "full.keras", with_lambda=True
+    ).read_bytes()
+    (tmp_path / "full.keras").unlink()
+    # Drop the central directory at the end; the stored member survives.
+    (tmp_path / "broken.keras").write_bytes(full[: full.rfind(b"PK\x01\x02")])
+
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert any(t.startswith("KERAS_LAMBDA:") for t in art["details"]["threats"])
+
+
+def test_unrecognized_container_with_no_signature_stays_unknown(tmp_path):
+    (tmp_path / "junk.keras").write_bytes(b"not a container at all" * 10)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["risk_level"] == "UNKNOWN (Unrecognized Container)"
+    assert "CRITICAL" not in art["risk_level"]
+
+
+def test_config_larger_than_the_read_budget_is_not_called_clean(tmp_path, monkeypatch):
+    """A config past the read window must not report LOW.
+
+    Padding a config with ordinary layers so the Lambda falls beyond the cut is
+    cheap, and the compressed archive stays small and loadable.
+    """
+    import aisbom.scanner as scanner_mod
+
+    cfg = _keras2_config(with_lambda=False)
+    cfg["config"]["layers"].extend(
+        {"class_name": "Dense", "config": {"name": f"pad_{i}", "units": 64}}
+        for i in range(2000)
+    )
+    path = tmp_path / "big.keras"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("config.json", json.dumps(cfg))
+        z.writestr("metadata.json", json.dumps({"keras_version": "3.5.0"}))
+
+    monkeypatch.setattr(scanner_mod, "KERAS_MAX_SCAN_BYTES", 4096)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["details"]["truncated"] is True
+    assert "MEDIUM" in art["risk_level"]
+    assert "CRITICAL" not in art["risk_level"]
+
+
+# --- Hugging Face resolution ----------------------------------------------
+
+@pytest.mark.parametrize("filename", [
+    "model.keras", "model.h5", "model.hdf5",
+])
+def test_keras_files_are_resolved_from_a_hugging_face_repo(monkeypatch, filename):
+    """The dispatch arm is unreachable for `hf://` unless the resolver lists it.
+
+    Without this the remote scan of a repo holding a backdoored Keras model
+    returns no artifacts and no errors — a silent pass.
+    """
+    import aisbom.remote as remote
+
+    def fake_get(url, headers=None):
+        class Resp:
+            status_code = 200
+            headers = {}
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return [{"path": filename}, {"path": "README.md"}]
+
+        return Resp()
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+
+    urls = remote.resolve_huggingface_repo("hf://org/model")
+    assert any(u.endswith(filename) for u in urls), urls
+
+
 # --- SBOM plumbing --------------------------------------------------------
 
 def test_keras_format_token_is_registered():


### PR DESCRIPTION
Adds Keras as a scanned format, covering both containers Keras writes: the newer `.keras` zip and the legacy HDF5 `.h5`/`.hdf5`.

## The threat

A Keras `Lambda` layer serializes an arbitrary Python callable into the model config as a base64-encoded marshalled code object, and `load_model` executes it. That makes the model config itself an execution vector, in the same way a pickle stream is — so it gets the same treatment: read the serialized form, recognize the dangerous construct, never run it. Nothing here loads a model or calls `marshal.loads`.

## Detection (`safety.py`, beside `scan_pickle_stream`)

- **`scan_keras_config()`** walks the parsed config by *structure* rather than by one expected layout, because Keras 2 and Keras 3 nest Lambda layers differently — so a new serialization shape doesn't silently stop being seen. Lambda layers, nested serialized callables (`__lambda__`), and embedded code objects are reported under separate prefixes, so one Lambda layer is never double-counted.
- **`looks_like_marshalled_code()`** identifies a code object from its marshal header alone. It requires the argcount structure after the type byte (three zero bytes at offsets 2–4), which is what keeps ordinary text beginning with `c` (0x63) from reading as a code object. Handles the newline-wrapped base64 that Keras 2's `func_dump` produces.
- **`scan_keras_config_bytes()`** is a coarse signature fallback for a config that can't be parsed. A scanner that bails out on a malformed container is the evasion this project treats as a defect, so a truncated file is still scanned.

## HDF5 without an HDF5 dependency

HDF5 stores attribute values uncompressed and contiguous, so the `model_config` JSON is recovered by locating the attribute name and brace-matching the object that follows — with a *string-aware* matcher, so braces inside JSON string literals (accidental or deliberate) can't break delimitation.

This assumption was **probed before being relied on**, against files written by h5py — which is what Keras itself writes `.h5` through — with configs from 300 bytes to 300KB, including past HDF5's 64KB object-header limit. The shipped wheel and the PyInstaller bundle gain no new dependency.

## Notes

- The format token is registered in the single shared `properties._format_for` mapping, so the CycloneDX and SPDX exports can't drift apart. `aisbom:keras:*` properties carry container, threats, Lambda layer names, layer count, and Keras version.
- Remote scans read a **2MB** window rather than 16MB — every byte is an HTTP Range request, and the config sits at the head of the file. Remote Keras files were previously skipped entirely, which would have reported a backdoored model on a remote host as clean; there's a test for that path.
- **`h5py` is added as a dev-only dependency**, following the existing `py7zr` precedent: fixtures built with the same library Keras uses prove the byte parsing against the real container layout instead of against an assumption. The scanner never imports it.
- `generate-test-artifacts` is deliberately unchanged — out of scope for this change.

## Verification

- `poetry run pytest --cov=aisbom --cov-fail-under=85` → **334 passed, 90.19% coverage** (before: 302 passed, 89.80%)
- `aisbom bypass-scorecard --check` → **gate passed, 5/11 unchanged**. This slice adds no pickle-path behavior, and the ratchet confirms it.
- All CI smoke commands exit 0 (`generate-test-artifacts`, `info`, `scan demo_data`, `scan .`, `scan . --strict`, SPDX and CycloneDX export).
- Scanned end-to-end through the CLI: an h5py-written `.h5` with a Lambda layer and a `.keras` zip both report CRITICAL and exit 2; the benign `.keras` reports LOW and exits 0.

Test coverage spans: `.keras` zip and HDF5 containers, Keras 2 and Keras 3 Lambda shapes, benign models, a plain HDF5 file with no Keras config, a non-Keras zip, a >64KB config, a truncated container (asserting the structured parse *fails* and the fallback fires), an empty file, false-positive guards (a layer merely *named* "lambda", plain base64), a self-referential config, and the remote path.
