### PR TITLE
feat(safety): detect indirect-execution gadget imports in both modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,10 +324,23 @@ AI models aren't just text files — they're executable programs and IP assets.
 
 AIsbom uses a static analysis engine to disassemble Python Pickle opcodes. It looks for specific `GLOBAL` and `STACK_GLOBAL` instructions referencing dangerous modules:
 
-- `os` / `posix` (system calls)
+- `os` / `posix` / `nt` (system calls)
 - `subprocess` (shell execution)
-- `builtins.eval` / `exec` (dynamic code execution)
+- `builtins.eval` / `exec` / `__import__` (dynamic code execution)
 - `socket` (network reverse shells)
+
+It also covers **indirect-execution gadgets** — the "benign-looking module, dangerous method" pairs that reach the same sinks without naming them:
+
+- `bdb` / `pdb` — a debugger's `run`, `runeval` and `runcall` compile and execute a supplied string
+- `asyncio` — subprocess transports and event-loop run methods
+- `pip.main`, `runpy`, `importlib`, `imp` — installing or importing as a way to execute
+- `pty`, `platform.popen`, `multiprocessing`, `ctypes` — process spawning and native library loading
+- `code` / `codeop` / `timeit` / `cProfile` — helpers that take code as a string
+- `operator.methodcaller` — reaches a sink without ever naming it as a global
+
+Two rules generalize the list, so the *next* gadget doesn't need to be enumerated first: a dangerous package governs its submodules (an unlisted `asyncio.*` module is still judged as `asyncio`), and an execution-shaped attribute name (`.run`, `.system`, `.popen`, `.import_module`) is flagged whatever module it arrives through — including on otherwise-trusted packages.
+
+Attribute names are matched **exactly, never as substrings**, so ordinary globals like `torch.storage._load_from_bytes` are untouched. Every entry above was checked against the globals a genuine checkpoint carries (`torch._utils._rebuild_tensor_v2`, `collections.OrderedDict`, `numpy.core.multiarray._reconstruct`, …) — a scanner that flags real models is one people switch off, which is a worse outcome than a missed case.
 
 SafeTensors and GGUF use binary formats with structured headers — AIsbom parses these headers directly to extract metadata (artifact names, license info, architecture details) without loading tensor weights.
 

--- a/aisbom/safety.py
+++ b/aisbom/safety.py
@@ -8,13 +8,124 @@ from typing import Any, Dict, List, Set, Tuple
 
 # The "Blocklist" of dangerous modules and functions
 # If a model tries to import these, it is trying to break out of the sandbox.
