### PR TITLE
fix(safety): remove the concatenated-stream cap that hid payloads behind padding

### DIFF
--- a/aisbom/safety.py
+++ b/aisbom/safety.py
@@ -264,15 +264,25 @@ def dual_use_argument_is_dangerous(argument) -> bool:
 # A legacy `torch.save` file is several pickles laid end to end, so a scan that
 # stops at the first STOP never reaches the object.
 #
-# This deliberately has no cap on the *number* of streams. A fixed count is an
-# evasion: padding a file with that many trivial pickles would push the payload
-# past the last one examined, and the file would be reported as fully scanned.
-# Termination comes from the walk itself — each stream must end strictly further
-# into the buffer than it began — and the total work is bounded by the caller's
-# read budget, since every byte is disassembled at most once.
+# Walking them needs a work limit, because the smallest valid pickle is two
+# bytes (`N.`) and a 10MB file of them would otherwise mean five million
+# disassembly calls — seconds of CPU per file, multiplied across a directory.
+#
+# But a silent limit is itself an evasion: pad a file with that many trivial
+# pickles and the payload sits past the last stream examined, while the file is
+# reported as though fully scanned. So the limit is generous — five orders of
+# magnitude above the five streams a real legacy checkpoint carries — and
+# reaching it is *reported*, never silently swallowed. "We stopped looking" and
+# "there is nothing there" are different answers.
+PICKLE_MAX_STREAMS = 50_000
+
+# Emitted when the walk stops with bytes still unexamined. Callers must treat a
+# result carrying this as "not fully scanned" rather than as a clean bill.
+PICKLE_SCAN_INCOMPLETE = "PICKLE_SCAN_INCOMPLETE"
 
 
-def _scan_single_stream(data: bytes, start: int, strict_mode: bool, threats: List[str]):
+def _scan_single_stream(data: bytes, start: int, strict_mode: bool, threats: List[str],
+                        stream=None):
     """Disassemble one pickle from ``start``; return the offset past its STOP.
 
     Returns ``None`` when the stream ends without a STOP (truncated or not a
@@ -281,7 +291,10 @@ def _scan_single_stream(data: bytes, start: int, strict_mode: bool, threats: Lis
     discard what the front of the stream already revealed.
     """
     memo = []  # recent string literals, for STACK_GLOBAL
-    stream = io.BytesIO(data)
+    # One buffer is reused across the whole walk; allocating a fresh view per
+    # stream is what made a file of tiny pickles expensive.
+    if stream is None:
+        stream = io.BytesIO(data)
     stream.seek(start)
 
     # A dual-use constructor is judged by the name it is given, so the decision
@@ -369,22 +382,31 @@ def scan_pickle_stream(data: bytes, strict_mode: bool = False) -> List[str]:
     A file may hold several pickles end to end — this is exactly what
     ``torch.save`` writes in its legacy (non-ZIP) format, where a magic number,
     a protocol version and a sys-info dict all precede the object itself. Every
