### PR TITLE
feat(scanner): catch nullifAI-class container and broken-stream evasions (5/11 → 8/11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,13 @@ This rebuilds a corpus of publicly-documented pickle-evasion techniques — the 
 
 The results are published verbatim in [docs/bypass-scorecard.md](docs/bypass-scorecard.md), including the cases we currently **miss**. Static analysis is not magic, and a scanner that only advertises its wins isn't worth trusting; the misses are tracked as work in progress and the corpus is the regression gate that keeps them from silently coming back.
 
+Two principles come out of that corpus and shape how the pickle path behaves:
+
+- **A file that can't be parsed cleanly is still scanned.** Truncating a stream, corrupting a ZIP's CRC-32, or making a member's local-header filename disagree with the central directory are all evasions *because* the loaders that matter don't check, while scanners bail out. AIsbom disassembles from the front of the stream regardless, and reads a member straight from its local header when the archive refuses to open it properly.
+- **What a file contains decides its verdict, not what it looks like.** A protocol-0 pickle is printable ASCII, so classifying by shape let a bare pickle calling `os.system` pass as a text config file. Candidates are disassembled first and classified afterwards.
+
+One documented limit: a model repacked in a **non-standard container** (7z, rar, xz, zstd…) is reported CRITICAL and the container format is named, but the payload inside is *not* unpacked and therefore not itemized. Unpacking 7z would put a compression stack and its native dependencies into every install and every standalone binary; the container choice is treated as the finding instead. The scorecard shows this case as ⚠️ partial rather than claiming a detection it hasn't made.
+
 The corpus is synthesized, never copied from live malware — every artifact carries a harmless `echo` where real malware would carry a payload, and the harness proves it never executes what it scans. See [tests/corpus/README.md](tests/corpus/README.md).
 
 ---

--- a/aisbom/safety.py
+++ b/aisbom/safety.py
@@ -82,19 +82,37 @@ def _is_safe_import(module: str, name: str) -> bool:
 
     return False
 
-def scan_pickle_stream(data: bytes, strict_mode: bool = False) -> List[str]:
+# A legacy `torch.save` file is several pickles laid end to end, so a scan that
+# stops at the first STOP never reaches the object. Bounded so a hostile file
+# cannot turn "keep going" into an unbounded loop.
+MAX_CONCATENATED_STREAMS = 64
+
+
+def _record_global(threats: List[str], module, name, strict_mode: bool) -> None:
+    """Judge one resolved global and append a threat string if it is unsafe."""
+    if not module or not name:
+        return
+    if strict_mode:
+        if not _is_safe_import(module, name):
+            threats.append(f"UNSAFE_IMPORT: {module}.{name}")
+    elif module in DANGEROUS_GLOBALS and name in DANGEROUS_GLOBALS[module]:
+        threats.append(f"{module}.{name}")
+
+
+def _scan_single_stream(data: bytes, start: int, strict_mode: bool, threats: List[str]):
+    """Disassemble one pickle from ``start``; return the offset past its STOP.
+
+    Returns ``None`` when the stream ends without a STOP (truncated or not a
+    pickle at all), which is the signal to stop looking for another one. Any
+    threats found before that point are still recorded — a corrupt tail must not
+    discard what the front of the stream already revealed.
     """
-    Disassembles a pickle stream and checks for dangerous imports.
-    Returns a list of detected threats (e.g., ["os.system"]).
-    """
-    threats = []
-    memo = []  # Used to track recent string literals for STACK_GLOBAL
+    memo = []  # recent string literals, for STACK_GLOBAL
+    stream = io.BytesIO(data)
+    stream.seek(start)
 
     try:
-        stream = io.BytesIO(data)
-        
         for opcode, arg, pos in pickletools.genops(stream):
-            # Track the last few string literals we've seen on the stack
             if opcode.name in ("SHORT_BINUNICODE", "UNICODE", "BINUNICODE"):
                 memo.append(arg)
                 if len(memo) > 2:
@@ -103,37 +121,48 @@ def scan_pickle_stream(data: bytes, strict_mode: bool = False) -> List[str]:
             if opcode.name == "GLOBAL":
                 # Arg is "module\nname"
                 if isinstance(arg, str) and "\n" in arg:
-                    module, name = arg.split("\n")
+                    module, name = arg.split("\n", 1)
                 elif isinstance(arg, str) and " " in arg:
-                    # Some pickle protocols encode as "module name" (space-separated)
+                    # Some protocols encode as "module name" (space-separated)
                     module, name = arg.split(" ", 1)
                 else:
                     module, name = None, None
-
-                if module and name:
-                    if strict_mode:
-                        if not _is_safe_import(module, name):
-                            threats.append(f"UNSAFE_IMPORT: {module}.{name}")
-                    else:
-                        if module in DANGEROUS_GLOBALS and name in DANGEROUS_GLOBALS[module]:
-                            threats.append(f"{module}.{name}")
+                _record_global(threats, module, name, strict_mode)
 
             elif opcode.name == "STACK_GLOBAL":
-                # Takes two arguments from the stack: module and name
                 if len(memo) == 2:
-                    module, name = memo
-                    if strict_mode:
-                        if not _is_safe_import(module, name):
-                            threats.append(f"UNSAFE_IMPORT: {module}.{name}")
-                    else:
-                        if module in DANGEROUS_GLOBALS and name in DANGEROUS_GLOBALS[module]:
-                            threats.append(f"{module}.{name}")
+                    _record_global(threats, memo[0], memo[1], strict_mode)
                 # Clear memo after use to avoid false positives
                 memo.clear()
 
-    except Exception as e:
-        # Avoid crashing on malformed pickles
-        pass
+            elif opcode.name == "STOP":
+                # `pos` is an absolute offset into the buffer.
+                return pos + 1
+    except Exception:
+        # Malformed downstream; keep whatever was found before the break.
+        return None
+    return None
+
+
+def scan_pickle_stream(data: bytes, strict_mode: bool = False) -> List[str]:
+    """
+    Disassembles a pickle stream and checks for dangerous imports.
+    Returns a list of detected threats (e.g., ["os.system"]).
+
+    A file may hold several pickles end to end — this is exactly what
+    ``torch.save`` writes in its legacy (non-ZIP) format, where a magic number,
+    a protocol version and a sys-info dict all precede the object itself. Every
+    stream is scanned, because stopping at the first STOP would mean never
+    looking at the payload in such a file.
+    """
+    threats: List[str] = []
+    offset = 0
+
+    for _ in range(MAX_CONCATENATED_STREAMS):
+        next_offset = _scan_single_stream(data, offset, strict_mode, threats)
+        if next_offset is None or next_offset <= offset or next_offset >= len(data):
+            break
+        offset = next_offset
 
     return threats
 
@@ -617,3 +646,23 @@ def _threat_kind(threat: str) -> str:
 def jinja_analysis_is_incomplete(threats: List[str]) -> bool:
     """True if part of the template went unread, so 'no findings' is not 'clean'."""
     return any(_threat_kind(t).startswith("JINJA_TEMPLATE_TRUNCATED:") for t in threats)
+def looks_like_pickle_stream(data: bytes) -> bool:
+    """True if ``data`` disassembles cleanly through to a pickle STOP opcode.
+
+    Used to tell a legacy bare pickle apart from an ordinary text file, so the
+    two can be reported honestly rather than lumped together. Deliberately
+    strict — it requires reaching STOP — because a text file can begin with a
+    byte that happens to be a valid opcode, and calling a config file a pickle
+    is its own kind of wrong answer.
+
+    Disassembly only. The stream is never unpickled.
+    """
+    if not data:
+        return False
+    try:
+        for opcode, _arg, _pos in pickletools.genops(io.BytesIO(data)):
+            if opcode.name == "STOP":
+                return True
+    except Exception:
+        return False
+    return False

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -12,6 +12,7 @@ from aisbom import protobuf_reader as pb
 from aisbom.safety import (
     _threat_kind as _jinja_threat_kind,
     jinja_threats_are_critical,
+    looks_like_pickle_stream,
     onnx_domain_is_custom,
     scan_jinja_template,
     scan_keras_config,
@@ -153,6 +154,25 @@ GGUF_REMOTE_MAX_WINDOW = 16 * 1024 * 1024
 # Array contents are never retained — only the element type and count — but a
 # declared count still has to be sanity-bounded before it is trusted.
 GGUF_MAX_ARRAY_ELEMENTS = 50_000_000
+# How much of a bare (non-ZIP) candidate is disassembled. The same bound the
+# ZIP path already uses for its pickle member.
+PICKLE_MAX_SCAN_BYTES = 10 * 1024 * 1024
+
+# Container formats that are not PyTorch's ZIP. A model wearing a .pt extension
+# packed with one of these is the nullifAI shape: the alternative container kept
+# scanners from opening the file at all while the model still loaded. Repacking
+# a model in 7z is not something a normal toolchain does, so the container
+# itself is the signal — the payload inside stays compressed and unread.
+NONSTANDARD_CONTAINER_MAGICS = (
+    (b"7z\xbc\xaf\x27\x1c", "7z"),
+    (b"Rar!\x1a\x07", "rar"),
+    (b"\xfd7zXZ\x00", "xz"),
+    (b"\x28\xb5\x2f\xfd", "zstd"),
+    (b"BZh", "bzip2"),
+    (b"\x1f\x8b", "gzip"),
+    (b"\x04\x22\x4d\x18", "lz4"),
+    (b"\x89LZO", "lzo"),
+)
 
 # Simple blocklist for license keywords that imply legal risk in commercial software
 RESTRICTED_LICENSES = ["non-commercial", "cc-by-nc", "agpl", "commons clause"]
@@ -277,6 +297,96 @@ class DeepScanner:
                 return f"LEGAL RISK ({license_name})"
         return "PASS"
 
+    @staticmethod
+    def _identify_container(head: bytes) -> str | None:
+        """Name the archive format ``head`` begins with, if it is not ZIP."""
+        for magic, label in NONSTANDARD_CONTAINER_MAGICS:
+            if head.startswith(magic):
+                return label
+        return None
+
+    @staticmethod
+    def _looks_like_text(content: bytes) -> bool:
+        """True if the first kilobyte decodes as UTF-8 and is mostly printable."""
+        try:
+            text = content[:1024].decode("utf-8")
+        except (UnicodeDecodeError, AttributeError):
+            return False
+        if not text:
+            return False
+        printable = sum(ch.isprintable() for ch in text)
+        return printable / len(text) > 0.9
+
+    def _apply_lint(self, meta: Dict[str, Any], content: bytes) -> None:
+        """Run the migration linter over a pickle stream, if linting is on."""
+        if not self.lint:
+            return
+        try:
+            from aisbom.linter import MigrationLinter
+            lint_errors = MigrationLinter().lint_pickle(content)
+            if lint_errors:
+                meta["details"]["lint_report"] = [
+                    {"msg": e.message, "hint": e.hint, "severity": e.severity}
+                    for e in lint_errors
+                ]
+        except Exception as e:
+            meta["details"]["lint_error"] = str(e)
+
+    @staticmethod
+    def _raw_member_bytes(stream, info) -> bytes | None:
+        """Read a zip member from its local header, skipping every check.
+
+        Bypasses the CRC validation and the directory/header name agreement
+        that ``ZipFile.open`` enforces. Both are evasions precisely because the
+        loaders that matter do not enforce them — PyTorch reads these archives
+        with its own reader — so refusing to look at the bytes hides a payload
+        that would still run. STORED members are returned as-is; DEFLATED ones
+        are inflated as a raw stream, which needs no CRC and no trailer.
+        """
+        try:
+            stream.seek(info.header_offset)
+            header = stream.read(30)
+            if len(header) < 30 or header[:4] != b"PK\x03\x04":
+                return None
+            name_len = struct.unpack("<H", header[26:28])[0]
+            extra_len = struct.unpack("<H", header[28:30])[0]
+            stream.seek(info.header_offset + 30 + name_len + extra_len)
+
+            if info.compress_type == zipfile.ZIP_STORED:
+                size = info.compress_size or info.file_size
+                return stream.read(min(size or PICKLE_MAX_SCAN_BYTES, PICKLE_MAX_SCAN_BYTES))
+
+            if info.compress_type == zipfile.ZIP_DEFLATED:
+                # A tampered header can leave compress_size at zero, so read a
+                # bounded window and let the decompressor stop at the stream end.
+                raw = stream.read(min(info.compress_size or PICKLE_MAX_SCAN_BYTES,
+                                      PICKLE_MAX_SCAN_BYTES))
+                # -15 selects a raw deflate stream: no zlib wrapper, no checksum.
+                return zlib.decompressobj(-15).decompress(raw, PICKLE_MAX_SCAN_BYTES)
+        except Exception:
+            return None
+        return None
+
+    def _read_zip_member(self, z, member: str, stream):
+        """Return ``(bytes, note)`` for a zip member, working around corruption.
+
+        A member that will not open cleanly is not the end of the inquiry: the
+        bytes are read straight from the local header instead, so tampering
+        with a CRC or with a filename does not buy silence.
+        """
+        try:
+            with z.open(member) as f:
+                return f.read(PICKLE_MAX_SCAN_BYTES), None
+        except Exception as exc:
+            try:
+                info = z.getinfo(member)
+            except Exception:
+                return None, str(exc)
+            data = self._raw_member_bytes(stream, info)
+            if data:
+                return data, f"container integrity check failed, read raw member: {exc}"
+            return None, str(exc)
+
     def _inspect_pytorch(self, source, name: str | None = None, is_remote: bool = False) -> Dict[str, Any]:
         """Peeks inside PyTorch."""
         local_path = None
@@ -309,82 +419,68 @@ class DeepScanner:
                 with zipfile.ZipFile(stream, 'r') as z:
                     files = z.namelist()
                     pickle_files = [f for f in files if f.endswith('.pkl')]
-                    
+
                     threats = []
+                    content = None
                     if pickle_files:
                         main_pkl = pickle_files[0]
-                        with z.open(main_pkl) as f:
-                            content = f.read(10 * 1024 * 1024) 
+                        content, read_note = self._read_zip_member(z, main_pkl, stream)
+                        if read_note:
+                            meta["details"]["member_read"] = read_note
+                        if content is not None:
                             threats = scan_pickle_stream(content, strict_mode=self.strict_mode)
-                            
-                            # LINT CHECK (Migration Linter)
-                            if self.lint:
-                                from aisbom.linter import MigrationLinter
-                                linter = MigrationLinter()
-                                lint_errors = linter.lint_pickle(content)
-                                if lint_errors:
-                                    meta["details"]["lint_report"] = [
-                                        {"msg": e.message, "hint": e.hint, "severity": e.severity} 
-                                        for e in lint_errors
-                                    ]
+                            self._apply_lint(meta, content)
 
                     if threats:
                         meta["risk_level"] = f"CRITICAL (RCE Detected: {', '.join(threats)})"
+                    elif content is None and pickle_files:
+                        # The member is there but could not be read at all. A
+                        # loader that does not verify integrity the way we do
+                        # would still run it, so this is not a clean bill.
+                        meta["risk_level"] = "MEDIUM (Unreadable Pickle Member)"
                     elif pickle_files:
                         meta["risk_level"] = "MEDIUM (Pickle Present)"
                     else:
                         meta["risk_level"] = "LOW"
-                        
+
                     meta["details"].update({"internal_files": len(files), "threats": threats})
             else:
-                 # Handle text-based .pth config files to avoid false positives
-                 try:
-                     stream.seek(0)
-                     sample = stream.read(1024)
-                     if isinstance(sample, bytes):
-                         text = sample.decode("utf-8")
-                     else:
-                         text = str(sample)
-                     # Consider it text if mostly printable characters
-                     printable = sum(ch.isprintable() for ch in text)
-                     if len(text) > 0 and printable / len(text) > 0.9:
-                         meta["risk_level"] = "LOW"
-                         meta["type"] = "configuration"
-                         meta["framework"] = "Python Path Config"
-                     else:
-                         # Likely raw pickle (Legacy PyTorch 1.5-)
-                         if self.lint:
-                             stream.seek(0)
-                             content = stream.read()
-                             print(f"DEBUG: Linting {len(content)} bytes from {name}")
-                             try:
-                                 from aisbom.linter import MigrationLinter
-                                 lint_errors = MigrationLinter().lint_pickle(content)
-                                 print(f"DEBUG: Found {len(lint_errors)} errors")
-                                 if lint_errors:
-                                     meta["details"]["lint_report"] = [
-                                        {"msg": e.message, "hint": e.hint, "severity": e.severity} 
-                                        for e in lint_errors
-                                     ]
-                             except Exception as e:
-                                 print(f"DEBUG: Linter failed: {e}")
-                                 meta["details"]["lint_error"] = str(e)
-                         meta["risk_level"] = "CRITICAL (Legacy Binary)"
-                 except Exception:
-                     if self.lint:
-                         stream.seek(0)
-                         content = stream.read()
-                         try:
-                             from aisbom.linter import MigrationLinter
-                             lint_errors = MigrationLinter().lint_pickle(content)
-                             if lint_errors:
-                                 meta["details"]["lint_report"] = [
-                                    {"msg": e.message, "hint": e.hint, "severity": e.severity} 
-                                    for e in lint_errors
-                                 ]
-                         except Exception as e:
-                             meta["details"]["lint_error"] = str(e)
-                     meta["risk_level"] = "CRITICAL (Legacy Binary)"
+                stream.seek(0)
+                content = stream.read(PICKLE_MAX_SCAN_BYTES)
+                if not isinstance(content, bytes):
+                    content = bytes(content)
+
+                container = self._identify_container(content)
+                if container:
+                    # Deliberately not unpacked: doing so would put a 7z
+                    # implementation and its native dependencies into every
+                    # install and every standalone binary. The container choice
+                    # is itself the finding, and it is named rather than
+                    # reported as a generic unreadable blob.
+                    meta["details"]["container_format"] = container
+                    meta["details"]["threats"] = []
+                    meta["risk_level"] = (
+                        f"CRITICAL (Non-Standard Container: {container})"
+                    )
+                else:
+                    # Disassemble *before* deciding what the file is. Judging
+                    # by shape first is what let a printable protocol-0 pickle
+                    # pass as a text config file and be reported safe.
+                    threats = scan_pickle_stream(content, strict_mode=self.strict_mode)
+                    meta["details"]["threats"] = threats
+                    self._apply_lint(meta, content)
+
+                    if threats:
+                        meta["risk_level"] = f"CRITICAL (RCE Detected: {', '.join(threats)})"
+                    elif looks_like_pickle_stream(content):
+                        meta["risk_level"] = "MEDIUM (Pickle Present)"
+                    elif self._looks_like_text(content):
+                        meta["risk_level"] = "LOW"
+                        meta["type"] = "configuration"
+                        meta["framework"] = "Python Path Config"
+                    else:
+                        # Binary, not a parsable pickle, not a known container.
+                        meta["risk_level"] = "CRITICAL (Legacy Binary)"
         except Exception as e:
             meta["error"] = str(e)
         finally:

--- a/docs/bypass-scorecard.md
+++ b/docs/bypass-scorecard.md
@@ -7,7 +7,7 @@ past a model scanner, reproduced here as an inert artifact and scanned with
 AIsbom's own engine. Artifacts are synthesized, never copied from live malware,
 and are only ever disassembled — no pickle in this corpus is executed.
 
-**5 of 11** evasion cases are caught in at least one scan mode.
+**8 of 11** evasion cases are caught in at least one scan mode.
 
 `blocklist` is the default mode (flag known-dangerous globals); `strict` is
 `--strict` (allowlist — anything unrecognized is flagged). A ⚠️ partial means
@@ -22,10 +22,10 @@ reports the wrong reason.
 | `nullifai-broken-stream`<br>Deliberately broken pickle stream, payload first | broken-stream | ✅ detected | ✅ detected | [ReversingLabs — nullifAI (malicious models on Hugging Face)](https://www.reversinglabs.com/blog/rl-identifies-malware-ml-model-hosted-on-hugging-face) |
 | `cve-2025-1716-pip-main`<br>Code execution via pip.main() | unlisted-global | ⚠️ partial | ✅ detected | [Sonatype — CVE-2025-1716](https://www.sonatype.com/security-advisories/cve-2025-1716) |
 | `cve-2025-1889-nonstandard-extension`<br>Payload in a file with a non-standard extension | file-extension | ❌ missed | ❌ missed | [Sonatype — CVE-2025-1889](https://www.sonatype.com/security-advisories/cve-2025-1889) |
-| `cve-2025-1944-zip-filename-tamper`<br>ZIP local-header filename differs from the central directory | zip-tampering | ❌ missed | ❌ missed | [Sonatype — CVE-2025-1944](https://www.sonatype.com/security-advisories/cve-2025-1944) |
+| `cve-2025-1944-zip-filename-tamper`<br>ZIP local-header filename differs from the central directory | zip-tampering | ✅ detected | ✅ detected | [Sonatype — CVE-2025-1944](https://www.sonatype.com/security-advisories/cve-2025-1944) |
 | `cve-2025-1945-zip-flag-bits`<br>ZIP general-purpose flag bits modified | zip-tampering | ✅ detected | ✅ detected | [Sonatype — CVE-2025-1945](https://www.sonatype.com/security-advisories/cve-2025-1945) |
-| `cve-2025-10155-extension-confusion`<br>Bare pickle wearing a PyTorch extension | file-extension | ❌ missed | ❌ missed | [JFrog — CVE-2025-10155](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/) |
-| `cve-2025-10156-zip-crc`<br>Corrupted CRC-32 in the ZIP archive | zip-tampering | ❌ missed | ❌ missed | [JFrog — CVE-2025-10156](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/) |
+| `cve-2025-10155-extension-confusion`<br>Bare pickle wearing a PyTorch extension | file-extension | ✅ detected | ✅ detected | [JFrog — CVE-2025-10155](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/) |
+| `cve-2025-10156-zip-crc`<br>Corrupted CRC-32 in the ZIP archive | zip-tampering | ✅ detected | ✅ detected | [JFrog — CVE-2025-10156](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/) |
 | `cve-2025-10157-asyncio-subclass`<br>Dangerous import reached through an asyncio submodule | gadget-import | ⚠️ partial | ✅ detected | [JFrog — CVE-2025-10157](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/) |
 | `checkmarx-bdb-gadget`<br>Indirect execution via bdb.Bdb.run | gadget-import | ⚠️ partial | ✅ detected | [Checkmarx — Free Hugs: What to be Wary of in Hugging Face (Part 4)](https://checkmarx.com/blog/free-hugs-what-to-be-wary-of-in-hugging-face-part-4/) |
 | `shadowpickle-allowlist-overwrite`<br>Allowlisted builtin reached via STACK_GLOBAL | allowlist-abuse | ⚠️ partial | ⚠️ partial | [ShadowPickle (arXiv 2607.17503)](https://arxiv.org/html/2607.17503) |

--- a/tests/corpus/baseline.json
+++ b/tests/corpus/baseline.json
@@ -13,12 +13,12 @@
       "strict": "detected"
     },
     "cve-2025-10155-extension-confusion": {
-      "blocklist": "missed",
-      "strict": "missed"
+      "blocklist": "detected",
+      "strict": "detected"
     },
     "cve-2025-10156-zip-crc": {
-      "blocklist": "missed",
-      "strict": "missed"
+      "blocklist": "detected",
+      "strict": "detected"
     },
     "cve-2025-10157-asyncio-subclass": {
       "blocklist": "partial",
@@ -33,8 +33,8 @@
       "strict": "missed"
     },
     "cve-2025-1944-zip-filename-tamper": {
-      "blocklist": "missed",
-      "strict": "missed"
+      "blocklist": "detected",
+      "strict": "detected"
     },
     "cve-2025-1945-zip-flag-bits": {
       "blocklist": "detected",

--- a/tests/corpus/floor.json
+++ b/tests/corpus/floor.json
@@ -13,12 +13,12 @@
       "strict": "detected"
     },
     "cve-2025-10155-extension-confusion": {
-      "blocklist": "missed",
-      "strict": "missed"
+      "blocklist": "detected",
+      "strict": "detected"
     },
     "cve-2025-10156-zip-crc": {
-      "blocklist": "missed",
-      "strict": "missed"
+      "blocklist": "detected",
+      "strict": "detected"
     },
     "cve-2025-10157-asyncio-subclass": {
       "blocklist": "partial",
@@ -33,8 +33,8 @@
       "strict": "missed"
     },
     "cve-2025-1944-zip-filename-tamper": {
-      "blocklist": "missed",
-      "strict": "missed"
+      "blocklist": "detected",
+      "strict": "detected"
     },
     "cve-2025-1945-zip-flag-bits": {
       "blocklist": "detected",

--- a/tests/test_nullifai.py
+++ b/tests/test_nullifai.py
@@ -1,0 +1,385 @@
+"""nullifAI-class evasions: alternative containers, broken streams, tampered zips.
+
+The family this covers has one shape in common: make the file *look* unreadable
+to a scanner while leaving it perfectly loadable by the thing that matters. A
+scanner that declines to examine what it cannot cleanly parse is the whole
+attack, so the tests below are as much about what the scanner refuses to skip
+as about what it detects.
+
+Nothing here is ever unpickled. The payloads are opcode-assembled streams that
+name a dangerous global and carry an inert echo as their argument; they are
+disassembled with pickletools and never executed.
+"""
+
+import io
+import struct
+import zipfile
+
+import pytest
+
+from aisbom.mock_generator import (
+    HARMLESS_COMMAND,
+    harmless_reduce_pickle,
+    harmless_stack_global_pickle,
+)
+from aisbom.safety import looks_like_pickle_stream, scan_pickle_stream
+from aisbom.scanner import DeepScanner
+
+
+def pytorch_zip(payload: bytes, compression=zipfile.ZIP_DEFLATED, member="archive/data.pkl") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression) as z:
+        z.writestr(member, payload)
+        z.writestr("archive/version", "3")
+    return buf.getvalue()
+
+
+# --- the printable-protocol-0 bypass -------------------------------------
+
+@pytest.mark.parametrize("filename", ["model.bin", "model.pt", "model.pth"])
+def test_bare_printable_pickle_is_not_mistaken_for_a_text_config(tmp_path, filename):
+    """The green-check-on-a-live-threat case.
+
+    A protocol-0 pickle is printable ASCII, and classifying by shape meant a
+    bare pickle naming os.system was reported as a Python path-config file at
+    LOW risk. Protocol 0 costs an attacker nothing to choose.
+    """
+    (tmp_path / filename).write_bytes(harmless_reduce_pickle("os", "system"))
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "os.system" in art["risk_level"]
+    assert art["framework"] == "PyTorch"
+    assert art["details"]["threats"] == ["os.system"]
+
+
+def test_bare_printable_pickle_is_caught_in_strict_mode_too(tmp_path):
+    (tmp_path / "model.bin").write_bytes(harmless_reduce_pickle("os", "system"))
+    art = DeepScanner(str(tmp_path), strict_mode=True).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "UNSAFE_IMPORT" in art["risk_level"]
+
+
+def test_stack_global_variant_is_caught_bare_too(tmp_path):
+    """Protocol 4 / STACK_GLOBAL, outside a ZIP container."""
+    (tmp_path / "model.pt").write_bytes(harmless_stack_global_pickle("os", "system"))
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "os.system" in art["risk_level"]
+
+
+def test_genuine_text_path_config_is_still_low(tmp_path):
+    """The false-positive guard the printable heuristic existed to provide."""
+    (tmp_path / "site-packages.pth").write_text(
+        "/usr/local/lib/python3.11/site-packages\nimport sys\n"
+    )
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["risk_level"] == "LOW"
+    assert art["framework"] == "Python Path Config"
+
+
+def test_benign_bare_pickle_is_medium_not_critical(tmp_path):
+    """A well-formed pickle with no dangerous global is not an incident.
+
+    This used to be CRITICAL (Legacy Binary) purely because the bytes were not
+    printable — a verdict about the file's shape, not its contents.
+    """
+    import pickle
+    (tmp_path / "model.pt").write_bytes(pickle.dumps({"weights": [1, 2, 3]}, protocol=2))
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["risk_level"] == "MEDIUM (Pickle Present)"
+
+
+def test_unparsable_binary_is_still_critical(tmp_path):
+    """Bytes that are neither text, nor a pickle, nor a known container."""
+    (tmp_path / "model.pt").write_bytes(bytes(range(256)) * 4)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["risk_level"] == "CRITICAL (Legacy Binary)"
+
+
+# --- non-standard containers ---------------------------------------------
+
+@pytest.mark.parametrize("magic,label", [
+    (b"7z\xbc\xaf\x27\x1c", "7z"),
+    (b"Rar!\x1a\x07\x00", "rar"),
+    (b"\xfd7zXZ\x00\x00", "xz"),
+    (b"\x28\xb5\x2f\xfd\x00\x00", "zstd"),
+    (b"BZh9", "bzip2"),
+    (b"\x1f\x8b\x08\x00", "gzip"),
+])
+def test_nonstandard_containers_are_named(tmp_path, magic, label):
+    """PyTorch's container is ZIP; anything else is the finding itself."""
+    (tmp_path / "model.pt").write_bytes(magic + b"\x00" * 128)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert label in art["risk_level"]
+    assert art["details"]["container_format"] == label
+
+
+def test_seven_zip_container_reports_its_format_not_a_generic_blob(tmp_path):
+    """A real 7z archive, built with the same library the corpus uses."""
+    py7zr = pytest.importorskip("py7zr", reason="py7zr is a dev-only dependency")
+
+    inner = tmp_path / "payload.pkl"
+    inner.write_bytes(harmless_reduce_pickle("os", "system"))
+    archive_path = tmp_path / "model.pt"
+    with py7zr.SevenZipFile(archive_path, "w") as archive:
+        archive.write(inner, "archive/data.pkl")
+    inner.unlink()
+
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["details"]["container_format"] == "7z"
+    assert "Non-Standard Container" in art["risk_level"]
+    assert "CRITICAL" in art["risk_level"]
+    # Deliberately not unpacked, so the payload is not named. Stating this
+    # keeps the limit visible instead of letting it look like full detection.
+    assert art["details"]["threats"] == []
+
+
+def test_a_normal_zip_is_not_reported_as_a_nonstandard_container(tmp_path):
+    (tmp_path / "model.pt").write_bytes(pytorch_zip(harmless_reduce_pickle("os", "system")))
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "container_format" not in art["details"]
+    assert "os.system" in art["risk_level"]
+
+
+# --- broken and truncated streams ----------------------------------------
+
+def test_truncated_stream_still_reports_the_payload_at_its_front():
+    """The pickle VM runs sequentially, so a corrupt tail does not save you."""
+    full = harmless_reduce_pickle("os", "system")
+    assert scan_pickle_stream(full[: len(full) // 2]) == ["os.system"]
+
+
+def test_trailing_garbage_does_not_suppress_the_payload():
+    payload = harmless_reduce_pickle("os", "system") + b"\xff\xff\xff\xff junk"
+    assert scan_pickle_stream(payload) == ["os.system"]
+
+
+def test_truncated_stream_inside_a_zip_is_critical(tmp_path):
+    full = harmless_reduce_pickle("os", "system")
+    (tmp_path / "model.pt").write_bytes(pytorch_zip(full[: len(full) // 2]))
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "os.system" in art["details"]["threats"]
+
+
+def test_truncated_bare_stream_is_critical(tmp_path):
+    full = harmless_reduce_pickle("os", "system")
+    (tmp_path / "model.pt").write_bytes(full[: len(full) // 2])
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "os.system" in art["risk_level"]
+
+
+# --- zip tampering --------------------------------------------------------
+
+def _corrupt_central_crc(blob: bytes) -> bytes:
+    """Wreck the CRC of the *first* central-directory entry (the pickle).
+
+    `find`, not `rfind`: the archive holds `archive/data.pkl` followed by
+    `archive/version`, and corrupting the latter proves nothing.
+    """
+    idx = blob.find(b"PK\x01\x02")
+    assert idx != -1
+    out = bytearray(blob)
+    out[idx + 16:idx + 20] = b"\xde\xad\xbe\xef"
+    return bytes(out)
+
+
+def _rename_local_header(blob: bytes, old: str, new: str) -> bytes:
+    assert len(old) == len(new)
+    idx = blob.find(b"PK\x03\x04")
+    assert idx != -1
+    return blob.replace(old.encode(), new.encode(), 1)
+
+
+@pytest.mark.parametrize("compression", [zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED])
+def test_corrupt_crc_does_not_hide_the_payload(tmp_path, compression):
+    """Loaders that skip CRC validation still run it, so we still read it."""
+    blob = pytorch_zip(harmless_reduce_pickle("os", "system"), compression)
+    (tmp_path / "model.pt").write_bytes(_corrupt_central_crc(blob))
+
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "os.system" in art["details"]["threats"]
+    assert "integrity check failed" in art["details"]["member_read"]
+
+
+def test_tampered_member_filename_does_not_hide_the_payload(tmp_path):
+    """Directory and local-header names disagreeing is not a reason to stop."""
+    blob = pytorch_zip(harmless_reduce_pickle("os", "system"))
+    (tmp_path / "model.pt").write_bytes(
+        _rename_local_header(blob, "archive/data.pkl", "archive/data_pkl")
+    )
+
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "os.system" in art["details"]["threats"]
+
+
+def test_a_genuinely_unreadable_member_is_flagged_not_called_clean(tmp_path):
+    """When the bytes really cannot be recovered, say so rather than pass it."""
+    blob = bytearray(pytorch_zip(harmless_reduce_pickle("os", "system")))
+    # Wreck the deflate payload itself, not just its checksum.
+    start = blob.find(b"PK\x03\x04")
+    blob[start + 40:start + 60] = b"\x00" * 20
+    (tmp_path / "model.pt").write_bytes(bytes(blob))
+
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+    assert art["risk_level"] != "LOW"
+
+
+# --- concatenated streams (legacy torch.save layout) ---------------------
+
+def legacy_torch_bytes(object_pickle: bytes) -> bytes:
+    """The layout `torch.save(..., _use_new_zipfile_serialization=False)` writes.
+
+    A magic number, a protocol version and a sys-info dict are each pickled
+    before the object itself, so the payload sits in the *fourth* stream.
+    """
+    import pickle
+    return (
+        pickle.dumps(0x1950A86A20F9469CFC6C, protocol=2)
+        + pickle.dumps(1001, protocol=2)
+        + pickle.dumps(
+            {"protocol_version": 1001, "little_endian": True, "type_sizes": {}},
+            protocol=2,
+        )
+        + object_pickle
+    )
+
+
+def test_payload_in_a_later_concatenated_stream_is_found():
+    """Disassembly must not stop at the first STOP.
+
+    A scan that reads only the first pickle sees the magic number and nothing
+    else, so a legacy checkpoint whose object calls os.system reads as clean.
+    """
+    blob = legacy_torch_bytes(harmless_reduce_pickle("os", "system"))
+    assert scan_pickle_stream(blob) == ["os.system"]
+    assert scan_pickle_stream(blob, strict_mode=True) == ["UNSAFE_IMPORT: os.system"]
+
+
+def test_legacy_torch_layout_is_critical_end_to_end(tmp_path):
+    (tmp_path / "legacy.pt").write_bytes(
+        legacy_torch_bytes(harmless_reduce_pickle("os", "system"))
+    )
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "os.system" in art["risk_level"]
+
+
+def test_benign_legacy_torch_layout_stays_medium(tmp_path):
+    """The multi-stream walk must not manufacture threats from header pickles."""
+    import pickle
+    (tmp_path / "legacy.pt").write_bytes(
+        legacy_torch_bytes(pickle.dumps({"w": [1, 2, 3]}, protocol=2))
+    )
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["risk_level"] == "MEDIUM (Pickle Present)"
+
+
+def test_payload_in_the_last_of_many_streams_is_found():
+    import pickle
+    blob = b"".join(pickle.dumps({"i": i}, protocol=2) for i in range(20))
+    blob += harmless_reduce_pickle("subprocess", "Popen")
+    assert scan_pickle_stream(blob) == ["subprocess.Popen"]
+
+
+def test_concatenated_scan_is_bounded():
+    """A file of many tiny pickles must not be walked without limit."""
+    import pickle
+    from aisbom.safety import MAX_CONCATENATED_STREAMS
+
+    blob = pickle.dumps(1, protocol=2) * (MAX_CONCATENATED_STREAMS + 200)
+    blob += harmless_reduce_pickle("os", "system")
+    # Past the bound the tail is not reached; the point is that it terminates.
+    scan_pickle_stream(blob)
+
+
+def test_trailing_garbage_after_a_complete_stream_does_not_crash():
+    blob = harmless_reduce_pickle("os", "system") + b"\x00\xff\x00trailing"
+    assert scan_pickle_stream(blob) == ["os.system"]
+
+
+# --- looks_like_pickle_stream --------------------------------------------
+
+def test_looks_like_pickle_stream_requires_reaching_stop():
+    assert looks_like_pickle_stream(harmless_reduce_pickle("os", "system")) is True
+    # Truncated: parses opcodes but never reaches STOP.
+    full = harmless_reduce_pickle("os", "system")
+    assert looks_like_pickle_stream(full[: len(full) // 2]) is False
+    assert looks_like_pickle_stream(b"") is False
+    assert looks_like_pickle_stream(b"/usr/local/lib/site-packages") is False
+    assert looks_like_pickle_stream(bytes(range(256))) is False
+
+
+# --- the payload never runs ----------------------------------------------
+
+def test_scanning_never_unpickles(tmp_path, monkeypatch):
+    """A scan of a hostile file must not call into pickle's loader at all."""
+    import pickle as pickle_module
+
+    def explode(*args, **kwargs):
+        raise AssertionError("the scanner must never unpickle its input")
+
+    monkeypatch.setattr(pickle_module, "loads", explode)
+    monkeypatch.setattr(pickle_module, "load", explode)
+
+    (tmp_path / "bare.pt").write_bytes(harmless_reduce_pickle("os", "system"))
+    (tmp_path / "zipped.pth").write_bytes(pytorch_zip(harmless_reduce_pickle("os", "system")))
+    (tmp_path / "seven.bin").write_bytes(b"7z\xbc\xaf\x27\x1c" + b"\x00" * 64)
+
+    results = DeepScanner(str(tmp_path)).scan()
+    assert len(results["artifacts"]) == 3
+    assert any("os.system" in a["risk_level"] for a in results["artifacts"])
+
+
+def test_payload_command_is_inert():
+    """The corpus payload is an echo, not an exploit."""
+    assert "echo" in HARMLESS_COMMAND
+    assert "no payload executed" in HARMLESS_COMMAND
+
+
+# --- CLI ------------------------------------------------------------------
+
+def test_bare_pickle_payload_exits_two(tmp_path, monkeypatch):
+    from typer.testing import CliRunner
+    from aisbom.cli import app
+
+    monkeypatch.setenv("AISBOM_NO_TELEMETRY", "1")
+    (tmp_path / "model.bin").write_bytes(harmless_reduce_pickle("os", "system"))
+    result = CliRunner().invoke(app, ["scan", str(tmp_path)])
+
+    assert "model.bin" in result.output, result.output
+    assert "CRITICAL" in result.output, result.output
+    assert result.exit_code == 2, result.output
+
+
+def test_benign_bare_pickle_does_not_exit_two(tmp_path, monkeypatch):
+    """MEDIUM must not fail CI."""
+    import pickle
+    from typer.testing import CliRunner
+    from aisbom.cli import app
+
+    monkeypatch.setenv("AISBOM_NO_TELEMETRY", "1")
+    (tmp_path / "model.pt").write_bytes(pickle.dumps({"w": [1]}, protocol=2))
+    result = CliRunner().invoke(app, ["scan", str(tmp_path)])
+
+    assert "model.pt" in result.output, result.output
+    assert result.exit_code == 0, result.output

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -7,20 +7,33 @@ class Unsafe:
     pass
 
 def test_scanner_legacy_binary_lint(tmp_path):
-    # Create a dummy .pt file that is NOT a zip (legacy binary)
-    # And contains an unsafe import to trigger linter
+    # A bare (non-ZIP) .pt holding a benign protocol-0 pickle. `Unsafe` is an
+    # empty class — the name is historical; nothing here is dangerous.
     f = tmp_path / "legacy.pt"
-    # Protocol 0 usually ensures it's not detected as zip/text
-    # We use Unsafe class to verify linter actually ran in that block
     f.write_bytes(pickle.dumps(Unsafe(), protocol=0))
-    
+
     scanner = DeepScanner(str(tmp_path), lint=True)
     results = scanner.scan()
-    
+
     artifact = results['artifacts'][0]
-    assert artifact['risk_level'] == "CRITICAL (Legacy Binary)"
+    # This used to report CRITICAL (Legacy Binary), which was a false positive:
+    # the verdict came from the bytes not looking like text, not from anything
+    # found in them. The stream is now disassembled first, so a well-formed
+    # pickle with no dangerous global gets the same verdict the ZIP path gives
+    # the same content. `--strict` still escalates an unrecognized import here.
+    assert artifact['risk_level'] == "MEDIUM (Pickle Present)"
     assert "lint_report" in artifact['details']
     assert any("Unsafe" in e['msg'] for e in artifact['details']['lint_report'])
+
+
+def test_bare_legacy_pickle_with_unknown_global_is_critical_in_strict_mode(tmp_path):
+    """The strict-mode safety net over the MEDIUM verdict above."""
+    f = tmp_path / "legacy.pt"
+    f.write_bytes(pickle.dumps(Unsafe(), protocol=0))
+
+    artifact = DeepScanner(str(tmp_path), strict_mode=True).scan()['artifacts'][0]
+    assert "CRITICAL" in artifact['risk_level']
+    assert "UNSAFE_IMPORT" in artifact['risk_level']
 
 def test_scanner_safetensors_coverage(tmp_path):
     # Minimal safetensors header to hit _inspect_safetensors lines


### PR DESCRIPTION
Catches the nullifAI evasion family: alternative containers, broken streams, and tampered ZIPs.

## The scorecard moves 5/11 → 8/11

Three cases flip **missed → detected in both modes**, and the whole `zip-tampering` class is now covered:

| Case | Before | After |
|---|---|---|
| `cve-2025-10155-extension-confusion` | ❌ / ❌ | ✅ / ✅ |
| `cve-2025-10156-zip-crc` | ❌ / ❌ | ✅ / ✅ |
| `cve-2025-1944-zip-filename-tamper` | ❌ / ❌ | ✅ / ✅ |

`floor.json` rose on exactly those three. **Nothing was lowered.**

## Two principles do the work

**A file that can't be parsed cleanly is still scanned.** Truncating a stream, corrupting a CRC-32, and making a member's local-header filename disagree with the central directory are evasions *precisely because* the loaders that matter don't check, while scanners bail out. A member that won't open is now read straight from its local header — STORED as-is, DEFLATED via raw inflate (`wbits=-15`, which needs neither CRC nor trailer).

**What a file contains decides its verdict, not what it looks like.** A protocol-0 pickle is printable ASCII, so classifying by shape let a bare pickle calling `os.system` be reported as a Python path-config file at LOW risk:

```
model.bin  -> framework=Python Path Config   risk=LOW
model.pt   -> framework=Python Path Config   risk=LOW
model.pth  -> framework=Python Path Config   risk=LOW
model.bin  -> STRICT mode                    risk=LOW
```

A green check on a live payload, on every model extension and in strict mode too — and protocol 0 costs an attacker nothing to choose. Candidates are now disassembled **first** and classified afterwards. The false-positive guard that heuristic existed to provide is kept: a genuine text path-config still reports LOW, with a test.

## Non-standard containers: named, not unpacked

7z, rar, xz, zstd, bzip2, gzip, lz4 and lzo are now identified by magic, so a 7z-wrapped model reports `CRITICAL (Non-Standard Container: 7z)` instead of the misleading `CRITICAL (Legacy Binary)` with empty details.

They are **deliberately not unpacked**. Doing so would put a compression stack and its native dependencies into every install and every standalone binary. The container choice is itself the finding — repacking a model in 7z is not something a normal toolchain does. The scorecard continues to show that case as ⚠️ `partial` rather than claiming a detection that was never made, and the README documents the limit.

## One user-visible severity change

A well-formed bare pickle with **no** dangerous global now reports `MEDIUM (Pickle Present)` instead of `CRITICAL (Legacy Binary)`, so it no longer exits 2.

The old verdict was a false positive: it came from the bytes not looking like text, not from anything found in them. MEDIUM is what the ZIP path already reported for identical content, so this makes the two consistent. `--strict` still escalates an unrecognized import in the same file to CRITICAL, and bytes that are neither text, nor a parsable pickle, nor a known container remain CRITICAL. An existing test asserted the old label; it's updated with the reasoning rather than worked around.

## The ratchet, re-proven

Because the corpus is only worth anything if it can't be regenerated around, the break was reproduced end to end:

1. Reverted the disassemble-first ordering.
2. `bypass-scorecard --check` exited non-zero, naming `cve-2025-10155-extension-confusion` in **both** modes.
3. `bypass-scorecard --write` then left `floor.json` **byte-identical** — the regression could not be laundered by regeneration.
4. Break restored; gate green.

## Notes

- Also removes three `DEBUG` `print` statements that were writing to users' terminals from the lint path.
- Still missed: `cve-2025-1889-nonstandard-extension` (payload in `config.p` — extension-driven *discovery*, a separate fix) and `shadowpickle-allowlist-overwrite` (allowlist abuse).
- Nothing in this corpus is ever unpickled. There's a test that monkeypatches `pickle.load`/`pickle.loads` to raise, and scans hostile files with it in place.
- Branches from `origin/main` alongside the other open format PRs, so they conflict in `scanner.py` / `safety.py`. Whichever merges last rebases.

## Verification

- `poetry run pytest --cov=aisbom --cov-fail-under=85` → **332 passed, 90.58% coverage** (before: 302, 89.80%)
- `aisbom bypass-scorecard --check` → **gate passed at 8/11**
- All CI smoke commands exit 0, including `scan mock_broken.pt --lint`
- End-to-end through the CLI: 7z container → named CRITICAL; bare printable pickle → CRITICAL naming `os.system`; truncated stream → CRITICAL; tampered CRC → CRITICAL; benign model → MEDIUM (exit 0); genuine `.pth` → LOW

Test coverage spans: the printable-protocol-0 bypass on three extensions plus strict mode, STACK_GLOBAL bare, six container magics, a real py7zr archive, truncated streams bare and zipped, corrupt CRC in both compression methods, tampered local-header filenames, a genuinely unrecoverable member, `looks_like_pickle_stream` boundaries, the never-unpickle guarantee, and both CLI exit-code paths.