+#
+# The entries below the original six close the *indirect* paths: reaching an
+# executable sink through a module nobody thinks to blocklist. A debugger's
+# `run`, an event loop's subprocess transport and a package installer's entry
+# point all execute attacker-chosen code just as surely as `os.system` does,
+# and each has been used in a published picklescan bypass.
+#
+# Every addition was checked against the globals a genuine checkpoint carries —
+# `torch._utils._rebuild_tensor_v2`, `torch.FloatStorage`,
+# `torch.storage._load_from_bytes`, `collections.OrderedDict`,
+# `numpy.core.multiarray._reconstruct`, `numpy.dtype`, `numpy.ndarray`,
+# `builtins.complex` — because a scanner that flags ordinary models is a
+# scanner people switch off, and that is a worse outcome than a missed case.
 DANGEROUS_GLOBALS = {
-    "os": {"system", "popen", "execl", "execvp"},
-    "subprocess": {"Popen", "call", "check_call", "check_output", "run"},
-    "builtins": {"eval", "exec", "compile", "open"},
-    "posix": {"system", "popen"},
-    "webbrowser": {"open"},
-    "socket": {"socket", "connect"},
+    "os": {"system", "popen", "execl", "execvp", "execv", "execve", "spawnl", "spawnv"},
+    "subprocess": {"Popen", "call", "check_call", "check_output", "run", "getoutput", "getstatusoutput"},
+    "builtins": {"eval", "exec", "compile", "open", "__import__", "breakpoint", "input"},
+    "posix": {"system", "popen", "execv", "spawnv"},
+    "nt": {"system", "popen", "execv", "spawnv"},
+    "webbrowser": {"open", "open_new", "open_new_tab", "get"},
+    "socket": {"socket", "connect", "create_connection"},
+
+    # Debugger gadgets. `Bdb.run` and friends compile and execute a string;
+    # the debugger module itself is the "benign-looking" part.
+    "bdb": {"Bdb", "run", "runeval", "runcall", "runctx"},
+    "pdb": {"Pdb", "run", "runeval", "runcall", "set_trace", "post_mortem"},
+
+    # Event-loop gadgets: the subprocess transports spawn a process, and the
+    # loop's own run methods execute a supplied coroutine.
+    "asyncio": {
+        "create_subprocess_shell", "create_subprocess_exec", "run",
+        "get_event_loop", "new_event_loop", "SelectorEventLoop",
+    },
+    "asyncio.unix_events": {
+        "_UnixSubprocessTransport", "_UnixDefaultEventLoopPolicy", "SelectorEventLoop",
+    },
+    "asyncio.base_events": {"BaseEventLoop"},
+    "asyncio.base_subprocess": {"BaseSubprocessTransport"},
+    "asyncio.subprocess": {"create_subprocess_shell", "create_subprocess_exec"},
+    "asyncio.events": {"get_event_loop", "new_event_loop"},
+
+    # Package installation as code execution.
+    "pip": {"main"},
+    "pip._internal": {"main"},
+    "pip._internal.cli.main": {"main"},
+    "setuptools": {"setup"},
+
+    # Terminal / process spawning.
+    "pty": {"spawn", "fork", "openpty"},
+    "platform": {"popen", "_syscmd_ver"},
+    "multiprocessing": {"Process", "Pool"},
+
+    # Import-mechanism abuse — the primitive a shadowing attack needs before it
+    # can make an allowlisted name resolve somewhere else.
+    "importlib": {"import_module", "reload", "__import__"},
+    "importlib.util": {"spec_from_file_location", "module_from_spec"},
+    "importlib.machinery": {"SourceFileLoader", "ExtensionFileLoader"},
+    "imp": {"load_source", "load_module", "load_dynamic", "load_compiled"},
+    "runpy": {"run_path", "run_module", "_run_code", "_run_module_code"},
+    "pkgutil": {"get_loader", "find_loader"},
+    "sys": {"modules", "settrace", "setprofile", "_getframe", "exit"},
+
+    # Interactive interpretation and timing helpers that take code as a string.
+    "code": {"interact", "InteractiveInterpreter", "InteractiveConsole", "compile_command"},
+    "codeop": {"compile_command", "Compile", "CommandCompiler"},
+    "timeit": {"timeit", "repeat", "Timer"},
+    "cProfile": {"run", "runctx", "Profile"},
+    "profile": {"run", "runctx", "Profile"},
+
+    # Native code loading.
+    "ctypes": {"CDLL", "cdll", "WinDLL", "windll", "PyDLL", "LibraryLoader", "CFUNCTYPE"},
+
+}
+
+# Callable-construction helpers that are genuinely dual-use. `methodcaller` and
+# `attrgetter` build a callable from a *name given as a string*, so
+# `methodcaller("system")` reaches a sink without ever naming it as a global —
+# but `attrgetter("name")` is an ordinary helper that real code serializes.
+#
+# Listing them unconditionally would flag every checkpoint that stores one, so
+# the argument decides: these are reported only when the name they fetch is
+# itself an execution sink or an introspection primitive. `functools.reduce` is
+# deliberately absent — the dangerous callable it is handed appears as its own
+# global and is caught on its own merits.
+DUAL_USE_CONSTRUCTORS = {
+    ("operator", "methodcaller"),
+    ("operator", "attrgetter"),
+    ("_operator", "methodcaller"),
+    ("_operator", "attrgetter"),
+}
+
+# Introspection primitives that make an attribute fetch an escape chain.
+_ESCAPE_ATTRIBUTE_NAMES = {
+    "__class__", "__bases__", "__base__", "__mro__", "__subclasses__",
+    "__globals__", "__builtins__", "__import__", "__init__", "__code__",
+    "__reduce__", "__getattribute__", "__dict__", "__func__", "__self__",
+    "__module__", "__loader__", "__spec__",
+}
+
+# Modules whose *whole family* is dangerous: a dotted submodule inherits the
+# parent's entry, so `asyncio.unix_events.X` is judged against `asyncio` too.
+# Without this a new submodule name sidesteps the table by not being listed.
+DANGEROUS_MODULE_FAMILIES = ("asyncio", "importlib", "pip", "ctypes", "multiprocessing")
+
+# Attribute names that execute something, whatever module they are reached
+# through. This is the generalization of the table above: it catches the next
+# "benign module, dangerous method" pair without waiting for it to be listed.
+#
+# Matched exactly, never as a substring — `torch.storage._load_from_bytes` must
+# not match `load`, and it does not.
+EXECUTION_ATTRIBUTE_NAMES = {
+    "system", "popen", "spawn", "spawnl", "spawnv", "fork", "forkpty",
+    "exec", "execv", "execl", "execfile", "eval", "compile",
+    "run", "runeval", "runcall", "runctx", "run_path", "run_module",
+    "call", "check_call", "check_output", "getoutput", "getstatusoutput",
+    "Popen", "check_response",
+    "import_module", "__import__", "load_module", "load_source", "load_dynamic",
+    "interact", "compile_command",
 }
 
 # Strict allowlist mode: only these modules/functions are permitted