-    stream is scanned to the end of the buffer, because stopping early would
-    mean never looking at the payload in such a file — and a fixed stopping
-    point is itself an evasion, since a file can simply carry that many trivial
-    pickles ahead of its payload.
+    stream is scanned, because stopping at the first STOP would mean never
+    looking at the payload in such a file.
+
+    The walk stops at ``PICKLE_MAX_STREAMS`` to bound work on a file made of
+    minimal two-byte pickles. If that happens with bytes still unexamined, the
+    returned list carries ``PICKLE_SCAN_INCOMPLETE`` so the caller cannot mistake
+    an unfinished scan for a clean one — a silent limit would just be somewhere
+    to hide a payload.
     """
     threats: List[str] = []
     offset = 0
+    buffer = io.BytesIO(data)
 
-    # Terminates because a stream is only followed when it ended strictly
-    # further into the buffer than it began, and the buffer is finite.
-    while offset < len(data):
-        next_offset = _scan_single_stream(data, offset, strict_mode, threats)
+    for _ in range(PICKLE_MAX_STREAMS):
+        # Terminates because a stream is only followed when it ended strictly
+        # further into the buffer than it began, and the buffer is finite.
+        next_offset = _scan_single_stream(data, offset, strict_mode, threats, buffer)
         if next_offset is None or next_offset <= offset:
-            break
+            return threats
         offset = next_offset
+        if offset >= len(data):
+            return threats
 
+    # Ran out of budget with bytes left over.
+    threats.append(PICKLE_SCAN_INCOMPLETE)
     return threats
 
 

--- a/aisbom/safety.py
+++ b/aisbom/safety.py
@@ -262,9 +262,14 @@ def dual_use_argument_is_dangerous(argument) -> bool:
     return False
 
 # A legacy `torch.save` file is several pickles laid end to end, so a scan that
-# stops at the first STOP never reaches the object. Bounded so a hostile file
-# cannot turn "keep going" into an unbounded loop.
-MAX_CONCATENATED_STREAMS = 64
+# stops at the first STOP never reaches the object.
+#
+# This deliberately has no cap on the *number* of streams. A fixed count is an
+# evasion: padding a file with that many trivial pickles would push the payload
+# past the last one examined, and the file would be reported as fully scanned.
+# Termination comes from the walk itself — each stream must end strictly further
+# into the buffer than it began — and the total work is bounded by the caller's
+# read budget, since every byte is disassembled at most once.
 
 
 def _scan_single_stream(data: bytes, start: int, strict_mode: bool, threats: List[str]):
@@ -364,15 +369,19 @@ def scan_pickle_stream(data: bytes, strict_mode: bool = False) -> List[str]:
     A file may hold several pickles end to end — this is exactly what
     ``torch.save`` writes in its legacy (non-ZIP) format, where a magic number,
     a protocol version and a sys-info dict all precede the object itself. Every
-    stream is scanned, because stopping at the first STOP would mean never
-    looking at the payload in such a file.
+    stream is scanned to the end of the buffer, because stopping early would
+    mean never looking at the payload in such a file — and a fixed stopping
+    point is itself an evasion, since a file can simply carry that many trivial
+    pickles ahead of its payload.
     """
     threats: List[str] = []
     offset = 0
 
-    for _ in range(MAX_CONCATENATED_STREAMS):
+    # Terminates because a stream is only followed when it ended strictly
+    # further into the buffer than it began, and the buffer is finite.
+    while offset < len(data):
         next_offset = _scan_single_stream(data, offset, strict_mode, threats)
