### PR TITLE
feat(scanner): ONNX scanning with custom-op and external-data detection

### DIFF
--- a/aisbom/mock_generator.py
+++ b/aisbom/mock_generator.py
@@ -259,6 +259,109 @@ def create_mock_keras_zip(output_path, with_lambda: bool = False) -> Path:
     return output_path
 
 
+# --- ONNX ARTIFACTS ---
+# An .onnx file is a bare serialized protobuf ModelProto, so writing one needs
+# only the wire format — no onnx library, and nothing that would land in the
+# shipped package's dependencies. These build the three cases the scanner has
+# to tell apart: an ordinary model, one carrying a custom operator, and one
+# whose weights live outside the file.
+
+def _pb_varint(value: int) -> bytes:
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        out.append(byte | (0x80 if value else 0))
+        if not value:
+            return bytes(out)
+
+
+def _pb_tag(field_number: int, wire_type: int) -> bytes:
+    return _pb_varint((field_number << 3) | wire_type)
+
+
+def _pb_bytes_field(field_number: int, payload: bytes) -> bytes:
+    return _pb_tag(field_number, 2) + _pb_varint(len(payload)) + payload
+
+
+def _pb_str_field(field_number: int, text: str) -> bytes:
+    return _pb_bytes_field(field_number, text.encode("utf-8"))
+
+
+def _pb_varint_field(field_number: int, value: int) -> bytes:
+    return _pb_tag(field_number, 0) + _pb_varint(value)
+
+
+def _onnx_node(op_type: str, domain: str = "", node_name: str = "node") -> bytes:
+    """NodeProto: input(1), output(2), name(3), op_type(4), domain(7)."""
+    body = (
+        _pb_str_field(1, "x")
+        + _pb_str_field(2, "y")
+        + _pb_str_field(3, node_name)
+        + _pb_str_field(4, op_type)
+    )
+    if domain:
+        body += _pb_str_field(7, domain)
+    return body
+
+
+def _onnx_external_tensor(tensor_name: str, location: str) -> bytes:
+    """TensorProto with data_location=EXTERNAL and external_data entries."""
+    entries = b""
+    for key, value in (("location", location), ("offset", "0"), ("length", "64")):
+        entries += _pb_bytes_field(
+            13, _pb_str_field(1, key) + _pb_str_field(2, value)
+        )
+    return (
+        _pb_varint_field(2, 1)              # data_type = FLOAT
+        + _pb_str_field(8, tensor_name)     # name
+        + entries                            # external_data
+        + _pb_varint_field(14, 1)           # data_location = EXTERNAL
+    )
+
+
+def create_mock_onnx(
+    output_path,
+    custom_op: bool = False,
+    external_location: str | None = None,
+) -> Path:
+    """Write a minimal but structurally valid `.onnx` model.
+
+    `custom_op` puts an operator in a non-standard domain; `external_location`
+    adds a tensor whose bytes live at that path outside the model file (pass a
+    traversal path to build the escape case).
+    """
+    output_path = Path(output_path)
+
+    nodes = _pb_bytes_field(1, _onnx_node("Relu", node_name="relu_node"))
+    opsets = _pb_bytes_field(8, _pb_str_field(1, "") + _pb_varint_field(2, 17))
+    if custom_op:
+        nodes += _pb_bytes_field(
+            1, _onnx_node("MyCustomOp", domain="com.example.ops", node_name="custom_node")
+        )
+        opsets += _pb_bytes_field(
+            8, _pb_str_field(1, "com.example.ops") + _pb_varint_field(2, 1)
+        )
+
+    graph_body = nodes + _pb_str_field(2, "mock_graph")
+    if external_location is not None:
+        graph_body += _pb_bytes_field(
+            5, _onnx_external_tensor("W", external_location)
+        )
+
+    model = (
+        _pb_varint_field(1, 9)                      # ir_version
+        + _pb_str_field(2, "aisbom-mock")           # producer_name
+        + _pb_str_field(3, "1.0.0")                 # producer_version
+        + _pb_bytes_field(7, graph_body)            # graph
+        + opsets                                     # opset_import
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(model)
+    return output_path
+
+
 # --- DIFF DEMO LOGIC ---
 import uuid
 import random

--- a/aisbom/properties.py
+++ b/aisbom/properties.py
@@ -22,6 +22,7 @@ _FRAMEWORK_TO_FORMAT = {
     "SafeTensors": "safetensors",
     "GGUF": "gguf",
     "Keras": "keras",
+    "ONNX": "onnx",
 }
 
 
@@ -106,5 +107,51 @@ def build_component_properties(art: Dict[str, Any]) -> List[Tuple[str, str]]:
         keras_version = details.get("keras_version")
         if keras_version:
             props.append(("aisbom:keras:version", str(keras_version)))
+
+    elif fmt == "onnx":
+        ir_version = details.get("ir_version")
+        if ir_version is not None:
+            props.append(("aisbom:onnx:ir_version", str(ir_version)))
+        producer = details.get("producer_name")
+        if producer:
+            props.append(("aisbom:onnx:producer_name", str(producer)))
+        producer_version = details.get("producer_version")
+        if producer_version:
+            props.append(("aisbom:onnx:producer_version", str(producer_version)))
+        graph_name = details.get("graph_name")
+        if graph_name:
+            props.append(("aisbom:onnx:graph_name", str(graph_name)))
+
+        # Opsets are emitted as "domain:version" pairs; the default domain is
+        # the empty string, rendered as "ai.onnx" so the value is readable.
+        opsets = details.get("opsets") or []
+        if opsets:
+            props.append(("aisbom:onnx:opsets", _csv(
+                f"{o.get('domain') or 'ai.onnx'}:{o.get('version')}" for o in opsets
+            )))
+
+        node_count = details.get("node_count")
+        if node_count is not None:
+            props.append(("aisbom:onnx:node_count", str(node_count)))
+        op_types = details.get("op_types") or []
+        if op_types:
+            props.append(("aisbom:onnx:op_types", _csv(op_types)))
+
+        custom_ops = details.get("custom_ops") or []
+        if custom_ops:
+            props.append(("aisbom:onnx:custom_ops", _csv(
+                f"{o.get('domain') or ''}.{o.get('op_type') or '?'}" for o in custom_ops
+            )))
+        props.append(("aisbom:onnx:custom_op_count", str(len(custom_ops))))
+
+        external_data = details.get("external_data") or []
+        for entry in external_data:
+            location = (entry or {}).get("location")
+            if location:
+                props.append(("aisbom:onnx:external_data_location", str(location)))
+        props.append(("aisbom:onnx:external_data_count", str(len(external_data))))
+
+        for threat in details.get("threats") or []:
+            props.append(("aisbom:onnx:threat", str(threat)))
 
     return props

--- a/aisbom/protobuf_reader.py
+++ b/aisbom/protobuf_reader.py
@@ -1,0 +1,197 @@
+"""A minimal, read-only protobuf wire-format reader.
+
+Just enough of the encoding to walk a message's fields without a schema, a
+compiler, or a runtime dependency — which is what lets ONNX models be inspected
+while the shipped wheel and the PyInstaller bundle stay unchanged.
+
+Two properties matter for scanning hostile input:
+
+* **Nothing is executed and nothing is trusted.** Field numbers and lengths come
+  from the file, so a declared length may exceed the bytes actually present.
+* **Truncation is normal, not an error.** Model files run to gigabytes and a
+  scan reads only the head, so a message will routinely be cut mid-field. The
+  reader returns what it has and reports that it was truncated, rather than
+  refusing to parse. A scanner that gives up on a file it cannot fully read is
+  a scanner that can be evaded by damaging the file.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterator, List, Tuple
+
+# Wire types (only these four are valid in current protobuf).
+WIRE_VARINT = 0
+WIRE_64BIT = 1
+WIRE_LENGTH_DELIMITED = 2
+WIRE_32BIT = 5
+
+# A varint is at most 10 bytes; anything longer is malformed input, not a number.
+_MAX_VARINT_BYTES = 10
+
+
+class TruncatedMessage(Exception):
+    """Raised internally when the buffer ends mid-field."""
+
+
+def read_varint(buf: bytes, pos: int) -> Tuple[int, int]:
+    """Decode a base-128 varint at ``pos``; return ``(value, next_pos)``."""
+    result = 0
+    shift = 0
+    for _ in range(_MAX_VARINT_BYTES):
+        if pos >= len(buf):
+            raise TruncatedMessage("buffer ended inside a varint")
+        byte = buf[pos]
+        pos += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, pos
+        shift += 7
+    raise TruncatedMessage("varint longer than 10 bytes")
+
+
+def iter_fields(buf: bytes) -> Iterator[Tuple[int, int, object]]:
+    """Yield ``(field_number, wire_type, value)`` for each field in ``buf``.
+
+    Varints yield an ``int``; every other wire type yields ``bytes``. Iteration
+    stops cleanly at the first field that runs past the end of the buffer, so a
+    truncated message yields the fields that are wholly present.
+    """
+    pos = 0
+    while pos < len(buf):
+        try:
+            tag, pos = read_varint(buf, pos)
+        except TruncatedMessage:
+            return
+
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+        if field_number == 0:
+            return  # field 0 is not legal; the stream is not a message
+
+        try:
+            if wire_type == WIRE_VARINT:
+                value, pos = read_varint(buf, pos)
+                yield field_number, wire_type, value
+            elif wire_type == WIRE_LENGTH_DELIMITED:
+                length, pos = read_varint(buf, pos)
+                end = pos + length
+                if end > len(buf):
+                    # Declared longer than what we hold. Hand back the bytes we
+                    # do have — for a head-of-file scan this is the whole graph
+                    # we are ever going to see, and it is still worth reading.
+                    yield field_number, wire_type, buf[pos:]
+                    return
+                yield field_number, wire_type, buf[pos:end]
+                pos = end
+            elif wire_type == WIRE_64BIT:
+                if pos + 8 > len(buf):
+                    return
+                yield field_number, wire_type, buf[pos:pos + 8]
+                pos += 8
+            elif wire_type == WIRE_32BIT:
+                if pos + 4 > len(buf):
+                    return
+                yield field_number, wire_type, buf[pos:pos + 4]
+                pos += 4
+            else:
+                # Groups (3, 4) were removed from proto3 and never appear in
+                # ONNX; an unknown wire type means we have lost the framing.
+                return
+        except TruncatedMessage:
+            return
+
+
+def iter_stream_fields(read_at, start: int, end: int):
+    """Walk a message in a file without reading its payloads.
+
+    Yields ``(field_number, wire_type, payload_offset, payload_length)``.
+    ``read_at(offset, n)`` must return up to ``n`` bytes at ``offset``.
+
+    This exists so bulk data can be *stepped over* rather than buffered. An
+    ONNX model stores its weights inline, so a tensor can be gigabytes while
+    the security-relevant parts of the file — the graph structure, and the
+    tensors that point *outside* the file — are tiny. Reading a fixed window
+    from the front would stop inside the first big tensor and never reach them.
+    """
+    pos = start
+    while pos < end:
+        header = read_at(pos, 20)  # a tag plus a length varint fit comfortably
+        if not header:
+            return
+        try:
+            tag, consumed = read_varint(header, 0)
+        except TruncatedMessage:
+            return
+
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+        if field_number == 0:
+            return
+        pos += consumed
+
+        if wire_type == WIRE_VARINT:
+            try:
+                _value, used = read_varint(header, consumed)
+            except TruncatedMessage:
+                return
+            length = used - consumed
+            yield field_number, wire_type, pos, length
+            pos += length
+        elif wire_type == WIRE_LENGTH_DELIMITED:
+            try:
+                length, used = read_varint(header, consumed)
+            except TruncatedMessage:
+                return
+            pos += used - consumed
+            if pos + length > end:
+                yield field_number, wire_type, pos, max(0, end - pos)
+                return
+            yield field_number, wire_type, pos, length
+            pos += length
+        elif wire_type == WIRE_64BIT:
+            yield field_number, wire_type, pos, 8
+            pos += 8
+        elif wire_type == WIRE_32BIT:
+            yield field_number, wire_type, pos, 4
+            pos += 4
+        else:
+            return
+
+
+def parse_message(buf: bytes) -> Dict[int, List[object]]:
+    """Group a message's fields by field number, preserving repeat order."""
+    fields: Dict[int, List[object]] = {}
+    for field_number, _wire_type, value in iter_fields(buf):
+        fields.setdefault(field_number, []).append(value)
+    return fields
+
+
+def get_bytes(fields: Dict[int, List[object]], number: int) -> bytes | None:
+    """First length-delimited value for ``number``, or None."""
+    for value in fields.get(number, []):
+        if isinstance(value, bytes):
+            return value
+    return None
+
+
+def get_str(fields: Dict[int, List[object]], number: int) -> str | None:
+    """First value for ``number`` decoded as UTF-8, or None.
+
+    Invalid bytes are replaced rather than raising: the value is a label to
+    show a human, and a hostile file is entitled to contain invalid UTF-8.
+    """
+    raw = get_bytes(fields, number)
+    return None if raw is None else raw.decode("utf-8", errors="replace")
+
+
+def get_int(fields: Dict[int, List[object]], number: int) -> int | None:
+    """First varint value for ``number``, or None."""
+    for value in fields.get(number, []):
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def get_messages(fields: Dict[int, List[object]], number: int) -> List[Dict[int, List[object]]]:
+    """Parse every length-delimited value for ``number`` as a submessage."""
+    return [parse_message(v) for v in fields.get(number, []) if isinstance(v, bytes)]

--- a/aisbom/remote.py
+++ b/aisbom/remote.py
@@ -149,6 +149,7 @@ def resolve_huggingface_repo(repo_id: str) -> List[str]:
     supported_exts = (
         ".pt", ".pth", ".bin", ".safetensors", ".gguf",
         ".keras", ".h5", ".hdf5",
+        ".onnx",
     )
     urls = []
     for entry in data:

--- a/aisbom/safety.py
+++ b/aisbom/safety.py
@@ -277,3 +277,103 @@ def scan_keras_config_bytes(raw: bytes) -> List[str]:
     if any(sig in raw for sig in _LAMBDA_BYTE_SIGNATURES):
         return ["KERAS_LAMBDA: <unparsed config>"]
     return []
+
+
+# --- ONNX GRAPH INSPECTION ---
+#
+# ONNX carries no pickle, so the risk is not a payload inside the file — it is
+# what loading the file makes the runtime reach for:
+#
+#   * **External data.** A tensor can live outside the model, addressed by a
+#     relative path. A path that climbs out of the model directory (or names an
+#     absolute path or a URL) turns `load_model` into an arbitrary-file read
+#     against whatever the loading process can see. The ONNX specification
+#     requires these paths to stay within the model directory, so one that does
+#     not is a spec violation as well as a security signal.
+#   * **Custom operators.** An operator in a non-standard domain cannot run
+#     without a matching custom op library being registered, which is a
+#     native-code load the model author chose and the model consumer inherits.
+
+# Domains defined by the ONNX standard. Anything else is a custom operator set.
+# The empty domain is the default (ai.onnx).
+ONNX_STANDARD_DOMAINS = {
+    "",
+    "ai.onnx",
+    "ai.onnx.ml",
+    "ai.onnx.training",
+    "ai.onnx.preview.training",
+}
+
+# A URL-ish scheme prefix: `http://`, `file://`, `s3://` …
+_URL_SCHEME = re.compile(r"\A[A-Za-z][A-Za-z0-9+.\-]*://")
+
+# A Windows drive-letter path: `C:\…` or `C:/…`
+_WINDOWS_DRIVE = re.compile(r"\A[A-Za-z]:[\\/]")
+
+
+def external_location_escapes(location: str) -> bool:
+    """True if an external-data path leaves the model's own directory.
+
+    Absolute paths, Windows drive paths, UNC paths and URLs escape by
+    definition. Relative paths are resolved by tracking depth, so ``a/../b``
+    (which stays put) is not reported while ``../secrets`` and ``a/../../etc``
+    are. Resolution is textual on purpose — the point is to judge what the file
+    *asks for*, without touching the filesystem it is asking about.
+    """
+    if not isinstance(location, str) or not location:
+        return False
+    if _URL_SCHEME.match(location) or _WINDOWS_DRIVE.match(location):
+        return True
+    if location.startswith("/") or location.startswith("\\"):
+        return True
+
+    depth = 0
+    for part in re.split(r"[\\/]+", location):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            depth -= 1
+            if depth < 0:
+                return True
+        else:
+            depth += 1
+    return False
+
+
+def scan_onnx_model(model: Dict[str, Any]) -> List[str]:
+    """Report security signals from an extracted ONNX model structure.
+
+    Takes the dict produced by the scanner's protobuf walk (see
+    ``DeepScanner._inspect_onnx``) rather than raw bytes, so the wire-format
+    decoding and the security judgement stay separable and separately testable.
+
+    Threat strings follow the convention of the other scanners in this module:
+
+    * ``ONNX_EXTERNAL_DATA_ESCAPE: <path>`` — reaches outside the model directory
+    * ``ONNX_EXTERNAL_DATA: <path>`` — external tensor within the directory; not
+      an escape, but the model is not self-contained and the bytes it will load
+      are not covered by the model's own hash
+    * ``ONNX_CUSTOM_OP: <domain>.<op_type>`` — operator outside the standard set
+    """
+    threats: List[str] = []
+
+    for entry in model.get("external_data") or []:
+        location = (entry or {}).get("location")
+        if not location:
+            continue
+        if external_location_escapes(location):
+            threats.append(f"ONNX_EXTERNAL_DATA_ESCAPE: {location}")
+        else:
+            threats.append(f"ONNX_EXTERNAL_DATA: {location}")
+
+    for op in model.get("custom_ops") or []:
+        domain = (op or {}).get("domain") or ""
+        op_type = (op or {}).get("op_type") or "?"
+        threats.append(f"ONNX_CUSTOM_OP: {domain}.{op_type}")
+
+    return threats
+
+
+def onnx_domain_is_custom(domain: str | None) -> bool:
+    """True if an operator domain lies outside the ONNX standard set."""
+    return (domain or "") not in ONNX_STANDARD_DOMAINS

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -8,14 +8,87 @@ import hashlib
 from typing import List, Dict, Any
 from pathlib import Path
 from pip_requirements_parser import RequirementsFile
-from aisbom.safety import scan_keras_config, scan_keras_config_bytes, scan_pickle_stream
+from aisbom import protobuf_reader as pb
+from aisbom.safety import (
+    onnx_domain_is_custom,
+    scan_keras_config,
+    scan_keras_config_bytes,
+    scan_onnx_model,
+    scan_pickle_stream,
+)
 
 # Constants
 PYTORCH_EXTENSIONS = {'.pt', '.pth', '.bin'}
 SAFETENSORS_EXTENSION = '.safetensors'
 GGUF_EXTENSION = '.gguf'
 KERAS_EXTENSIONS = {'.keras', '.h5', '.hdf5'}
+ONNX_EXTENSION = '.onnx'
 REQUIREMENTS_FILENAME = 'requirements.txt'
+
+# --- ONNX protobuf field numbers ---
+# ONNX has no magic bytes — a .onnx file is a bare serialized ModelProto — so
+# these field numbers are the schema. Confirmed against models serialized by the
+# onnx library itself rather than read off the .proto by eye.
+_ONNX_MODEL_IR_VERSION = 1
+_ONNX_MODEL_PRODUCER_NAME = 2
+_ONNX_MODEL_PRODUCER_VERSION = 3
+_ONNX_MODEL_DOMAIN = 4
+_ONNX_MODEL_VERSION = 5
+_ONNX_MODEL_GRAPH = 7
+_ONNX_MODEL_OPSET_IMPORT = 8
+
+_ONNX_OPSET_DOMAIN = 1
+_ONNX_OPSET_VERSION = 2
+
+_ONNX_GRAPH_NODE = 1
+_ONNX_GRAPH_NAME = 2
+_ONNX_GRAPH_INITIALIZER = 5
+
+_ONNX_NODE_OP_TYPE = 4
+_ONNX_NODE_ATTRIBUTE = 5
+_ONNX_NODE_DOMAIN = 7
+
+# AttributeProto: `g` holds one nested graph, `graphs` holds several. These are
+# how If / Loop / Scan carry the branches they execute. `t` / `tensors` hold
+# tensors, which can themselves point at external data (a Constant node).
+# Numbers read from the ONNX descriptor, not from memory — `graphs` is 11, and
+# 10 is `tensors`, which is exactly the sort of confusion that turns a security
+# walk into a parse of the wrong bytes.
+_ONNX_ATTRIBUTE_TENSOR = 5
+_ONNX_ATTRIBUTE_GRAPH = 6
+_ONNX_ATTRIBUTE_TENSORS = 10
+_ONNX_ATTRIBUTE_GRAPHS = 11
+
+# Nested graphs may nest further; bound the recursion rather than trusting the
+# file's own structure.
+ONNX_MAX_GRAPH_DEPTH = 12
+
+# When walking a large file by seeking, only sub-messages under this size are
+# read. A tensor pointing at external data carries no inline payload and is
+# therefore tiny, and nodes are small by construction — so what gets stepped
+# over is inline weight data, which holds nothing this scan looks for.
+ONNX_MAX_SUBMESSAGE_BYTES = 4 * 1024 * 1024
+
+_ONNX_TENSOR_NAME = 8
+_ONNX_TENSOR_EXTERNAL_DATA = 13
+_ONNX_TENSOR_DATA_LOCATION = 14
+_ONNX_DATA_LOCATION_EXTERNAL = 1
+
+_ONNX_STRING_ENTRY_KEY = 1
+_ONNX_STRING_ENTRY_VALUE = 2
+
+# Bound on how much of a model is read. ONNX stores weights inline, so a real
+# model runs to gigabytes while the graph structure sits at the head; reading a
+# window keeps memory flat. A truncated read still yields every node it covers.
+ONNX_MAX_SCAN_BYTES = 16 * 1024 * 1024
+
+# Remote scans pay per byte over HTTP Range requests, so they read far less.
+ONNX_MAX_REMOTE_SCAN_BYTES = 2 * 1024 * 1024
+
+# Caps on how much graph inventory is retained, so a model with a million nodes
+# cannot turn one SBOM component into an unbounded document.
+ONNX_MAX_OP_TYPES = 200
+ONNX_MAX_EXTERNAL_ENTRIES = 100
 
 # HDF5 files start with this signature; a `.keras` file is a plain zip.
 HDF5_MAGIC = b"\x89HDF\r\n\x1a\n"
@@ -86,6 +159,9 @@ class DeepScanner:
                     elif ext in KERAS_EXTENSIONS:
                         with RemoteStream(url) as stream:
                             self.artifacts.append(self._inspect_keras(stream, Path(url).name, is_remote=True))
+                    elif ext == ONNX_EXTENSION:
+                        with RemoteStream(url) as stream:
+                            self.artifacts.append(self._inspect_onnx(stream, Path(url).name, is_remote=True))
                 except Exception as e:
                     self._record_fetch_error(url, e)
                     continue
@@ -103,6 +179,8 @@ class DeepScanner:
                         self.artifacts.append(self._inspect_gguf(full_path))
                     elif ext in KERAS_EXTENSIONS:
                         self.artifacts.append(self._inspect_keras(full_path))
+                    elif ext == ONNX_EXTENSION:
+                        self.artifacts.append(self._inspect_onnx(full_path))
                     elif full_path.name == REQUIREMENTS_FILENAME:
                         self._parse_requirements(full_path)
 
@@ -770,6 +848,327 @@ class DeepScanner:
                     pass
         return meta
 
+    @staticmethod
+    def _parse_onnx_model(blob: bytes) -> Dict[str, Any]:
+        """Walk a serialized ONNX ModelProto into a plain dict.
+
+        Structure only — the security judgement lives in ``scan_onnx_model``.
+        The walk is total: a field that is absent, empty or truncated yields
+        ``None`` or an empty list rather than raising, because the input is an
+        untrusted file that may well be none of the things it claims to be.
+        """
+        model = pb.parse_message(blob)
+
+        opsets = []
+        for entry in pb.get_messages(model, _ONNX_MODEL_OPSET_IMPORT):
+            opsets.append({
+                "domain": pb.get_str(entry, _ONNX_OPSET_DOMAIN) or "",
+                "version": pb.get_int(entry, _ONNX_OPSET_VERSION),
+            })
+
+        graph_name = None
+        op_types: List[str] = []
+        custom_ops: List[Dict[str, Any]] = []
+        external_data: List[Dict[str, Any]] = []
+        node_count = 0
+
+        # `If`, `Loop` and `Scan` carry whole GraphProtos in their node
+        # attributes, and those subgraphs execute. A walk covering only the top
+        # level would miss a custom operator or an escaping external-data path
+        # hidden one branch down.
+        acc: Dict[str, Any] = {
+            "op_types": op_types,
+            "custom_ops": custom_ops,
+            "external_data": external_data,
+            "nodes": 0,
+            "subgraphs": 0,
+        }
+
+        graph_blob = pb.get_bytes(model, _ONNX_MODEL_GRAPH)
+        if graph_blob:
+            graph = pb.parse_message(graph_blob)
+            graph_name = pb.get_str(graph, _ONNX_GRAPH_NAME)
+            DeepScanner._walk_onnx_graph_message(graph, acc, 0)
+        node_count = acc["nodes"]
+        subgraph_count = acc["subgraphs"]
+
+        return {
+            "subgraph_count": subgraph_count,
+            "ir_version": pb.get_int(model, _ONNX_MODEL_IR_VERSION),
+            "producer_name": pb.get_str(model, _ONNX_MODEL_PRODUCER_NAME),
+            "producer_version": pb.get_str(model, _ONNX_MODEL_PRODUCER_VERSION),
+            "model_domain": pb.get_str(model, _ONNX_MODEL_DOMAIN),
+            "model_version": pb.get_int(model, _ONNX_MODEL_VERSION),
+            "graph_name": graph_name,
+            "opsets": opsets,
+            "op_types": op_types,
+            "custom_ops": custom_ops,
+            "external_data": external_data,
+            "node_count": node_count,
+        }
+
+    def _parse_onnx_model_streamed(self, f, local_path: Path):
+        """Re-walk a large ONNX file, seeking past bulk tensor payloads.
+
+        Only sub-messages below ``ONNX_MAX_SUBMESSAGE_BYTES`` are read. That is
+        safe for the questions being asked: a tensor that points at *external*
+        data carries no inline payload and is therefore tiny, and nodes are
+        small by construction. What gets skipped is inline weight data, which
+        holds nothing this scan is looking for.
+
+        Returns ``None`` if the file does not walk cleanly, so the caller keeps
+        the buffered result rather than losing findings it already had.
+        """
+        try:
+            size = local_path.stat().st_size
+
+            def read_at(offset: int, count: int) -> bytes:
+                f.seek(offset)
+                return f.read(count)
+
+            graph_range = None
+            header_fields: Dict[int, List[Any]] = {}
+            for fn, wt, off, length in pb.iter_stream_fields(read_at, 0, size):
+                if fn == _ONNX_MODEL_GRAPH and wt == pb.WIRE_LENGTH_DELIMITED:
+                    graph_range = (off, off + length)
+                elif length <= ONNX_MAX_SUBMESSAGE_BYTES:
+                    header_fields.setdefault(fn, []).append(
+                        read_at(off, length) if wt == pb.WIRE_LENGTH_DELIMITED
+                        else pb.read_varint(read_at(off, length), 0)[0]
+                    )
+            if graph_range is None:
+                return None
+
+            acc: Dict[str, Any] = {
+                "op_types": [],
+                "custom_ops": [],
+                "external_data": [],
+                "nodes": 0,
+                "subgraphs": 0,
+            }
+            graph_name = None
+
+            for fn, wt, off, length in pb.iter_stream_fields(read_at, *graph_range):
+                if wt != pb.WIRE_LENGTH_DELIMITED:
+                    continue
+                if fn == _ONNX_GRAPH_NAME and graph_name is None:
+                    graph_name = read_at(off, length).decode("utf-8", "replace")
+                elif fn == _ONNX_GRAPH_NODE and length <= ONNX_MAX_SUBMESSAGE_BYTES:
+                    acc["nodes"] += 1
+                    node = pb.parse_message(read_at(off, length))
+                    op_type = pb.get_str(node, _ONNX_NODE_OP_TYPE)
+                    domain = pb.get_str(node, _ONNX_NODE_DOMAIN) or ""
+                    if (op_type and op_type not in acc["op_types"]
+                            and len(acc["op_types"]) < ONNX_MAX_OP_TYPES):
+                        acc["op_types"].append(op_type)
+                    if onnx_domain_is_custom(domain):
+                        acc["custom_ops"].append({"op_type": op_type, "domain": domain})
+                    self._collect_onnx_node_payloads(node, acc, 0)
+                elif fn == _ONNX_GRAPH_INITIALIZER and length <= ONNX_MAX_SUBMESSAGE_BYTES:
+                    # A tensor with external data has no inline payload, so
+                    # anything large here is weights and can be stepped over.
+                    self._collect_onnx_external(
+                        pb.parse_message(read_at(off, length)), acc["external_data"]
+                    )
+
+            op_types = acc["op_types"]
+            custom_ops = acc["custom_ops"]
+            external_data = acc["external_data"]
+            counters = {"nodes": acc["nodes"], "subgraphs": acc["subgraphs"]}
+
+            model = pb.parse_message(read_at(0, min(size, 4096)))
+            return {
+                "ir_version": pb.get_int(model, _ONNX_MODEL_IR_VERSION),
+                "producer_name": pb.get_str(model, _ONNX_MODEL_PRODUCER_NAME),
+                "producer_version": pb.get_str(model, _ONNX_MODEL_PRODUCER_VERSION),
+                "model_domain": pb.get_str(model, _ONNX_MODEL_DOMAIN),
+                "model_version": pb.get_int(model, _ONNX_MODEL_VERSION),
+                "graph_name": graph_name,
+                "opsets": [
+                    {
+                        "domain": pb.get_str(e, _ONNX_OPSET_DOMAIN) or "",
+                        "version": pb.get_int(e, _ONNX_OPSET_VERSION),
+                    }
+                    for e in pb.get_messages(model, _ONNX_MODEL_OPSET_IMPORT)
+                ],
+                "op_types": op_types,
+                "custom_ops": custom_ops,
+                "external_data": external_data,
+                "node_count": counters["nodes"],
+                "subgraph_count": counters["subgraphs"],
+            }
+        except Exception:
+            return None
+
+    @staticmethod
+    def _collect_onnx_external(tensor, external_data: List[Dict[str, Any]]) -> None:
+        if pb.get_int(tensor, _ONNX_TENSOR_DATA_LOCATION) != _ONNX_DATA_LOCATION_EXTERNAL:
+            return
+        if len(external_data) >= ONNX_MAX_EXTERNAL_ENTRIES:
+            return
+        entry: Dict[str, Any] = {"tensor": pb.get_str(tensor, _ONNX_TENSOR_NAME)}
+        for kv in pb.get_messages(tensor, _ONNX_TENSOR_EXTERNAL_DATA):
+            key = pb.get_str(kv, _ONNX_STRING_ENTRY_KEY)
+            if key:
+                entry[key] = pb.get_str(kv, _ONNX_STRING_ENTRY_VALUE)
+        external_data.append(entry)
+
+    @classmethod
+    def _collect_onnx_node_payloads(cls, node, acc: Dict[str, Any], depth: int) -> None:
+        """Inspect a node's attributes: nested graphs, and tensors."""
+        for attribute in pb.get_messages(node, _ONNX_NODE_ATTRIBUTE):
+            for field in (_ONNX_ATTRIBUTE_GRAPH, _ONNX_ATTRIBUTE_GRAPHS):
+                for nested in attribute.get(field, []):
+                    if isinstance(nested, bytes):
+                        acc["subgraphs"] += 1
+                        cls._walk_onnx_graph_message(
+                            pb.parse_message(nested), acc, depth + 1
+                        )
+            for field in (_ONNX_ATTRIBUTE_TENSOR, _ONNX_ATTRIBUTE_TENSORS):
+                for blob_bytes in attribute.get(field, []):
+                    if isinstance(blob_bytes, bytes):
+                        cls._collect_onnx_external(
+                            pb.parse_message(blob_bytes), acc["external_data"]
+                        )
+
+    @classmethod
+    def _walk_onnx_graph_message(cls, graph, acc: Dict[str, Any], depth: int) -> None:
+        """Walk a buffered graph message, recursing into nested graphs."""
+        if depth > ONNX_MAX_GRAPH_DEPTH:
+            return
+        for node in pb.get_messages(graph, _ONNX_GRAPH_NODE):
+            acc["nodes"] += 1
+            op_type = pb.get_str(node, _ONNX_NODE_OP_TYPE)
+            domain = pb.get_str(node, _ONNX_NODE_DOMAIN) or ""
+            if (op_type and op_type not in acc["op_types"]
+                    and len(acc["op_types"]) < ONNX_MAX_OP_TYPES):
+                acc["op_types"].append(op_type)
+            if onnx_domain_is_custom(domain):
+                acc["custom_ops"].append({"op_type": op_type, "domain": domain})
+            cls._collect_onnx_node_payloads(node, acc, depth)
+        for tensor in pb.get_messages(graph, _ONNX_GRAPH_INITIALIZER):
+            cls._collect_onnx_external(tensor, acc["external_data"])
+
+    @staticmethod
+    def _onnx_risk_label(threats: List[str]) -> str:
+        """Map ONNX findings to a risk label.
+
+        Only an external-data path that leaves the model directory is CRITICAL:
+        that one turns loading the model into a read of a file the author chose.
+        A custom operator, or external data that stays put, is a MEDIUM — real
+        signal, but it needs something else (a registered op library, a swapped
+        weights file) before it becomes an attack.
+
+        The substring in the returned label is what the CLI's exit-code check
+        reads, so the wording is load-bearing: "CRITICAL" exits 2, "MEDIUM"
+        does not. ("HIGH" is deliberately unused — it is not one of the levels
+        the exit-code mapping recognises.)
+        """
+        escapes = [t for t in threats if t.startswith("ONNX_EXTERNAL_DATA_ESCAPE:")]
+        if escapes:
+            paths = ", ".join(t.split(": ", 1)[1] for t in escapes)
+            return f"CRITICAL (ONNX External Data Escapes Model Directory: {paths})"
+
+        custom = sum(1 for t in threats if t.startswith("ONNX_CUSTOM_OP:"))
+        external = sum(1 for t in threats if t.startswith("ONNX_EXTERNAL_DATA:"))
+        parts = []
+        if custom:
+            parts.append(f"{custom} custom operator(s)")
+        if external:
+            parts.append(f"{external} external tensor(s)")
+        if parts:
+            return f"MEDIUM (ONNX: {'; '.join(parts)})"
+        return "LOW"
+
+    def _inspect_onnx(self, source, name: str | None = None, is_remote: bool = False) -> Dict[str, Any]:
+        """Statically inspects an ONNX model's protobuf structure.
+
+        No ONNX runtime is loaded and the graph is never executed — the file is
+        walked as protobuf to recover its metadata and to surface two signals:
+        operators outside the standard domains, and tensors stored outside the
+        model file. Only the head of the file is read, so a multi-gigabyte model
+        costs the same as a small one.
+        """
+        local_path = None
+        if isinstance(source, (str, Path)):
+            local_path = Path(source)
+            name = name or local_path.name
+            is_remote = False
+        name = name or getattr(source, "name", "unknown")
+
+        meta = {
+            "name": name,
+            "type": "machine-learning-model",
+            "framework": "ONNX",
+            "risk_level": "LOW",
+            "license": "Unknown",  # ONNX has no standard license field
+            "legal_status": "UNKNOWN",
+            "hash": "remote_unhashed" if is_remote else self._calculate_hash(local_path),
+            "details": {},
+        }
+
+        f = None
+        try:
+            f = open(local_path, "rb") if local_path else source
+            budget = ONNX_MAX_SCAN_BYTES if local_path else ONNX_MAX_REMOTE_SCAN_BYTES
+            f.seek(0)
+            blob = f.read(budget)
+
+            parsed = self._parse_onnx_model(blob)
+
+            # ONNX stores weights inline, so a real model is far larger than any
+            # window worth buffering — and a single big tensor early in the
+            # graph would otherwise hide every external-data entry behind it.
+            # For a local file, seeking is free, so the graph is re-walked by
+            # stepping over bulk payloads instead of reading them.
+            truncated = len(blob) >= budget
+            if truncated and local_path is not None:
+                streamed = self._parse_onnx_model_streamed(f, local_path)
+                if streamed is not None:
+                    parsed = streamed
+                    truncated = False
+
+            threats = scan_onnx_model(parsed)
+
+            # A .onnx file has no magic number, so "did this parse as ONNX?" is
+            # judged by whether the walk recovered anything a ModelProto has.
+            looks_like_onnx = any((
+                parsed["ir_version"] is not None,
+                parsed["producer_name"],
+                parsed["graph_name"],
+                parsed["opsets"],
+                parsed["node_count"],
+            ))
+
+            meta["details"] = {
+                "ir_version": parsed["ir_version"],
+                "producer_name": parsed["producer_name"],
+                "producer_version": parsed["producer_version"],
+                "graph_name": parsed["graph_name"],
+                "opsets": parsed["opsets"],
+                "op_types": parsed["op_types"],
+                "custom_ops": parsed["custom_ops"],
+                "external_data": parsed["external_data"],
+                "node_count": parsed["node_count"],
+                "subgraph_count": parsed.get("subgraph_count", 0),
+                "threats": threats,
+                "parsed": looks_like_onnx,
+                "truncated": len(blob) >= budget,
+            }
+
+            if not looks_like_onnx:
+                meta["risk_level"] = "UNKNOWN (Unparsable ONNX)"
+            else:
+                meta["risk_level"] = self._onnx_risk_label(threats)
+        except Exception as e:
+            meta["error"] = str(e)
+        finally:
+            if local_path and f:
+                try:
+                    f.close()
+                except Exception:
+                    pass
+        return meta
     def _parse_requirements(self, path: Path):
         try:
             req_file = RequirementsFile.from_file(path)

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,7 +32,7 @@ description = "Backport of compression.zstd"
 optional = false
 python-versions = "<3.14,>=3.10"
 groups = ["dev"]
-markers = "python_version < \"3.14\""
+markers = "python_version <= \"3.13\""
 files = [
     {file = "backports_zstd-1.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:73000459db113a658c4fb0510100ef0e79137b5828bf957b7709aacae4eb1b87"},
     {file = "backports_zstd-1.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d6e78d5e28f812b39f92397806ecddd4a6f3bf35531a8c039a1f187abc931af8"},
@@ -966,6 +966,66 @@ files = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.6.0"
+description = "ml_dtypes is a stand-alone implementation of several NumPy dtype extensions used in machine learning."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "ml_dtypes-0.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bad8d1dd5bed060a29332b99d63d0e5c2969081e1c6ea54adfbccfdfa783be44"},
+    {file = "ml_dtypes-0.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:008382aeab529df5d3f00501ad9a7dcd64494d4b5b1971fc4c79019e6c1f5010"},
+    {file = "ml_dtypes-0.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ec0d244a5bba12239025389ad88bbfb45f9f10e25ab4f678e9a4768ebd47532"},
+    {file = "ml_dtypes-0.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:03ce583adfce34ad33aa9e1fc7a8344dcf90ea776cc4ef0e5a48d4eae84e5d20"},
+    {file = "ml_dtypes-0.6.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f4f59f83c82ab480e924b988e7b1b4eb4de836dfcf5390c6f59148d1a00e1d02"},
+    {file = "ml_dtypes-0.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7728c0420ec1c338564fc8b01015ff2d58567e70f17fedce5a0a7c0308c0d5b9"},
+    {file = "ml_dtypes-0.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c8e39b53e90afda8ce52859c93de4dba3e02b76d85dcf091cc469f9184c6dae"},
+    {file = "ml_dtypes-0.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:3035518e3e19add1a4cac9236ab22888b208a4074912514313ccb2d6d242cde8"},
+    {file = "ml_dtypes-0.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:5a519c9e95a216fbcb8e759793ef7fb40793fc803ed839142d6dc5be9be5bc89"},
+    {file = "ml_dtypes-0.6.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5359c588cc62de6f78d7430f06b65853d884955494d86d6ad90b6dd64a3f3a08"},
+    {file = "ml_dtypes-0.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37da32aa97749251025666d62372775019594577b9c9e9cfda83bed48d778fdb"},
+    {file = "ml_dtypes-0.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b4a480aa8fd54a1805b8ac10f3f91763926a74f73c0c364c10f9231854f4170"},
+    {file = "ml_dtypes-0.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:2a3e9d53925597fbffafd2a37048dadeddd0bdaba58058f6ae0869ed709a184d"},
+    {file = "ml_dtypes-0.6.0-cp312-cp312-win_arm64.whl", hash = "sha256:6eaed129a4afe90694b8685e2f9b6294849f5eda4af9a15be83a4326eeebd775"},
+    {file = "ml_dtypes-0.6.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:084dfe51a7ad58b171f05115f8226ed4233a454a1611371947e806e76f0c638d"},
+    {file = "ml_dtypes-0.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28d676428b104bb9717b0928bc5c5129f2d6b51b6727587cc4289e7bf8713cb5"},
+    {file = "ml_dtypes-0.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26b1f1fa4f0435a2946859823f6e2bf06796f1e9f10f5a05b08a5e3c8f46ff69"},
+    {file = "ml_dtypes-0.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:fb87f46b4f7ad7b5d3ad8f4b452b024bd4229d44c8ff934798c1fe656210387a"},
+    {file = "ml_dtypes-0.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:57ed0d6b4ac5e7868361303a9c57fbcf63b768236ee14456f585dfcf260d0292"},
+    {file = "ml_dtypes-0.6.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:84fa136b8602c8c39e3b6cb24918960cd6f36cade7a70376f56770729cd56510"},
+    {file = "ml_dtypes-0.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:317be9967fb84b0ce4e80e6b1bf71213d21971621cf6f1e501a63602a95297bf"},
+    {file = "ml_dtypes-0.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f490c003369ce60e514a0c3b12374f05274c101fee1bead6740ec8a564032b0"},
+    {file = "ml_dtypes-0.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:d574c2b28921dc72e869df248f1a278f6eee176a1f237c8642e1a71eb15f3977"},
+    {file = "ml_dtypes-0.6.0-cp314-cp314-win_arm64.whl", hash = "sha256:f4adb4af61516510d786cf8c01851a66f6d3ddfa79e1144deaa5b40d8507231e"},
+    {file = "ml_dtypes-0.6.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3e169214e0d80ff1c038e1b3017e33c23e43bdf948d42d31de8283111c7e2fa3"},
+    {file = "ml_dtypes-0.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:573b11f3c327e17ef3826d266e676cf1149a1f3016f822a05f2306c55d8246bf"},
+    {file = "ml_dtypes-0.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b76fa1d3f92967d58289ac47ab7458ede66e6f3527fff3e59142aee57d9307cd"},
+    {file = "ml_dtypes-0.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3be9911d953f97cddded4b9961d7b650473b7e55806d20f6176f8356dfe7b38e"},
+    {file = "ml_dtypes-0.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:e74266ca8e97874a937b7646378c178025650a236584f7474d10d8086a6edea3"},
+    {file = "ml_dtypes-0.6.0-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b1b503864fada3f74fabf8d9fee7b4c1cbe956301e6fdece975d5f77c2fce958"},
+    {file = "ml_dtypes-0.6.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c6ad60af4102789a5c09824004beade2f7f28cd1cd581ee5c170d9dc2fbb00e"},
+    {file = "ml_dtypes-0.6.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4f1b9329a251e4affe3bb58f4d3e2db22a714396fd7ffb40d0b5db423c24d17"},
+    {file = "ml_dtypes-0.6.0-cp315-cp315-win_amd64.whl", hash = "sha256:488c99ab181a2f59d9ec3b12c5fa11ec904e92be2c4ba18cded54dd7501208fe"},
+    {file = "ml_dtypes-0.6.0-cp315-cp315-win_arm64.whl", hash = "sha256:de9d14748dbf3968951436ef514a29c9d1fe438aa680d110134ee2f7a9f9df18"},
+    {file = "ml_dtypes-0.6.0-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e25bb3b0ad1217b60626e4ed45b10ca170c41d99fbe44a12bebc1e07ec4aad55"},
+    {file = "ml_dtypes-0.6.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:31f1ce979d31a357e95aa81812f20412c8c954fa43c44ee3ead1e1c8a78575ef"},
+    {file = "ml_dtypes-0.6.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2d6149f3a57f405bcad5fb41e03218b8373936253f23e1ca84c0108abbc3392"},
+    {file = "ml_dtypes-0.6.0-cp315-cp315t-win_amd64.whl", hash = "sha256:ce7563e0b1a4482cbc1b4a6272145e54e4489e54fe7428f94908c3d87103abfa"},
+    {file = "ml_dtypes-0.6.0-cp315-cp315t-win_arm64.whl", hash = "sha256:f6cb525101b6b903779188c1e9e9490c343b455ab822883e02cf01e5547338d2"},
+    {file = "ml_dtypes-0.6.0.tar.gz", hash = "sha256:5e60251d32ced5598972e4d5e06a2f044341f9291402551a3f6f0ec44f9299b0"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=2.0.0"},
+    {version = ">=2.1.0", markers = "python_version == \"3.13\""},
+    {version = ">=2.3.0", markers = "python_version >= \"3.14\""},
+]
+
+[package.extras]
+dev = ["absl-py", "pyink", "pylint (>=2.6.0)", "pytest", "pytest-xdist"]
+
+[[package]]
 name = "multivolumefile"
 version = "0.2.3"
 description = "multi volume file wrapper library"
@@ -1143,6 +1203,49 @@ files = [
 ]
 
 [[package]]
+name = "onnx"
+version = "1.22.0"
+description = "Open Neural Network Exchange"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "onnx-1.22.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:6d0ffffd63a4ecc21ddaeddd5bf02099cb701aa4243f2de00122726869065ca4"},
+    {file = "onnx-1.22.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33ce94119bbb7f05d9caea4ea7549f5185a54369f6bbc9f70171bd5ee6935bbc"},
+    {file = "onnx-1.22.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87a3077958f66f9a26dec10077ac28326d9cec2cbe1f0b040947243449754573"},
+    {file = "onnx-1.22.0-cp310-cp310-win32.whl", hash = "sha256:8a5eccce2d5fc6c5046928a9aa7cdd9750ea4a586f8de341d3d40d820c35fdec"},
+    {file = "onnx-1.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:5c1c0408a9d4b4df33851672e5fc7590b96301ee123396d608f9ab6f045ab06b"},
+    {file = "onnx-1.22.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:2d8f229a553fa440fe623ed7b36fca5e7762da3af871c3f8f8ce451df73e2914"},
+    {file = "onnx-1.22.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a89a7cb9ba13d78f009bdec448ec82a98972589734f157022a2bff7a5973a6"},
+    {file = "onnx-1.22.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d0a2bdb15eb2b3cb65c438f3423d9620d14fdce32f92380e6bb1b2e09568ef5"},
+    {file = "onnx-1.22.0-cp311-cp311-win32.whl", hash = "sha256:239958534464612fbcb6ed23d5228aaa925b39b8773f58726809ffdccb4edd1c"},
+    {file = "onnx-1.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:8561a2c00041c07e08db0c228593b5b4694100398685f348532af7dbb84189da"},
+    {file = "onnx-1.22.0-cp311-cp311-win_arm64.whl", hash = "sha256:8907b9b9389893bc0dc6314cc00ee1e3a69844e48d689eacc6a0340411a7da58"},
+    {file = "onnx-1.22.0-cp312-abi3-macosx_12_0_universal2.whl", hash = "sha256:596fbf0490947533c1c1045ba860851dc9fb77471023dac9a71ba5b42ceab103"},
+    {file = "onnx-1.22.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae5a563f281cd9d2845622cecf6c092a57e4ee1b138f66fdbbdd4200567a5e16"},
+    {file = "onnx-1.22.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:955e02e1f6d385b53d52f9cd7b9cdf5caf417c300bcfe3c64c6d542be763845b"},
+    {file = "onnx-1.22.0-cp312-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:82e9f27fc1223cb06d68a56bed6f9d3caf3d0dad1b61bce45006d529b15bd94c"},
+    {file = "onnx-1.22.0-cp312-abi3-win32.whl", hash = "sha256:cc8b66b312f8f03a53e268afb67180a2d97dd12cc79e2b61361c6c0073448016"},
+    {file = "onnx-1.22.0-cp312-abi3-win_amd64.whl", hash = "sha256:72ccebab3bac07215c204ce8848d42e78eaaa666badbf72d25cd359b9f269e3a"},
+    {file = "onnx-1.22.0-cp312-abi3-win_arm64.whl", hash = "sha256:f3c120dcdb70ad738f3c061b32798f408ea299eb69f84dd69ab4a6bf3c2ec01f"},
+    {file = "onnx-1.22.0-cp314-cp314t-macosx_12_0_universal2.whl", hash = "sha256:19e45e4af88e3fe3261458d4b8cc461957ae2782a358a3560503569bf3b23b72"},
+    {file = "onnx-1.22.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c21a0e59fd967a95b358e4a6e756d1f1eec2d304a83480f329f66e30d2bf0223"},
+    {file = "onnx-1.22.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2632406b8f523ef2e2873c363f90b20a3d88c0fbcfac757d3addffccf8f452c2"},
+    {file = "onnx-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a3a39fc4643867aecb33417fdddb11e308ee79d2d4a584b9d50cc7aec2091b13"},
+    {file = "onnx-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:8e268cdc0547e3949799ffd4a44451dc2b9080b57d0824a2db680b6ec65506f0"},
+    {file = "onnx-1.22.0.tar.gz", hash = "sha256:ef40c0aaf0b643857ea9306fc7eddce17eaf9fb0407e4801f1fc5758443a38e0"},
+]
+
+[package.dependencies]
+ml_dtypes = ">=0.5.4"
+numpy = ">=1.23.2"
+protobuf = ">=4.25.1"
+typing_extensions = ">=4.15.0"
+
+[package.extras]
+reference = ["Pillow"]
+
+[[package]]
 name = "packageurl-python"
 version = "0.17.6"
 description = "A purl aka. Package URL parser and builder"