@@ -43,6 +154,19 @@ SAFE_MODULES = {
     "types",
     "_operator",
     "complex",
+    # Ordinary value types that turn up in model metadata and configs. Strict
+    # mode flagged these before, purely for being unrecognized; none of them
+    # carries an execution-shaped attribute, and the attribute check above
+    # still governs them.
+    "decimal",
+    "fractions",
+    "uuid",
+    "numbers",
+    "array",
+    "struct",
+    "math",
+    "itertools",
+    "string",
 }
 
 SAFE_BUILTINS = {
@@ -52,51 +176,95 @@ SAFE_BUILTINS = {
     "bool", "int", "float", "str", "bytes", "object",
 }
 
+def _module_roots(module: str):
+    """Yield a dotted module and each of its ancestors, longest first.
+
+    ``asyncio.unix_events`` yields ``asyncio.unix_events`` then ``asyncio``, so
+    a rule written against a package also governs its submodules.
+    """
+    parts = (module or "").split(".")
+    for cut in range(len(parts), 0, -1):
+        yield ".".join(parts[:cut])
+
+
+def is_dangerous_global(module: str, name: str) -> bool:
+    """True if ``module.name`` is a known execution sink, direct or indirect.
+
+    Checks the exact pair, then the module's ancestors for the families where a
+    submodule inherits the parent's entry, then the attribute name on its own —
+    so a sink reached through an unlisted submodule is still caught.
+    """
+    if not module or not name:
+        return False
+
+    for candidate in _module_roots(module):
+        listed = DANGEROUS_GLOBALS.get(candidate)
+        if listed and name in listed:
+            return True
+        # For a dangerous family, any attribute that executes something counts,
+        # even one nobody has enumerated yet.
+        if candidate in DANGEROUS_MODULE_FAMILIES and name in EXECUTION_ATTRIBUTE_NAMES:
+            return True
+
+    return False
+
+
 def _is_safe_import(module: str, name: str) -> bool:
-    """Helper to validate imports against strict mode policies."""
-    # 1. Exact Match Safe Modules
-    if module in SAFE_MODULES:
-        return True
-    
-    # 2. Torch Submodules (torch.*)
-    if module.startswith("torch."):
-        return True
-    
-    # 3. Codecs (Explicitly allow encode/decode only)
+    """Validate an import against strict (allowlist) mode.
+
+    Strict mode answers "is this recognized as safe", but a name being reached
+    through a recognized module is not enough on its own: the attribute has to
+    be innocuous too. An allowlisted package with an execution-shaped attribute
+    (`.run`, `.system`, `.popen`) is exactly the "benign prefix" shape this is
+    meant to close, so that check runs before the module allowlist.
+    """
+    if not module:
+        return False
+
+    # 0. A known sink is never safe, whatever its module looks like.
+    if is_dangerous_global(module, name):
+        return False
+
+    # 1. An execution-shaped attribute is not safe even on an allowlisted
+    #    module. Builtins are exempted here because SAFE_BUILTINS is an explicit
+    #    allowlist of names, checked below, and it is narrower than this rule.
+    if module not in ("builtins", "__builtin__") and name in EXECUTION_ATTRIBUTE_NAMES:
+        return False
+
+    # 2. Exact-match safe modules, and their submodules. Real checkpoints carry
+    #    globals like `torch.nn.modules.linear.Linear` and
+    #    `numpy.core.multiarray._reconstruct`, so submodules of an allowlisted
+    #    package have to be permitted — with step 1 above as the guard rail.
+    for candidate in _module_roots(module):
+        if candidate in SAFE_MODULES:
+            if candidate in ("builtins", "__builtin__"):
+                return name in SAFE_BUILTINS
+            return True
+
+    # 3. Codecs (explicitly allow encode/decode only).
     if module == "_codecs" and name in ("encode", "decode"):
         return True
-        
-    # 4. Pathlib internals handling (pathlib._local or generic submodules of safe packages?)
-    # Generally if 'pathlib' is safe, 'pathlib.anything' *should* be safe if it's code, but strict mode is strict.
-    # On many python versions, Path is in 'pathlib'. 'pathlib._local' is an implementation detail.
-    # Let's allow submodules of SAFE_MODULES if they start with that name?
-    # No, that opens up 'os.path' if 'os' was safe (it isn't).
-    # But for 'pathlib', 're', nested usage is common.
-    # Let's add specific check for known safe packages that use submodules
-    if module.startswith("pathlib.") or module.startswith("re.") or module.startswith("collections."):
-        return True
 
-    # 5. Builtins Checks
-    if module in ("builtins", "__builtin__"):
-        return name in SAFE_BUILTINS
+    return False
 
+def dual_use_argument_is_dangerous(argument) -> bool:
+    """True if a name handed to `attrgetter`/`methodcaller` reaches a sink.
+
+    ``methodcaller("upper")`` builds an ordinary callable; ``methodcaller(
+    "system")`` builds one that runs a command. Dotted forms count too, since
+    ``attrgetter("__class__.__mro__")`` walks the chain in a single call.
+    """
+    if not isinstance(argument, str) or not argument:
+        return False
+    for part in argument.split("."):
+        if part in EXECUTION_ATTRIBUTE_NAMES or part in _ESCAPE_ATTRIBUTE_NAMES:
+            return True
     return False
 
 # A legacy `torch.save` file is several pickles laid end to end, so a scan that
 # stops at the first STOP never reaches the object. Bounded so a hostile file
 # cannot turn "keep going" into an unbounded loop.
 MAX_CONCATENATED_STREAMS = 64
-
-
-def _record_global(threats: List[str], module, name, strict_mode: bool) -> None:
-    """Judge one resolved global and append a threat string if it is unsafe."""
-    if not module or not name:
-        return
-    if strict_mode:
-        if not _is_safe_import(module, name):
-            threats.append(f"UNSAFE_IMPORT: {module}.{name}")
-    elif module in DANGEROUS_GLOBALS and name in DANGEROUS_GLOBALS[module]:
-        threats.append(f"{module}.{name}")
 
 
 def _scan_single_stream(data: bytes, start: int, strict_mode: bool, threats: List[str]):
@@ -111,12 +279,43 @@ def _scan_single_stream(data: bytes, start: int, strict_mode: bool, threats: Lis
     stream = io.BytesIO(data)
     stream.seek(start)
 
+    # A dual-use constructor is judged by the name it is given, so the decision
+    # waits for the arguments between the global and its REDUCE.
+    pending = {"ctor": None, "args": []}
+
+    def resolve(module, name):
+        if not module or not name:
+            return
+        if (module, name) in DUAL_USE_CONSTRUCTORS:
+            # Defer: the argument decides. Recorded even in strict mode, where
+            # the module is allowlisted and would otherwise pass unexamined.
+            pending["ctor"] = (module, name)
+            pending["args"] = []
+            return
+        if strict_mode:
+            if not _is_safe_import(module, name):
+                threats.append(f"UNSAFE_IMPORT: {module}.{name}")
+        elif is_dangerous_global(module, name):
+            threats.append(f"{module}.{name}")
+
+    def settle_dual():
+        ctor, args = pending["ctor"], pending["args"]
+        if ctor and any(dual_use_argument_is_dangerous(a) for a in args):
+            module, name = ctor
+            bad = next(a for a in args if dual_use_argument_is_dangerous(a))
+            label = f"{module}.{name}({bad!r})"
+            threats.append(f"UNSAFE_IMPORT: {label}" if strict_mode else label)
+        pending["ctor"] = None
+        pending["args"] = []
+
     try:
         for opcode, arg, pos in pickletools.genops(stream):
             if opcode.name in ("SHORT_BINUNICODE", "UNICODE", "BINUNICODE"):
                 memo.append(arg)
                 if len(memo) > 2:
                     memo.pop(0)
+                if pending["ctor"] is not None:
+                    pending["args"].append(arg)
 
             if opcode.name == "GLOBAL":
                 # Arg is "module\nname"
@@ -127,20 +326,33 @@ def _scan_single_stream(data: bytes, start: int, strict_mode: bool, threats: Lis
                     module, name = arg.split(" ", 1)
                 else:
                     module, name = None, None
-                _record_global(threats, module, name, strict_mode)
+                resolve(module, name)
 
             elif opcode.name == "STACK_GLOBAL":
                 if len(memo) == 2:
-                    _record_global(threats, memo[0], memo[1], strict_mode)
+                    # The module/name pair is not an argument to a pending
+                    # constructor; drop it from whatever was collected.
+                    if pending["ctor"] is not None:
+                        for used in memo:
+                            if pending["args"] and pending["args"][-1] == used:
+                                pending["args"].pop()
+                    resolve(memo[0], memo[1])
                 # Clear memo after use to avoid false positives
                 memo.clear()
 
+            elif opcode.name in ("REDUCE", "NEWOBJ", "OBJ", "INST"):
+                settle_dual()
+
             elif opcode.name == "STOP":
+                settle_dual()
                 # `pos` is an absolute offset into the buffer.
                 return pos + 1
     except Exception:
         # Malformed downstream; keep whatever was found before the break.
+        settle_dual()
         return None
+
+    settle_dual()
     return None
 
 

--- a/docs/bypass-scorecard.md
+++ b/docs/bypass-scorecard.md
@@ -20,14 +20,14 @@ reports the wrong reason.
 | --- | --- | --- | --- | --- |
 | `nullifai-7z-container`<br>Model packed with 7z instead of ZIP | container-format | ⚠️ partial | ⚠️ partial | [ReversingLabs — nullifAI (malicious models on Hugging Face)](https://www.reversinglabs.com/blog/rl-identifies-malware-ml-model-hosted-on-hugging-face) |
 | `nullifai-broken-stream`<br>Deliberately broken pickle stream, payload first | broken-stream | ✅ detected | ✅ detected | [ReversingLabs — nullifAI (malicious models on Hugging Face)](https://www.reversinglabs.com/blog/rl-identifies-malware-ml-model-hosted-on-hugging-face) |
-| `cve-2025-1716-pip-main`<br>Code execution via pip.main() | unlisted-global | ⚠️ partial | ✅ detected | [Sonatype — CVE-2025-1716](https://www.sonatype.com/security-advisories/cve-2025-1716) |
+| `cve-2025-1716-pip-main`<br>Code execution via pip.main() | unlisted-global | ✅ detected | ✅ detected | [Sonatype — CVE-2025-1716](https://www.sonatype.com/security-advisories/cve-2025-1716) |
 | `cve-2025-1889-nonstandard-extension`<br>Payload in a file with a non-standard extension | file-extension | ❌ missed | ❌ missed | [Sonatype — CVE-2025-1889](https://www.sonatype.com/security-advisories/cve-2025-1889) |
 | `cve-2025-1944-zip-filename-tamper`<br>ZIP local-header filename differs from the central directory | zip-tampering | ✅ detected | ✅ detected | [Sonatype — CVE-2025-1944](https://www.sonatype.com/security-advisories/cve-2025-1944) |
 | `cve-2025-1945-zip-flag-bits`<br>ZIP general-purpose flag bits modified | zip-tampering | ✅ detected | ✅ detected | [Sonatype — CVE-2025-1945](https://www.sonatype.com/security-advisories/cve-2025-1945) |
 | `cve-2025-10155-extension-confusion`<br>Bare pickle wearing a PyTorch extension | file-extension | ✅ detected | ✅ detected | [JFrog — CVE-2025-10155](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/) |
 | `cve-2025-10156-zip-crc`<br>Corrupted CRC-32 in the ZIP archive | zip-tampering | ✅ detected | ✅ detected | [JFrog — CVE-2025-10156](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/) |
-| `cve-2025-10157-asyncio-subclass`<br>Dangerous import reached through an asyncio submodule | gadget-import | ⚠️ partial | ✅ detected | [JFrog — CVE-2025-10157](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/) |
-| `checkmarx-bdb-gadget`<br>Indirect execution via bdb.Bdb.run | gadget-import | ⚠️ partial | ✅ detected | [Checkmarx — Free Hugs: What to be Wary of in Hugging Face (Part 4)](https://checkmarx.com/blog/free-hugs-what-to-be-wary-of-in-hugging-face-part-4/) |
+| `cve-2025-10157-asyncio-subclass`<br>Dangerous import reached through an asyncio submodule | gadget-import | ✅ detected | ✅ detected | [JFrog — CVE-2025-10157](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/) |
+| `checkmarx-bdb-gadget`<br>Indirect execution via bdb.Bdb.run | gadget-import | ✅ detected | ✅ detected | [Checkmarx — Free Hugs: What to be Wary of in Hugging Face (Part 4)](https://checkmarx.com/blog/free-hugs-what-to-be-wary-of-in-hugging-face-part-4/) |
 | `shadowpickle-allowlist-overwrite`<br>Allowlisted builtin reached via STACK_GLOBAL | allowlist-abuse | ⚠️ partial | ⚠️ partial | [ShadowPickle (arXiv 2607.17503)](https://arxiv.org/html/2607.17503) |
 
 ## Controls

--- a/tests/corpus/baseline.json
+++ b/tests/corpus/baseline.json
@@ -5,7 +5,7 @@
       "strict": "clean"
     },
     "checkmarx-bdb-gadget": {
-      "blocklist": "partial",
+      "blocklist": "detected",
       "strict": "detected"
     },
     "control-os-system-zip": {
@@ -21,11 +21,11 @@
       "strict": "detected"
     },
     "cve-2025-10157-asyncio-subclass": {
-      "blocklist": "partial",
+      "blocklist": "detected",
       "strict": "detected"
     },
     "cve-2025-1716-pip-main": {
-      "blocklist": "partial",
+      "blocklist": "detected",
       "strict": "detected"
     },
     "cve-2025-1889-nonstandard-extension": {

--- a/tests/corpus/floor.json
+++ b/tests/corpus/floor.json
@@ -5,7 +5,7 @@
       "strict": "clean"
     },
     "checkmarx-bdb-gadget": {
-      "blocklist": "partial",
+      "blocklist": "detected",
       "strict": "detected"
     },
     "control-os-system-zip": {
@@ -21,11 +21,11 @@
       "strict": "detected"
     },
     "cve-2025-10157-asyncio-subclass": {
-      "blocklist": "partial",
+      "blocklist": "detected",
       "strict": "detected"
     },
     "cve-2025-1716-pip-main": {
-      "blocklist": "partial",
+      "blocklist": "detected",
       "strict": "detected"
     },
     "cve-2025-1889-nonstandard-extension": {

--- a/tests/test_gadgets.py
+++ b/tests/test_gadgets.py
@@ -1,0 +1,385 @@
+"""Indirect-execution gadget imports, in blocklist and strict mode.
+
+The evasion these cover is not a clever opcode trick — it is picking a module
+nobody thought to list. A debugger's `run`, an event loop's subprocess
+transport and a package installer's entry point all execute attacker-chosen
+code exactly as `os.system` does, while looking like ordinary library imports.
+
+The dominant risk in this area is the *opposite* of a miss. Expanding a
+blocklist and tightening an allowlist is how a scanner starts flagging real
+checkpoints, and a scanner that flags real checkpoints gets switched off — so
+roughly half of what follows is false-positive guards.
+
+Nothing here is unpickled; payloads are disassembled with pickletools only.
+"""
+
+import collections
+import datetime
+import decimal
+import fractions
+import pathlib
+import pickle
+import re
+import uuid
+
+import pytest
+
+from aisbom.mock_generator import (
+    harmless_reduce_pickle,
+    harmless_stack_global_pickle,
+)
+from aisbom.safety import (
+    DANGEROUS_GLOBALS,
+    EXECUTION_ATTRIBUTE_NAMES,
+    _is_safe_import,
+    is_dangerous_global,
+    scan_pickle_stream,
+)
+
+
+# --- the documented gadgets ----------------------------------------------
+
+GADGETS = [
+    ("bdb", "Bdb"),
+    ("bdb", "run"),
+    ("bdb", "runeval"),
+    ("pdb", "Pdb"),
+    ("asyncio.unix_events", "_UnixSubprocessTransport"),
+    ("asyncio", "create_subprocess_shell"),
+    ("asyncio.subprocess", "create_subprocess_exec"),
+    ("asyncio.base_events", "BaseEventLoop"),
+    ("pip", "main"),
+    ("pip._internal", "main"),
+    ("runpy", "run_path"),
+    ("importlib", "import_module"),
+    ("imp", "load_source"),
+    ("pty", "spawn"),
+    ("platform", "popen"),
+    ("ctypes", "CDLL"),
+    ("timeit", "timeit"),
+    ("code", "interact"),
+    ("codeop", "compile_command"),
+    ("cProfile", "runctx"),
+    ("multiprocessing", "Process"),
+    ("sys", "modules"),
+    ("builtins", "__import__"),
+    ("nt", "system"),
+]
+
+
+@pytest.mark.parametrize("module,name", GADGETS)
+def test_gadget_is_flagged_in_blocklist_mode(module, name):
+    """The headline requirement: these must not need `--strict` to be caught."""
+    threats = scan_pickle_stream(harmless_reduce_pickle(module, name))
+    assert threats == [f"{module}.{name}"]
+
+
+@pytest.mark.parametrize("module,name", GADGETS)
+def test_gadget_is_flagged_in_strict_mode(module, name):
+    threats = scan_pickle_stream(harmless_reduce_pickle(module, name), strict_mode=True)
+    assert threats == [f"UNSAFE_IMPORT: {module}.{name}"]
+
+
+@pytest.mark.parametrize("module,name", GADGETS)
+def test_gadget_is_flagged_via_stack_global_too(module, name):
+    """Protocol 4 resolves the global off the stack; same verdict required."""
+    threats = scan_pickle_stream(harmless_stack_global_pickle(module, name))
+    assert threats == [f"{module}.{name}"]
+
+
+# --- submodules the table does not enumerate -----------------------------
+
+@pytest.mark.parametrize("module,name", [
+    ("asyncio.some_future_module", "run"),
+    ("asyncio.windows_events", "create_subprocess_shell"),
+    ("importlib.a.b.c", "import_module"),
+    ("pip._internal.cli.some.deep.path", "main"),
+    ("ctypes.util", "CDLL"),
+])
+def test_unlisted_submodule_of_a_dangerous_family_is_still_flagged(module, name):
+    """A new submodule name must not be a way around the table."""
+    assert is_dangerous_global(module, name) is True
+    assert scan_pickle_stream(harmless_reduce_pickle(module, name)) == [f"{module}.{name}"]
+
+
+def test_dangerous_attribute_on_an_allowlisted_module_is_not_strict_safe():
+    """The 'benign prefix' hole: an allowlisted package with a sink attribute."""
+    assert _is_safe_import("torch", "system") is False
+    assert _is_safe_import("torch.nested.thing", "popen") is False
+    assert _is_safe_import("numpy", "run") is False
+    assert _is_safe_import("collections", "eval") is False
+
+
+def test_ordinary_attributes_on_allowlisted_modules_remain_safe():
+    assert _is_safe_import("torch.nn.modules.linear", "Linear") is True
+    assert _is_safe_import("torch._utils", "_rebuild_tensor_v2") is True
+    assert _is_safe_import("numpy.core.multiarray", "_reconstruct") is True
+    assert _is_safe_import("collections", "OrderedDict") is True
+
+
+# --- dual-use constructors: the argument decides -------------------------
+#
+# `attrgetter`/`methodcaller` build a callable from a name given as a *string*,
+# so `methodcaller("system")` reaches a sink without naming it as a global.
+# Flagging the constructor unconditionally would flag every checkpoint that
+# stores an ordinary `attrgetter("name")`, so the argument is what is judged.
+# `functools.reduce` is deliberately not listed at all: whatever dangerous
+# callable it is handed appears as its own global and is caught on its own.
+
+BENIGN_DUAL_USE = [
+    ("attrgetter", ("name",)),
+    ("attrgetter", ("a.b",)),
+    ("attrgetter", ("weight", "bias")),
+    ("methodcaller", ("upper",)),
+    ("methodcaller", ("strip", " ")),
+    ("methodcaller", ("get", "key")),
+]
+
+DANGEROUS_DUAL_USE = [
+    ("attrgetter", ("__globals__",)),
+    ("attrgetter", ("__class__.__mro__",)),
+    ("attrgetter", ("__reduce__",)),
+    ("methodcaller", ("system", "id")),
+    ("methodcaller", ("popen", "id")),
+    ("methodcaller", ("run",)),
+]
+
+
+@pytest.mark.parametrize("ctor,args", BENIGN_DUAL_USE)
+@pytest.mark.parametrize("protocol", [2, 4])
+def test_benign_dual_use_constructors_are_clean(ctor, args, protocol):
+    import operator
+    blob = pickle.dumps(getattr(operator, ctor)(*args), protocol=protocol)
+    assert scan_pickle_stream(blob) == []
+    assert scan_pickle_stream(blob, strict_mode=True) == []
+
+
+@pytest.mark.parametrize("ctor,args", DANGEROUS_DUAL_USE)
+@pytest.mark.parametrize("protocol", [2, 4])
+def test_dangerous_dual_use_arguments_are_flagged(ctor, args, protocol):
+    import operator
+    blob = pickle.dumps(getattr(operator, ctor)(*args), protocol=protocol)
+    blocklist = scan_pickle_stream(blob)
+    strict = scan_pickle_stream(blob, strict_mode=True)
+
+    assert blocklist, f"{ctor}{args} should be reported"
+    assert strict, f"{ctor}{args} should be reported in strict mode"
+    # The finding names the argument, not just the constructor.
+    assert args[0] in blocklist[0]
+
+
+def test_dual_use_argument_judgement_is_directly_testable():
+    from aisbom.safety import dual_use_argument_is_dangerous as bad
+
+    assert bad("name") is False
+    assert bad("weight") is False
+    assert bad("") is False
+    assert bad(None) is False
+    assert bad("__globals__") is True
+    assert bad("__class__.__mro__") is True
+    assert bad("system") is True
+
+
+def test_functools_reduce_alone_is_not_reported():
+    """The callable it is given is what matters, and that is caught separately."""
+    from aisbom.safety import is_dangerous_global
+    assert is_dangerous_global("functools", "reduce") is False
+
+
+# --- false-positive guards (the main risk of this change) ----------------
+
+REAL_CHECKPOINT_GLOBALS = [
+    ("torch._utils", "_rebuild_tensor_v2"),
+    ("torch._utils", "_rebuild_parameter"),
+    ("torch", "FloatStorage"),
+    ("torch", "LongStorage"),
+    ("torch.storage", "_load_from_bytes"),
+    ("torch.nn.modules.linear", "Linear"),
+    ("torch.nn.modules.container", "Sequential"),
+    ("torch.nn.modules.activation", "ReLU"),
+    ("collections", "OrderedDict"),
+    ("numpy.core.multiarray", "_reconstruct"),
+    ("numpy.core.multiarray", "scalar"),
+    ("numpy", "dtype"),
+    ("numpy", "ndarray"),
+    ("builtins", "complex"),
+    ("re", "_compile"),
+    ("copyreg", "_reconstructor"),
+    ("datetime", "datetime"),
+    ("pathlib", "PurePosixPath"),
+]
+
+
+@pytest.mark.parametrize("module,name", REAL_CHECKPOINT_GLOBALS)
+def test_real_checkpoint_globals_are_never_flagged(module, name):
+    """These appear in genuine model files. Flagging any of them is a defect."""
+    assert is_dangerous_global(module, name) is False
+    assert _is_safe_import(module, name) is True
+    assert scan_pickle_stream(harmless_reduce_pickle(module, name)) == []
+    assert scan_pickle_stream(harmless_reduce_pickle(module, name), strict_mode=True) == []
+
+
+def _benign_objects():
+    return {
+        "state_dict": {"state_dict": {"layer.weight": [0.1, 0.2]}},
+        "ordered_dict": collections.OrderedDict([("w", [1.0]), ("b", [2.0])]),
+        "nested_ordered": collections.OrderedDict([("a", collections.OrderedDict([("b", 1)]))]),
+        "defaultdict": collections.defaultdict(list, {"a": [1]}),
+        "deque": collections.deque([1, 2, 3]),
+        "counter": collections.Counter("aabbcc"),
+        "mixed_tuple": (1, 2.5, "three", b"four", None, True),
+        "sets": {"s": {1, 2}, "f": frozenset([3, 4])},
+        "complex": complex(1, 2),
+        "regex": re.compile(r"^layer\.\d+$"),
+        "datetime": datetime.datetime(2026, 1, 1, 12, 0, 0),
+        "timedelta": datetime.timedelta(days=3, seconds=42),
+        "path": pathlib.PurePosixPath("/models/checkpoint.pt"),
+        "decimal": decimal.Decimal("3.14159"),
+        "fraction": fractions.Fraction(3, 7),
+        "uuid": uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        "bytearray": bytearray(b"weights"),
+    }
+
+
+@pytest.mark.parametrize("label", sorted(_benign_objects()))
+@pytest.mark.parametrize("protocol", [2, 4, 5])
+def test_ordinary_pickled_objects_are_clean_in_both_modes(label, protocol):
+    """A broad sweep of things a checkpoint plausibly contains.
+
+    Protocol 4 and 5 matter specifically: they reach globals through
+    STACK_GLOBAL, the same opcode an allowlist-abuse payload uses.
+    """
+    blob = pickle.dumps(_benign_objects()[label], protocol=protocol)
+    assert scan_pickle_stream(blob) == []
+    assert scan_pickle_stream(blob, strict_mode=True) == []
+
+
+def test_a_benign_ordered_dict_is_indistinguishable_from_the_allowlist_abuse_shape():
+    """Why allowlist abuse is not flagged, recorded as an executable fact.
+
+    An ordinary OrderedDict state_dict at protocol 4 reaches an allowlisted
+    global through STACK_GLOBAL and immediately REDUCEs it — the same
+    observable sequence as a payload that shadows a trusted name. Any rule
+    keyed on that shape would flag essentially every real checkpoint, so the
+    scorecard leaves that case at 'partial' rather than buying a detection
+    with false positives on ordinary models.
+    """
+    import io
+    import pickletools
+
+    benign = pickle.dumps(collections.OrderedDict([("w", [1.0])]), protocol=4)
+    abuse = harmless_stack_global_pickle("collections", "OrderedDict")
+
+    def signature(blob):
+        ops = [op.name for op, _a, _p in pickletools.genops(io.BytesIO(blob))]
+        return {"STACK_GLOBAL" in ops, "REDUCE" in ops}
+
+    assert signature(benign) == signature(abuse) == {True}
+    assert scan_pickle_stream(benign) == []
+    assert scan_pickle_stream(benign, strict_mode=True) == []
+
+
+# --- table hygiene --------------------------------------------------------
+
+def test_original_blocklist_entries_are_preserved():
+    """Expanding the table must not drop what it already caught."""
+    for module, name in [
+        ("os", "system"), ("os", "popen"), ("os", "execl"), ("os", "execvp"),
+        ("subprocess", "Popen"), ("subprocess", "call"), ("subprocess", "check_call"),
+        ("subprocess", "check_output"), ("subprocess", "run"),
+        ("builtins", "eval"), ("builtins", "exec"), ("builtins", "compile"),
+        ("builtins", "open"),
+        ("posix", "system"), ("posix", "popen"),
+        ("webbrowser", "open"),
+        ("socket", "socket"), ("socket", "connect"),
+    ]:
+        assert is_dangerous_global(module, name) is True, f"{module}.{name}"
+
+
+def test_execution_attribute_names_match_exactly_not_as_substrings():
+    """`_load_from_bytes` must not match `load`; `evaluate` must not match `eval`."""
+    assert _is_safe_import("torch.storage", "_load_from_bytes") is True
+    assert _is_safe_import("torch", "evaluate") is True
+    assert _is_safe_import("torch", "systematic") is True
+    assert _is_safe_import("torch", "compiler_config") is True
+
+
+def test_empty_and_malformed_globals_do_not_crash():
+    assert is_dangerous_global("", "") is False
+    assert is_dangerous_global(None, None) is False
+    assert is_dangerous_global("os", "") is False
+    assert _is_safe_import("", "x") is False
+
+
+def test_blocklist_names_are_all_plausible_attributes():
+    """Guard against a stray empty entry silently disabling a module."""
+    for module, names in DANGEROUS_GLOBALS.items():
+        assert names, f"{module} has an empty name set"
+        assert all(isinstance(n, str) and n for n in names), module
+
+
+def test_execution_attribute_set_is_non_empty_and_stringly_typed():
+    assert EXECUTION_ATTRIBUTE_NAMES
+    assert all(isinstance(n, str) and n for n in EXECUTION_ATTRIBUTE_NAMES)
+
+
+# --- end to end -----------------------------------------------------------
+
+def test_bdb_gadget_in_a_model_file_is_critical(tmp_path):
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("archive/data.pkl", harmless_reduce_pickle("bdb", "Bdb"))
+        z.writestr("archive/version", "3")
+    (tmp_path / "model.pt").write_bytes(buf.getvalue())
+
+    from aisbom.scanner import DeepScanner
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "bdb.Bdb" in art["risk_level"]
+
+
+def test_gadget_model_exits_two(tmp_path, monkeypatch):
+    import io
+    import zipfile
+    from typer.testing import CliRunner
+    from aisbom.cli import app
+
+    monkeypatch.setenv("AISBOM_NO_TELEMETRY", "1")
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("archive/data.pkl", harmless_reduce_pickle("asyncio", "create_subprocess_shell"))
+        z.writestr("archive/version", "3")
+    (tmp_path / "gadget.pt").write_bytes(buf.getvalue())
+
+    result = CliRunner().invoke(app, ["scan", str(tmp_path)])
+
+    assert "gadget.pt" in result.output, result.output
+    assert "CRITICAL" in result.output, result.output
+    assert result.exit_code == 2, result.output
+
+
+def test_ordinary_model_does_not_exit_two(tmp_path, monkeypatch):
+    """The false-positive guard, end to end."""
+    import io
+    import zipfile
+    from typer.testing import CliRunner
+    from aisbom.cli import app
+
+    monkeypatch.setenv("AISBOM_NO_TELEMETRY", "1")
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr(
+            "archive/data.pkl",
+            pickle.dumps(collections.OrderedDict([("layer.weight", [0.1])]), protocol=4),
+        )
+        z.writestr("archive/version", "3")
+    (tmp_path / "ordinary.pt").write_bytes(buf.getvalue())
+
+    result = CliRunner().invoke(app, ["scan", str(tmp_path)])
+
+    assert "ordinary.pt" in result.output, result.output
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
Closes the "benign-looking module, dangerous method" bypasses. A debugger's `run`, an event loop's subprocess transport and a package installer's entry point execute attacker-chosen code exactly as `os.system` does, while looking like ordinary library imports.

## Three cases move — and the headline number doesn't

| Case | blocklist | strict |
|---|---|---|
| `checkmarx-bdb-gadget` | ⚠️ partial → ✅ **detected** | ✅ detected |
| `cve-2025-10157-asyncio-subclass` | ⚠️ partial → ✅ **detected** | ✅ detected |
| `cve-2025-1716-pip-main` | ⚠️ partial → ✅ **detected** | ✅ detected |

They no longer need `--strict` to be caught. **The headline count reads 5/11 before and after**, because those cases were already `detected` in strict mode and the headline counts "caught in at least one mode".

That is exactly the weakness the per-case, per-mode gate was built for, and it was confirmed live rather than argued: with the `bdb` entry removed, the headline **still read 5/11** while the gate failed with

```
• checkmarx-bdb-gadget (blocklist): was detected, now partial
```

An aggregate-count gate would have waved that regression through.

## Two rules generalize the table

So the *next* gadget doesn't have to be enumerated first:

- **A dangerous package governs its submodules.** `asyncio.some_future_module.run` is caught without being listed.
- **An execution-shaped attribute is flagged whatever module it arrives through** — `.run`, `.system`, `.popen`, `.import_module`, etc. This closes the benign-prefix hole, where a `startswith("torch.")` rule blanket-approved every attribute underneath it.

## False positives are the real risk here

Expanding a blocklist and tightening an allowlist is how a scanner starts flagging real checkpoints — and a scanner that flags real checkpoints gets switched off, which is worse than a missed case. So:

- Attribute names match **exactly, never as substrings**: `torch.storage._load_from_bytes` does not match `load`; `evaluate` does not match `eval`. Both asserted in tests.
- A sweep of **57 pickled ordinary objects** across protocols 2, 4 and 5 (OrderedDict, defaultdict, deque, Counter, compiled regex, datetime, Path, Decimal, Fraction, UUID, sets, complex…) plus **18 globals a genuine torch/numpy checkpoint carries** → **zero false positives in either mode**.
- Three **pre-existing** strict-mode false positives surfaced along the way — `decimal.Decimal`, `fractions.Fraction`, `uuid.UUID` were never in the allowlist — and are fixed, along with a few other plain value types.

## One case deliberately left at `partial`

`shadowpickle-allowlist-overwrite` is **not** flagged, and that's a decision rather than an oversight.

An ordinary `OrderedDict` state_dict pickled at protocol ≥ 4 produces the *same observable opcode signature* as that corpus case: `STACK_GLOBAL` on `collections.OrderedDict` followed by `REDUCE`. Not similar — **identical in every signal a static disassembler can see**. Any rule keyed on that shape would flag essentially every real PyTorch checkpoint saved at protocol 4+.

`test_a_benign_ordered_dict_is_indistinguishable_from_the_allowlist_abuse_shape` asserts the equivalence, so the reasoning is executable rather than a comment that rots.

What *is* detectable is the precondition a real shadowing attack needs, so the import-mechanism primitives are now blocklisted: `sys.modules`, `importlib`, `imp`, `runpy`, `pkgutil`, `builtins.__import__`. None of these appear in benign model pickles.

## Merge note

This branch's `baseline.json` / `floor.json` reflect **these** three cases, computed from `main`. The sibling container/broken-stream PR raises the floor on three *different* cases. The floor is monotonic, so whoever merges second should rebase and re-run `bypass-scorecard --write` to get the union of both improvements — and then **verify** the result rather than assuming it, since a floor that silently drops an entry is the one failure this gate exists to prevent.

## Verification

- `poetry run pytest --cov=aisbom --cov-fail-under=85` → **465 passed, 89.97% coverage** (before: 302, 89.80%)
- `aisbom bypass-scorecard --check` → **gate passed**
- All CI smoke commands exit 0, including `scan . --strict`
- End-to-end: `bdb.Bdb`, `asyncio.unix_events._UnixSubprocessTransport` and `pip.main` each named specifically in **default** mode; an ordinary protocol-4 OrderedDict model stays MEDIUM and exits 0

Test coverage: 26 gadget pairs × 3 (blocklist, strict, STACK_GLOBAL), unlisted-submodule inheritance, the benign-prefix hole, 18 real checkpoint globals, 51 benign object/protocol combinations, exact-vs-substring matching, preservation of every original blocklist entry, table hygiene, and both CLI exit-code paths.