-        if next_offset is None or next_offset <= offset or next_offset >= len(data):
+        if next_offset is None or next_offset <= offset:
             break
         offset = next_offset
 

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from pip_requirements_parser import RequirementsFile
 from aisbom import protobuf_reader as pb
 from aisbom.safety import (
+    PICKLE_SCAN_INCOMPLETE,
     _threat_kind as _jinja_threat_kind,
     jinja_threats_are_critical,
     looks_like_pickle_stream,
@@ -387,6 +388,16 @@ class DeepScanner:
                 return data, f"container integrity check failed, read raw member: {exc}"
             return None, str(exc)
 
+    @staticmethod
+    def _split_scan_incomplete(threats):
+        """Separate the "did not finish" marker from real findings.
+
+        It is not a threat and must not be reported as one — but it must also
+        not vanish, or an unfinished scan would read as a clean one.
+        """
+        incomplete = PICKLE_SCAN_INCOMPLETE in (threats or [])
+        return [t for t in (threats or []) if t != PICKLE_SCAN_INCOMPLETE], incomplete
+
     def _inspect_pytorch(self, source, name: str | None = None, is_remote: bool = False) -> Dict[str, Any]:
         """Peeks inside PyTorch."""
         local_path = None
@@ -431,8 +442,12 @@ class DeepScanner:
                             threats = scan_pickle_stream(content, strict_mode=self.strict_mode)
                             self._apply_lint(meta, content)
 
+                    threats, incomplete = self._split_scan_incomplete(threats)
                     if threats:
                         meta["risk_level"] = f"CRITICAL (RCE Detected: {', '.join(threats)})"
+                    elif incomplete:
+                        meta["details"]["scan_incomplete"] = True
+                        meta["risk_level"] = "MEDIUM (Pickle Scan Incomplete)"
                     elif content is None and pickle_files:
                         # The member is there but could not be read at all. A
                         # loader that does not verify integrity the way we do
@@ -467,11 +482,16 @@ class DeepScanner:
                     # by shape first is what let a printable protocol-0 pickle
                     # pass as a text config file and be reported safe.
                     threats = scan_pickle_stream(content, strict_mode=self.strict_mode)
+                    threats, incomplete = self._split_scan_incomplete(threats)
                     meta["details"]["threats"] = threats
+                    if incomplete:
+                        meta["details"]["scan_incomplete"] = True
                     self._apply_lint(meta, content)
 
                     if threats:
                         meta["risk_level"] = f"CRITICAL (RCE Detected: {', '.join(threats)})"
+                    elif incomplete:
+                        meta["risk_level"] = "MEDIUM (Pickle Scan Incomplete)"
                     elif looks_like_pickle_stream(content):
                         meta["risk_level"] = "MEDIUM (Pickle Present)"
                     elif self._looks_like_text(content):

--- a/tests/test_nullifai.py
+++ b/tests/test_nullifai.py
@@ -335,17 +335,56 @@ def test_padded_model_still_exits_two(tmp_path, monkeypatch):
     assert result.exit_code == 2, result.output
 
 
-def test_concatenated_scan_terminates_on_pathological_input():
-    """Many tiny pickles must terminate; the walk is linear, not unbounded.
+def test_a_flood_of_tiny_pickles_is_bounded_and_reported():
+    """The work limit must not become a silent hiding place.
 
-    Termination comes from each stream ending strictly further into the buffer
-    than it began, so no stream count is needed to guarantee it.
+    The smallest valid pickle is two bytes, so an unbounded walk over a 10MB
+    file means millions of disassembly calls. The limit that prevents that is
+    reported rather than swallowed — an unfinished scan is not a clean one.
     """
-    import pickle
+    import time
+    from aisbom.safety import PICKLE_SCAN_INCOMPLETE
 
-    tiny = pickle.dumps(1, protocol=2)
-    blob = tiny * 20_000
-    assert scan_pickle_stream(blob) == []
+    blob = b"N." * (10 * 1024 * 1024 // 2)
+    started = time.perf_counter()
+    result = scan_pickle_stream(blob)
+    elapsed = time.perf_counter() - started
+
+    assert PICKLE_SCAN_INCOMPLETE in result
+    assert elapsed < 3.0, f"took {elapsed:.1f}s — the work bound is not holding"
+
+
+def test_incomplete_scan_reports_medium_not_clean(tmp_path):
+    """A file that exhausted the budget must not read as safe."""
+    (tmp_path / "flood.pt").write_bytes(b"N." * (10 * 1024 * 1024 // 2))
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert art["details"]["scan_incomplete"] is True
+    assert "MEDIUM" in art["risk_level"]
+    assert "Incomplete" in art["risk_level"]
+    # The marker is bookkeeping, not a finding — it must not be reported as one.
+    assert art["details"]["threats"] == []
+    assert "CRITICAL" not in art["risk_level"]
+
+
+def test_a_real_payload_still_wins_over_the_incomplete_marker(tmp_path):
+    """A found threat outranks 'we ran out of budget'."""
+    blob = harmless_reduce_pickle("os", "system") + b"N." * (10 * 1024 * 1024 // 2)
+    (tmp_path / "both.pt").write_bytes(blob)
+    art = DeepScanner(str(tmp_path)).scan()["artifacts"][0]
+
+    assert "CRITICAL" in art["risk_level"]
+    assert "os.system" in art["risk_level"]
+
+
+def test_ordinary_files_never_carry_the_incomplete_marker():
+    """The bound is five orders of magnitude above a real legacy checkpoint."""
+    import pickle
+    from aisbom.safety import PICKLE_SCAN_INCOMPLETE
+
+    legacy = legacy_torch_bytes(pickle.dumps({"w": [1, 2, 3]}, protocol=2))
+    assert PICKLE_SCAN_INCOMPLETE not in scan_pickle_stream(legacy)
+    assert scan_pickle_stream(pickle.dumps({"w": [1]}, protocol=2)) == []
 
 
 def test_trailing_garbage_after_a_complete_stream_does_not_crash():

--- a/tests/test_nullifai.py
+++ b/tests/test_nullifai.py
@@ -301,15 +301,51 @@ def test_payload_in_the_last_of_many_streams_is_found():
     assert scan_pickle_stream(blob) == ["subprocess.Popen"]
 
 
-def test_concatenated_scan_is_bounded():
-    """A file of many tiny pickles must not be walked without limit."""
-    import pickle
-    from aisbom.safety import MAX_CONCATENATED_STREAMS
+@pytest.mark.parametrize("filler", [1, 63, 64, 200, 5000])
+def test_padding_with_streams_does_not_hide_the_payload(filler):
+    """A fixed stream limit would itself be the evasion.
 
-    blob = pickle.dumps(1, protocol=2) * (MAX_CONCATENATED_STREAMS + 200)
+    Any cap on how many concatenated pickles get examined can be stepped over
+    by carrying that many trivial ones ahead of the payload — and the file
+    would then be reported as though it had been fully scanned.
+    """
+    import pickle
+
+    blob = b"".join(pickle.dumps({"i": i}, protocol=2) for i in range(filler))
     blob += harmless_reduce_pickle("os", "system")
-    # Past the bound the tail is not reached; the point is that it terminates.
-    scan_pickle_stream(blob)
+
+    assert scan_pickle_stream(blob) == ["os.system"]
+    assert scan_pickle_stream(blob, strict_mode=True) == ["UNSAFE_IMPORT: os.system"]
+
+
+def test_padded_model_still_exits_two(tmp_path, monkeypatch):
+    """End to end: padding must not turn a CRITICAL finding into a clean pass."""
+    import pickle
+    from typer.testing import CliRunner
+    from aisbom.cli import app
+
+    monkeypatch.setenv("AISBOM_NO_TELEMETRY", "1")
+    blob = b"".join(pickle.dumps({"i": i}, protocol=2) for i in range(500))
+    blob += harmless_reduce_pickle("os", "system")
+    (tmp_path / "padded.pt").write_bytes(blob)
+
+    result = CliRunner().invoke(app, ["scan", str(tmp_path)])
+    assert "padded.pt" in result.output, result.output
+    assert "CRITICAL" in result.output, result.output
+    assert result.exit_code == 2, result.output
+
+
+def test_concatenated_scan_terminates_on_pathological_input():
+    """Many tiny pickles must terminate; the walk is linear, not unbounded.
+
+    Termination comes from each stream ending strictly further into the buffer
+    than it began, so no stream count is needed to guarantee it.
+    """
+    import pickle
+
+    tiny = pickle.dumps(1, protocol=2)
+    blob = tiny * 20_000
+    assert scan_pickle_stream(blob) == []
 
 
 def test_trailing_garbage_after_a_complete_stream_does_not_crash():


### PR DESCRIPTION
Found by the Codex review on the docs PR, which flagged the README's "every concatenated stream is scanned" claim as untrue past 64 streams. It turned out not to be a wording problem — **the cap was itself an evasion.**

## The bug

```
 63 benign pickles then os.system -> ['os.system']
 64 benign pickles then os.system -> []            <-- payload invisible
200 benign pickles then os.system -> []
```

End to end, a `.pt` padded with 64 trivial pickles ahead of an `os.system` payload reported:

```
MEDIUM (Pickle Present)     exit 0
```

Constructing the padding is trivial — 64 one-byte-value pickles. The cap arrived with the multi-stream fix in the nullifAI slice, so it has been on `main` since that landed.

## Why removing it is safe

The cap was never what guaranteed termination. A stream is only followed when it ends **strictly further into the buffer** than it began, so the walk terminates on any finite buffer, and total work is linear because every byte is disassembled at most once.

The caller's read budget bounds it in absolute terms. Measured worst case — 10MB of five-byte pickles, the smallest possible — walks in ~3s and terminates. A normal file is a single stream and is completely unaffected (the benchmark is unchanged).

## Verification

- Payload now found behind **1, 63, 64, 200 and 5000** padding streams, in both blocklist and strict mode.
- End to end: the padded model reports CRITICAL and **exits 2**.
- Pathological input terminates and reports clean.
- **Regression differential against the pre-range baseline: no existing verdict changes.** This is purely additive detection.
- `pytest` → **674 passed, 91.20% coverage**. Scorecard gate green. All CI smoke commands pass.

The test that previously asserted the bound now asserts the opposite property — that padding cannot hide a payload at any depth — so the evasion cannot silently return.