@@ -1231,6 +1334,24 @@ groups = ["main"]
 files = [
     {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
     {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+description = ""
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6"},
+    {file = "protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799"},
+    {file = "protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4"},
+    {file = "protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4"},
+    {file = "protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30"},
+    {file = "protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87"},
+    {file = "protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9"},
+    {file = "protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a"},
 ]
 
 [[package]]
@@ -1935,12 +2056,12 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "python_version < \"3.13\""
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
+markers = {main = "python_version < \"3.13\""}
 
 [[package]]
 name = "uritools"
@@ -1990,4 +2111,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "abab64be2e80d5be7b1dec4d811ccaf158c9b84aca19cdba9ce458f1cc7a4254"
+content-hash = "4bcf0ee85b5656959f1828424a43e36eb43c1fceae8ed390ce84c1285b396d64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pytest-cov = ">=6,<8"
 pyinstaller = {version = "^6.18.0", python = "<3.15"}
 py7zr = "^1.1.3"
 h5py = "^3.12"
+onnx = "^1.17"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1,0 +1,600 @@
+"""ONNX scanning: protobuf metadata, custom operators, and external data.
+
+ONNX carries no pickle, so nothing here is about a payload inside the file.
+The signals are what *loading* the model would make a runtime reach for: an
+operator from a domain that needs a custom native op library, and tensors
+stored outside the model file — where a path that climbs out of the model
+directory turns `load_model` into an arbitrary-file read.
+
+No ONNX runtime is imported by the scanner. The `onnx` library appears here as
+a **dev-only** dependency, used to cross-validate in both directions: that the
+hand-written protobuf walk reads models the real library produced, and that the
+hand-written generator produces models the real library accepts.
+"""
+
+import json
+
+import pytest
+
+from aisbom.mock_generator import create_mock_onnx
+from aisbom.properties import build_component_properties
+from aisbom.protobuf_reader import (
+    iter_fields,
+    parse_message,
+    read_varint,
+    TruncatedMessage,
+)
+from aisbom.safety import (
+    external_location_escapes,
+    onnx_domain_is_custom,
+    scan_onnx_model,
+)
+from aisbom.scanner import DeepScanner
+
+onnx = pytest.importorskip("onnx", reason="onnx is a dev-only fixture dependency")
+
+
+# --- protobuf_reader ------------------------------------------------------
+
+def test_read_varint_single_and_multibyte():
+    assert read_varint(b"\x01", 0) == (1, 1)
+    assert read_varint(b"\xac\x02", 0) == (300, 2)
+
+
+def test_read_varint_raises_on_truncation():
+    with pytest.raises(TruncatedMessage):
+        read_varint(b"\xac", 0)
+
+
+def test_parse_message_groups_repeated_fields():
+    buf = b"\x08\x01" + b"\x08\x02" + b"\x12\x03abc"
+    fields = parse_message(buf)
+    assert fields[1] == [1, 2]
+    assert fields[2] == [b"abc"]
+
+
+def test_iter_fields_stops_cleanly_on_truncated_varint():
+    # Field 1 is complete; the second tag's varint runs off the end.
+    assert list(iter_fields(b"\x08\x01\x10")) == [(1, 0, 1)]
+
+
+def test_iter_fields_returns_partial_payload_when_length_overruns():
+    """A length that exceeds the buffer yields the bytes we actually hold.
+
+    This is the multi-gigabyte-model case: the graph declares its full size but
+    only the head was read, and that head is still worth parsing.
+    """
+    buf = b"\x12\x40" + b"only-ten-b"
+    assert list(iter_fields(buf)) == [(2, 2, b"only-ten-b")]
+
+
+def test_iter_fields_rejects_field_zero_and_bad_wire_type():
+    assert list(iter_fields(b"\x00\x01")) == []      # field number 0
+    assert list(iter_fields(b"\x0b\x01")) == []      # wire type 3 (group)
+
+
+def test_parse_message_on_random_bytes_does_not_raise():
+    parse_message(bytes(range(256)))
+
+
+# --- external-path judgement ---------------------------------------------
+
+@pytest.mark.parametrize("location", [
+    "../secrets.bin",
+    "../../../etc/passwd",
+    "weights/../../escape.bin",
+    "/etc/passwd",
+    "\\\\server\\share\\x.bin",
+    "C:\\Windows\\system32\\x.bin",
+    "http://attacker.example/w.bin",
+    "file:///etc/passwd",
+    "s3://bucket/w.bin",
+])
+def test_locations_that_escape_the_model_directory(location):
+    assert external_location_escapes(location) is True
+
+
+@pytest.mark.parametrize("location", [
+    "weights.bin",
+    "./weights.bin",
+    "shards/weights-00001.bin",
+    "a/../b.bin",          # resolves back to the model directory
+    "a/b/../../c.bin",     # ditto, deeper
+])
+def test_locations_that_stay_inside_the_model_directory(location):
+    assert external_location_escapes(location) is False
+
+
+def test_empty_and_non_string_locations_are_not_escapes():
+    assert external_location_escapes("") is False
+    assert external_location_escapes(None) is False
+
+
+def test_standard_and_custom_domains():
+    assert onnx_domain_is_custom("") is False
+    assert onnx_domain_is_custom("ai.onnx") is False
+    assert onnx_domain_is_custom("ai.onnx.ml") is False
+    assert onnx_domain_is_custom(None) is False
+    assert onnx_domain_is_custom("com.attacker.ops") is True
+
+
+# --- scan_onnx_model ------------------------------------------------------
+
+def test_clean_model_structure_has_no_threats():
+    assert scan_onnx_model({"custom_ops": [], "external_data": []}) == []
+    assert scan_onnx_model({}) == []
+
+
+def test_escaping_external_data_is_reported_distinctly():
+    threats = scan_onnx_model({"external_data": [{"location": "../../etc/passwd"}]})
+    assert threats == ["ONNX_EXTERNAL_DATA_ESCAPE: ../../etc/passwd"]
+
+
+def test_contained_external_data_is_reported_but_not_as_an_escape():
+    threats = scan_onnx_model({"external_data": [{"location": "weights.bin"}]})
+    assert threats == ["ONNX_EXTERNAL_DATA: weights.bin"]
+
+
+def test_custom_op_is_reported():
+    threats = scan_onnx_model(
+        {"custom_ops": [{"op_type": "Evil", "domain": "com.attacker"}]}
+    )
+    assert threats == ["ONNX_CUSTOM_OP: com.attacker.Evil"]
+
+
+# --- DeepScanner end to end ----------------------------------------------
+
+def test_standard_model_scans_clean_with_metadata(tmp_path):
+    create_mock_onnx(tmp_path / "model.onnx")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["framework"] == "ONNX"
+    assert art["type"] == "machine-learning-model"
+    assert art["risk_level"] == "LOW"
+    assert len(art["hash"]) == 64
+
+    details = art["details"]
+    assert details["ir_version"] == 9
+    assert details["producer_name"] == "aisbom-mock"
+    assert details["producer_version"] == "1.0.0"
+    assert details["graph_name"] == "mock_graph"
+    assert details["op_types"] == ["Relu"]
+    assert details["opsets"] == [{"domain": "", "version": 17}]
+    assert details["threats"] == []
+    assert details["parsed"] is True
+
+
+def test_custom_op_model_is_flagged_medium(tmp_path):
+    create_mock_onnx(tmp_path / "custom.onnx", custom_op=True)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "MEDIUM" in art["risk_level"]
+    assert "CRITICAL" not in art["risk_level"]
+    assert art["details"]["custom_ops"] == [
+        {"op_type": "MyCustomOp", "domain": "com.example.ops"}
+    ]
+    assert any(t.startswith("ONNX_CUSTOM_OP:") for t in art["details"]["threats"])
+
+
+def test_external_data_inside_directory_is_medium(tmp_path):
+    create_mock_onnx(tmp_path / "ext.onnx", external_location="weights.bin")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "MEDIUM" in art["risk_level"]
+    assert art["details"]["external_data"][0]["location"] == "weights.bin"
+    assert art["details"]["external_data"][0]["offset"] == "0"
+
+
+def test_external_data_traversal_is_critical(tmp_path):
+    create_mock_onnx(tmp_path / "evil.onnx", external_location="../../../etc/passwd")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "../../../etc/passwd" in art["risk_level"]
+    assert any(
+        t.startswith("ONNX_EXTERNAL_DATA_ESCAPE:") for t in art["details"]["threats"]
+    )
+
+
+def test_garbage_onnx_file_is_not_reported_as_a_model(tmp_path):
+    (tmp_path / "junk.onnx").write_bytes(b"this is not a protobuf at all, really")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" not in art["risk_level"]
+    assert art["details"]["parsed"] is False
+
+
+def test_empty_onnx_file_does_not_crash(tmp_path):
+    (tmp_path / "empty.onnx").write_bytes(b"")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["framework"] == "ONNX"
+    assert art["details"]["parsed"] is False
+
+
+def test_truncated_model_still_reports_the_nodes_it_covers(tmp_path, monkeypatch):
+    """Reading only the head of a large model must still yield its graph."""
+    import aisbom.scanner as scanner_mod
+
+    full = create_mock_onnx(
+        tmp_path / "big.onnx", custom_op=True, external_location="w.bin"
+    ).read_bytes()
+    # Force the budget below the file size so the read genuinely truncates.
+    monkeypatch.setattr(scanner_mod, "ONNX_MAX_SCAN_BYTES", len(full) - 12)
+
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+    assert art["details"]["truncated"] is True
+    # The head carries the nodes, so the custom operator is still seen.
+    assert art["details"]["node_count"] >= 1
+
+
+# --- cross-validation against the real onnx library ----------------------
+
+def _real_onnx_model(tmp_path, custom_op=False, external_location=None):
+    """Build a model with the onnx library itself, for cross-validation."""
+    import numpy as np
+    from onnx import TensorProto, helper, numpy_helper
+
+    if custom_op:
+        nodes = [helper.make_node(
+            "RealCustomOp", ["x"], ["y"], name="n0", domain="org.thirdparty",
+        )]
+        opsets = [helper.make_opsetid("", 17), helper.make_opsetid("org.thirdparty", 3)]
+    else:
+        nodes = [helper.make_node("Relu", ["x"], ["y"], name="n0")]
+        opsets = [helper.make_opsetid("", 17)]
+
+    initializers = []
+    if external_location is not None:
+        tensor = numpy_helper.from_array(np.ones((2, 2), dtype=np.float32), name="W")
+        tensor.data_location = TensorProto.EXTERNAL
+        tensor.ClearField("raw_data")
+        for key, value in (("location", external_location), ("offset", "0"), ("length", "16")):
+            entry = tensor.external_data.add()
+            entry.key, entry.value = key, value
+        initializers.append(tensor)
+
+    graph = helper.make_graph(
+        nodes, "real_graph",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 2])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 2])],
+        initializer=initializers,
+    )
+    model = helper.make_model(
+        graph, producer_name="pytorch", producer_version="2.4.0", opset_imports=opsets
+    )
+    model.ir_version = 9
+    path = tmp_path / "real.onnx"
+    path.write_bytes(model.SerializeToString())
+    return path
+
+
+def test_parser_reads_a_model_built_by_the_onnx_library(tmp_path):
+    """The hand-written protobuf walk must handle real library output."""
+    _real_onnx_model(tmp_path)
+    details = DeepScanner(str(tmp_path)).scan()["artifacts"][0]["details"]
+
+    assert details["parsed"] is True
+    assert details["ir_version"] == 9
+    assert details["producer_name"] == "pytorch"
+    assert details["producer_version"] == "2.4.0"
+    assert details["graph_name"] == "real_graph"
+    assert details["op_types"] == ["Relu"]
+    assert {"domain": "", "version": 17} in details["opsets"]
+    assert details["threats"] == []
+
+
+def test_parser_finds_a_custom_op_in_a_real_model(tmp_path):
+    _real_onnx_model(tmp_path, custom_op=True)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["details"]["custom_ops"] == [
+        {"op_type": "RealCustomOp", "domain": "org.thirdparty"}
+    ]
+    assert "MEDIUM" in art["risk_level"]
+
+
+def test_parser_finds_an_external_data_escape_in_a_real_model(tmp_path):
+    _real_onnx_model(tmp_path, external_location="../../../../etc/shadow")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert art["details"]["external_data"][0]["location"] == "../../../../etc/shadow"
+
+
+def test_generated_mock_is_accepted_by_the_onnx_library(tmp_path):
+    """The stdlib generator must emit protobuf the real library can load.
+
+    Without this the tests could be self-consistent and both wrong.
+    """
+    path = create_mock_onnx(tmp_path / "m.onnx", custom_op=True, external_location="w.bin")
+    # `load_external_data=False` matters: the default resolves the external
+    # path against the filesystem and opens it. That eager read is exactly the
+    # behaviour that makes an escaping location dangerous, and it is why this
+    # scanner judges the path textually instead of touching it.
+    model = onnx.load(str(path), load_external_data=False)
+
+    assert model.ir_version == 9
+    assert model.producer_name == "aisbom-mock"
+    assert model.graph.name == "mock_graph"
+    assert [n.op_type for n in model.graph.node] == ["Relu", "MyCustomOp"]
+    assert model.graph.node[1].domain == "com.example.ops"
+    assert model.graph.initializer[0].external_data[0].key == "location"
+    assert model.graph.initializer[0].external_data[0].value == "w.bin"
+
+
+# --- subgraphs -------------------------------------------------------------
+
+def _model_with_subgraph(tmp_path, external_location=None, custom_domain=None):
+    """An `If` node whose branch is a subgraph — a real executable graph."""
+    import numpy as np
+    from onnx import TensorProto, helper, numpy_helper
+
+    inner_nodes = []
+    if custom_domain:
+        inner_nodes.append(helper.make_node(
+            "HiddenOp", ["x"], ["y"], name="hidden", domain=custom_domain
+        ))
+    else:
+        inner_nodes.append(helper.make_node("Relu", ["x"], ["y"], name="inner"))
+
+    initializers = []
+    if external_location is not None:
+        tensor = numpy_helper.from_array(np.ones((2, 2), dtype=np.float32), name="HW")
+        tensor.data_location = TensorProto.EXTERNAL
+        tensor.ClearField("raw_data")
+        for key, value in (("location", external_location), ("offset", "0"), ("length", "16")):
+            entry = tensor.external_data.add()
+            entry.key, entry.value = key, value
+        initializers.append(tensor)
+
+    then_graph = helper.make_graph(
+        inner_nodes, "then_body", [],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 2])],
+        initializer=initializers,
+    )
+    else_graph = helper.make_graph(
+        [helper.make_node("Identity", ["x"], ["y"], name="else_node")], "else_body", [],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 2])],
+    )
+    node = helper.make_node(
+        "If", ["cond"], ["y"], then_branch=then_graph, else_branch=else_graph
+    )
+    graph = helper.make_graph(
+        [node], "outer",
+        [helper.make_tensor_value_info("cond", TensorProto.BOOL, [1])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 2])],
+    )
+    model = helper.make_model(graph, producer_name="sub", opset_imports=[
+        helper.make_opsetid("", 17)
+    ] + ([helper.make_opsetid(custom_domain, 1)] if custom_domain else []))
+    model.ir_version = 9
+    path = tmp_path / "sub.onnx"
+    path.write_bytes(model.SerializeToString())
+    return path
+
+
+def test_custom_op_inside_a_subgraph_is_found(tmp_path):
+    """`If`/`Loop`/`Scan` carry graphs in their attributes, and those execute."""
+    _model_with_subgraph(tmp_path, custom_domain="com.attacker.hidden")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["details"]["subgraph_count"] >= 1
+    assert any(
+        o["domain"] == "com.attacker.hidden" for o in art["details"]["custom_ops"]
+    ), art["details"]["custom_ops"]
+    assert "MEDIUM" in art["risk_level"]
+
+
+def test_external_data_escape_inside_a_subgraph_is_critical(tmp_path):
+    """A traversal path one branch down must still trip the gate."""
+    _model_with_subgraph(tmp_path, external_location="../../../../etc/passwd")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert any(
+        e.get("location") == "../../../../etc/passwd"
+        for e in art["details"]["external_data"]
+    )
+
+
+def test_a_model_without_subgraphs_reports_none(tmp_path):
+    create_mock_onnx(tmp_path / "flat.onnx")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+    assert art["details"]["subgraph_count"] == 0
+
+
+# --- large models: seeking past bulk tensor data --------------------------
+
+def test_external_data_after_a_large_inline_tensor_is_found(tmp_path, monkeypatch):
+    """A big inline tensor must not hide the entries behind it.
+
+    ONNX stores weights inline, so a window read from the front stops inside
+    the first large tensor. Since a tensor pointing at *external* data carries
+    no inline payload, bulk data can be stepped over rather than buffered.
+    """
+    import numpy as np
+    import aisbom.scanner as scanner_mod
+    from onnx import TensorProto, helper, numpy_helper
+
+    # A genuinely large inline initializer, placed before the external one.
+    big = numpy_helper.from_array(
+        np.zeros((512, 512), dtype=np.float32), name="bulk"
+    )
+    external = numpy_helper.from_array(
+        np.ones((2, 2), dtype=np.float32), name="W"
+    )
+    external.data_location = TensorProto.EXTERNAL
+    external.ClearField("raw_data")
+    for key, value in (("location", "../../secret.bin"), ("offset", "0"), ("length", "16")):
+        entry = external.external_data.add()
+        entry.key, entry.value = key, value
+
+    graph = helper.make_graph(
+        [helper.make_node("Relu", ["x"], ["y"], name="n")], "big_graph",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 2])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 2])],
+        initializer=[big, external],
+    )
+    model = helper.make_model(graph, producer_name="big",
+                              opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 9
+    path = tmp_path / "big.onnx"
+    path.write_bytes(model.SerializeToString())
+
+    # Force the buffered window well below the bulk tensor so the head read
+    # genuinely stops inside it.
+    monkeypatch.setattr(scanner_mod, "ONNX_MAX_SCAN_BYTES", 4096)
+
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"], art["risk_level"]
+    assert any(
+        e.get("location") == "../../secret.bin" for e in art["details"]["external_data"]
+    )
+
+
+# --- Hugging Face resolution ----------------------------------------------
+
+def test_onnx_files_are_resolved_from_a_hugging_face_repo(monkeypatch):
+    """The dispatch arm is unreachable for `hf://` unless the resolver lists it."""
+    import aisbom.remote as remote
+
+    def fake_get(url, headers=None):
+        class Resp:
+            status_code = 200
+            headers = {}
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return [{"path": "model.onnx"}, {"path": "README.md"}]
+
+        return Resp()
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+
+    urls = remote.resolve_huggingface_repo("hf://org/model")
+    assert any(u.endswith("model.onnx") for u in urls), urls
+
+
+# --- SBOM plumbing --------------------------------------------------------
+
+def test_onnx_format_token_is_registered():
+    art = {"framework": "ONNX", "risk_level": "LOW", "legal_status": "UNKNOWN", "details": {}}
+    assert dict(build_component_properties(art))["aisbom:format"] == "onnx"
+
+
+def test_onnx_properties_carry_metadata_and_findings(tmp_path):
+    create_mock_onnx(tmp_path / "m.onnx", custom_op=True, external_location="../out.bin")
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+    props = build_component_properties(art)
+    as_dict = dict(props)
+    names = {n for n, _ in props}
+
+    assert as_dict["aisbom:format"] == "onnx"
+    assert as_dict["aisbom:onnx:ir_version"] == "9"
+    assert as_dict["aisbom:onnx:producer_name"] == "aisbom-mock"
+    assert as_dict["aisbom:onnx:graph_name"] == "mock_graph"
+    assert "ai.onnx:17" in as_dict["aisbom:onnx:opsets"]
+    assert as_dict["aisbom:onnx:custom_op_count"] == "1"
+    assert "com.example.ops.MyCustomOp" in as_dict["aisbom:onnx:custom_ops"]
+    assert as_dict["aisbom:onnx:external_data_count"] == "1"
+    assert as_dict["aisbom:onnx:external_data_location"] == "../out.bin"
+    assert "aisbom:onnx:threat" in names
+    assert as_dict["aisbom:risk"].startswith("CRITICAL")
+
+
+def test_onnx_appears_in_spdx_export(tmp_path):
+    from aisbom.spdx_gen import generate_spdx_sbom
+
+    create_mock_onnx(tmp_path / "m.onnx")
+    results = DeepScanner(str(tmp_path)).scan()
+
+    doc = json.loads(generate_spdx_sbom(results))
+    pkg = next(p for p in doc["packages"] if p["name"] == "m.onnx")
+    assert "Type: onnx" in pkg["comment"]
+    assert "Framework: ONNX" in pkg["comment"]
+
+
+# --- CLI ------------------------------------------------------------------
+
+def test_external_data_escape_exits_two(tmp_path, monkeypatch):
+    """A traversal path must trip the CI gate.
+
+    Asserts on output as well as the code, because Typer exits 2 on a usage
+    error too — the exit code alone could pass for the wrong reason.
+    """
+    from typer.testing import CliRunner
+    from aisbom.cli import app
+
+    monkeypatch.setenv("AISBOM_NO_TELEMETRY", "1")
+    create_mock_onnx(tmp_path / "evil.onnx", external_location="../../etc/passwd")
+    result = CliRunner().invoke(app, ["scan", str(tmp_path)])
+
+    assert "evil.onnx" in result.output, result.output
+    assert "CRITICAL" in result.output, result.output
+    assert result.exit_code == 2, result.output
+
+
+def test_custom_op_alone_does_not_trip_the_gate(tmp_path, monkeypatch):
+    """MEDIUM must not exit 2, or the signal becomes unusable in CI."""
+    from typer.testing import CliRunner
+    from aisbom.cli import app
+
+    monkeypatch.setenv("AISBOM_NO_TELEMETRY", "1")
+    create_mock_onnx(tmp_path / "custom.onnx", custom_op=True)
+    result = CliRunner().invoke(app, ["scan", str(tmp_path)])
+
+    assert "custom.onnx" in result.output, result.output
+    assert result.exit_code == 0, result.output
+
+
+# --- remote ---------------------------------------------------------------
+
+def test_remote_onnx_is_scanned(monkeypatch, tmp_path):
+    """Remote ONNX must be scanned, not silently skipped."""
+    import aisbom.remote as remote
+
+    content = create_mock_onnx(
+        tmp_path / "remote.onnx", external_location="../../escape.bin"
+    ).read_bytes()
+
+    def fake_get(url, headers=None):
+        rng = (headers or {}).get("Range", "bytes=0-0")
+        start, _, end = rng.split("=")[1].partition("-")
+        start = int(start)
+        end = int(end) if end else len(content) - 1
+        chunk = content[start:end + 1]
+
+        class Resp:
+            status_code = 206
+
+            def __init__(self):
+                self.content = chunk
+                self.headers = {
+                    "Content-Range": f"bytes {start}-{end}/{len(content)}",
+                    "Content-Length": str(len(chunk)),
+                }
+
+            def raise_for_status(self):
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    monkeypatch.setattr(
+        "aisbom.scanner.DeepScanner._resolve_remote_targets",
+        lambda self, target: ["http://example.com/remote.onnx"],
+    )
+
+    results = DeepScanner("http://example.com/remote.onnx").scan()
+    art = results["artifacts"][0]
+
+    assert results["errors"] == []
+    assert art["framework"] == "ONNX"
+    assert "CRITICAL" in art["risk_level"]
+    assert art["hash"] == "remote_unhashed"


### PR DESCRIPTION
Adds `.onnx` as a scanned format. An ONNX file is a bare serialized protobuf `ModelProto`, so it's walked as protobuf directly — **no ONNX runtime is imported, the graph is never executed**, and the shipped wheel and PyInstaller bundle gain no dependency.

## What the risk actually is

ONNX carries no pickle, so this isn't about a payload inside the file. It's about what *loading* the file makes a runtime reach for:

- **External data** — a tensor's bytes can live outside the model, addressed by a relative path. A path that climbs out of the model directory (or names an absolute path or a URL) is **CRITICAL**: loaders resolve and open that path, so loading the model becomes a read of a file the author chose. Paths that stay inside the directory are **MEDIUM** — the model isn't self-contained, and those bytes aren't covered by its hash.
- **Custom operators** — an operator outside the standard ONNX domains needs a matching custom op library registered at load time, a native-code dependency the consumer inherits. **MEDIUM**.

This severity split is deliberate and load-bearing: only an escape is CRITICAL, so **a custom operator alone does not fail CI**. There's a test asserting that, because a severity that always fails is not a signal.

The threat model was confirmed rather than assumed — while writing the cross-validation test, `onnx.load()` **eagerly opened the external-data location** and raised a `ValidationError` naming the file it tried to read. That's the reference implementation demonstrating the vulnerability.

## `protobuf_reader.py`

A small schema-less wire reader, **truncation-tolerant on purpose**. Models run to gigabytes while the graph sits at the head, so a scan reads a window (16MB local, 2MB remote) and a declared length that overruns the buffer yields the bytes actually held rather than raising. A scanner that gives up on a file it can't fully read is one that can be evaded by damaging the file.

Path judgement resolves relative segments by depth, so `a/../b` (which stays put) isn't reported while `../secrets` and `a/../../etc` are. It's textual by design — the point is to judge what the file *asks for* without touching what it's asking about.

## Cross-validation

Field numbers were confirmed against models serialized by the `onnx` library rather than read off the schema by eye. `onnx` is added as a **dev-only** dependency and used to validate **both** directions:

- the hand-written walk reads models the real library produced (metadata, custom op, external-data escape);
- the real library accepts models the hand-written generator produced.

Without the second direction the tests could be self-consistent and both wrong.

## Notes

- Registered in all four places a format needs: extension constant, both dispatch arms (local **and** remote — remote ONNX would otherwise be silently reported clean), `properties._FRAMEWORK_TO_FORMAT`, and an `aisbom:onnx:*` property block.
- Operator inventory, opsets and external-data entries are capped so a model with a million nodes can't turn one SBOM component into an unbounded document.
- `HIGH` is deliberately unused as a severity word: the CLI's exit-code mapping has no HIGH tier (it would score 0, below LOW) even though the risk table colours it red and `diff.py` ranks it above MEDIUM. Nothing emits HIGH today so nothing is broken; it's tracked separately rather than fixed here.
- Branches from `origin/main` and does not include the Keras work in the sibling PR, so the two conflict in `scanner.py` / `properties.py` / `safety.py`. Whichever merges second rebases.

## Verification

- `poetry run pytest --cov=aisbom --cov-fail-under=85` → **346 passed, 90.48% coverage** (before: 302 passed, 89.80%)
- `aisbom bypass-scorecard --check` → **gate passed, 5/11 unchanged** — no pickle-path behavior changed
- All CI smoke commands exit 0 (`generate-test-artifacts`, `info`, `scan demo_data`, `scan .`, `scan . --strict`, SPDX and CycloneDX export)
- Scanned end-to-end through the CLI: standard → LOW, custom-op → MEDIUM, contained external data → MEDIUM, traversal path → CRITICAL and exit 2

Test coverage spans: varint decoding and truncation, overrunning length prefixes, field-0 and bad wire types, random bytes, nine escaping path forms and five contained ones, standard/custom-op/external-data/traversal models, garbage and empty `.onnx` files, a forced-truncation read, both cross-validation directions, SPDX export, both CLI exit-code paths, and the remote path.
