### PR TITLE
feat(corpus): publish why each uncaught bypass case is uncaught

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **The bypass scorecard now publishes why each uncaught case is uncaught.** Cases that are not fully caught carry a `limitation` note, rendered into `docs/bypass-scorecard.md` alongside the verdict: what AIsbom actually reports, why that is the wrong reason, and what closing the gap would take. No case's `expected` verdict changes — every evasion technique in the corpus remains one a correct scanner should catch, so the gate keeps counting all three against us. The note explains a gap; it never excuses one.
+
 ## 1.3.0 — 2026-08-15
 
 ### New formats scanned

--- a/aisbom/corpus.py
+++ b/aisbom/corpus.py
@@ -579,14 +579,23 @@ def strip_generated_stamp(text: str) -> str:
     ).strip()
 
 
+def is_caught(row: dict) -> bool:
+    """
+    Whether a case counts as caught: named as a threat in at least one mode.
+
+    The headline count and the limitation-note gate must agree on this, or the
+    document can claim a case is uncaught while counting it among the wins.
+    """
+    return row["blocklist"] == "detected" or row["strict"] == "detected"
+
+
 def render_markdown(results: dict) -> str:
     """Render the human-readable scorecard published by the /blog article."""
     cases = results["cases"]
     evasions = [c for c in CASES if not is_control(c)]
     controls = [c for c in CASES if is_control(c)]
 
-    detected = sum(1 for c in evasions if cases[c.id]["blocklist"] == "detected"
-                   or cases[c.id]["strict"] == "detected")
+    detected = sum(1 for c in evasions if is_caught(cases[c.id]))
 
     lines = [
         "# Does AIsbom catch it? — pickle-evasion scorecard",
@@ -638,7 +647,15 @@ def render_markdown(results: dict) -> str:
             case.description,
             "",
         ]
-        if case.limitation:
+        # A limitation describes why a case is *not* caught, so it stops being
+        # true the moment detection improves. Gate it on the live verdict rather
+        # than publishing unconditionally: `--write` would otherwise regenerate
+        # the document with a stale claim, and the staleness test cannot catch
+        # that because it compares the committed file against this same
+        # renderer. test_limitation_note_is_dropped_once_a_case_is_caught pins
+        # the gate; test_no_limitation_note_on_a_caught_case fails the build so
+        # the dead text gets removed rather than silently lingering here.
+        if case.limitation and not is_caught(cases[case.id]):
             lines += [f"**Current limitation:** {case.limitation}", ""]
 
     return "\n".join(lines).rstrip() + "\n"

--- a/aisbom/corpus.py
+++ b/aisbom/corpus.py
@@ -216,6 +216,11 @@ class BypassCase:
     builder: Callable[[Path], None]
     expected: str = "detected"
     malicious: bool = True
+    # Why this case is currently not fully caught, for cases that aren't.
+    # Deliberately does *not* change `expected`: every evasion technique here
+    # remains one a correct scanner should catch, so the gate keeps counting it
+    # against us. This field explains a gap; it never excuses one.
+    limitation: str | None = None
 
 
 @dataclass(frozen=True)
@@ -262,6 +267,15 @@ CASES: tuple[BypassCase, ...] = (
             "meant picklescan never opened it, while the model still loaded."
         ),
         builder=_build_nullifai_7z,
+        limitation=(
+            "AIsbom reports `CRITICAL (Non-Standard Container: 7z)` — the right severity, "
+            "but earned from the container rather than the payload. The archive is named, "
+            "never unpacked, so the `os.system` call inside is never disassembled and the "
+            "reported reason is not the real one. Unpacking 7z would mean a native "
+            "dependency in every install to cover one evasion class, which is not a "
+            "trade worth making; a user acting on this verdict is nonetheless correctly "
+            "warned off the file."
+        ),
     ),
     BypassCase(
         id="nullifai-broken-stream",
@@ -299,6 +313,14 @@ CASES: tuple[BypassCase, ...] = (
             "so nothing is scanned. Fixed in picklescan 0.0.22."
         ),
         builder=_build_nonstandard_extension,
+        limitation=(
+            "The only outright miss in the corpus: the scan reports `No AI models found` "
+            "and emits zero artifacts, so a user gets a clean run on a file carrying a "
+            "payload. Nothing subtle blocks this — discovery is extension-driven and "
+            "`.p` is not on the list. picklescan closed it in 0.0.22 and AIsbom has not, "
+            "which is precisely why the case stays on the scorecard at "
+            "`expected=detected`."
+        ),
     ),
     BypassCase(
         id="cve-2025-1944-zip-filename-tamper",
@@ -386,6 +408,17 @@ CASES: tuple[BypassCase, ...] = (
             "argument, so string-matching on the opcode argument sees nothing."
         ),
         builder=_build_shadowpickle,
+        limitation=(
+            "AIsbom does resolve STACK_GLOBAL and reads the pair off the stack, so it "
+            "sees `collections.OrderedDict` — and that name is legitimately allowlisted, "
+            "because real state_dicts are OrderedDicts. Both modes therefore return only "
+            "`MEDIUM (Pickle Present)`, the baseline every pickle gets, rather than a "
+            "signal specific to this file. This is the ceiling on static allowlist "
+            "analysis: the call is indistinguishable from a legitimate call to an "
+            "allowlisted global, and flagging the shape would flag ordinary checkpoints. "
+            "Closing it needs evidence beyond the resolved name — argument shape, or "
+            "provenance — not a new entry on a blocklist."
+        ),
     ),
 )
 
@@ -605,6 +638,8 @@ def render_markdown(results: dict) -> str:
             case.description,
             "",
         ]
+        if case.limitation:
+            lines += [f"**Current limitation:** {case.limitation}", ""]
 
     return "\n".join(lines).rstrip() + "\n"
 

--- a/docs/bypass-scorecard.md
+++ b/docs/bypass-scorecard.md
@@ -63,6 +63,8 @@ A normal state_dict with no dangerous sinks. Guards the other direction: a scann
 
 PyTorch's default container is ZIP; packing the same payload with 7z meant picklescan never opened it, while the model still loaded.
 
+**Current limitation:** AIsbom reports `CRITICAL (Non-Standard Container: 7z)` — the right severity, but earned from the container rather than the payload. The archive is named, never unpacked, so the `os.system` call inside is never disassembled and the reported reason is not the real one. Unpacking 7z would mean a native dependency in every install to cover one evasion class, which is not a trade worth making; a user acting on this verdict is nonetheless correctly warned off the file.
+
 ### `nullifai-broken-stream` — Deliberately broken pickle stream, payload first
 
 **Evasion class:** broken-stream  
@@ -86,6 +88,8 @@ Reaches execution through a global nobody thought to blocklist: pip.main() insta
 **A correct scanner should:** detected
 
 The pickle is named config.p. Extension-driven discovery never opens it, so nothing is scanned. Fixed in picklescan 0.0.22.
+
+**Current limitation:** The only outright miss in the corpus: the scan reports `No AI models found` and emits zero artifacts, so a user gets a clean run on a file carrying a payload. Nothing subtle blocks this — discovery is extension-driven and `.p` is not on the list. picklescan closed it in 0.0.22 and AIsbom has not, which is precisely why the case stays on the scorecard at `expected=detected`.
 
 ### `cve-2025-1944-zip-filename-tamper` — ZIP local-header filename differs from the central directory
 
@@ -142,3 +146,5 @@ Uses a submodule rather than the exact blocklisted module name, so an exact-matc
 **A correct scanner should:** detected
 
 Overwrites collections.OrderedDict — a name on essentially every scanner's allowlist — and resolves it via STACK_GLOBAL rather than an inline GLOBAL argument, so string-matching on the opcode argument sees nothing.
+
+**Current limitation:** AIsbom does resolve STACK_GLOBAL and reads the pair off the stack, so it sees `collections.OrderedDict` — and that name is legitimately allowlisted, because real state_dicts are OrderedDicts. Both modes therefore return only `MEDIUM (Pickle Present)`, the baseline every pickle gets, rather than a signal specific to this file. This is the ceiling on static allowlist analysis: the call is indistinguishable from a legitimate call to an allowlisted global, and flagging the shape would flag ordinary checkpoints. Closing it needs evidence beyond the resolved name — argument shape, or provenance — not a new entry on a blocklist.

--- a/tests/test_bypass_corpus.py
+++ b/tests/test_bypass_corpus.py
@@ -19,6 +19,7 @@ No pickle is ever executed — every case is disassembled statically.
 
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
 
@@ -296,6 +297,54 @@ def test_bypass_scorecard_surfaces_missing_dev_dependency(tmp_path, monkeypatch)
     result = runner.invoke(app, ["bypass-scorecard", "--output-dir", str(tmp_path)])
     assert result.exit_code == 1
     assert "py7zr is not installed" in result.output
+
+
+def test_no_limitation_note_on_a_caught_case(generated):
+    """
+    A limitation explains why a case is not caught. Once it is caught, the text
+    is false and must be removed from the case rather than left to rot.
+
+    Gating the renderer keeps a stale note out of the published document, but
+    silently — the dead prose would sit in corpus.py indefinitely. This fails
+    the build instead, so improving detection forces the cleanup.
+    """
+    _, results = generated
+    stale = [
+        case.id
+        for case in corpus.CASES
+        if case.limitation and corpus.is_caught(results["cases"][case.id])
+    ]
+    assert not stale, (
+        f"these cases are now caught but still carry a limitation note: {stale}. "
+        "Delete the `limitation=` text — the gap it describes is closed."
+    )
+
+
+def test_limitation_note_is_dropped_once_a_case_is_caught(generated):
+    """
+    The renderer must gate on the live verdict, not just on the field existing.
+
+    Without this, `--write` after a detection improvement republishes claims
+    like "reports No AI models found" about a case that is now detected, and
+    test_committed_scorecard_doc_is_not_stale stays green because it compares
+    the committed file against this same renderer.
+    """
+    _, results = generated
+    uncaught = next(
+        case
+        for case in corpus.CASES
+        if case.limitation and not corpus.is_caught(results["cases"][case.id])
+    )
+    assert case_note_in(corpus.render_markdown(results), uncaught)
+
+    promoted = copy.deepcopy(results)
+    promoted["cases"][uncaught.id] = {"blocklist": "detected", "strict": "detected"}
+    assert not case_note_in(corpus.render_markdown(promoted), uncaught)
+
+
+def case_note_in(markdown: str, case) -> bool:
+    """Whether the rendered scorecard carries this case's limitation note."""
+    return f"**Current limitation:** {case.limitation}" in markdown
 
 
 def test_committed_scorecard_doc_is_not_stale(generated):


### PR DESCRIPTION
## Why

The bypass scorecard exists because "we detect evasion technique X" is
unverifiable from outside the project. A *limitation* stated only in release-note
prose has the same problem.

While fact-checking the v1.3.0 announcement copy, one such claim didn't survive
checking. The release notes say the scorecard lists three uncaught cases
"including one that stays uncaught deliberately: the technique is
opcode-for-opcode indistinguishable from an ordinary PyTorch checkpoint, so any
rule catching it would flag essentially every real model."

`docs/bypass-scorecard.md` contradicts this. All 11 evasion cases are marked
**A correct scanner should: detected** — only the benign control expects `clean`.
There is no deliberately-uncaught case, and no justification for one anywhere in
`docs/`, `tests/corpus/`, or `corpus.py`. The specific claim is also checkable and
false: the shadowpickle replica is a protocol-4 `STACK_GLOBAL` + `REDUCE` call,
while the corpus's own benign control is a protocol-2 dict — different opcode
shapes.

## What this changes

An optional `limitation` field on `BypassCase`, rendered into the generated doc
as **Current limitation:**, populated for the three cases that aren't fully
caught. Each was written against the verdict the scanner actually returns,
observed by running it:

| Case | Actual verdict | Why that's the wrong reason |
|---|---|---|
| `shadowpickle-allowlist-overwrite` | `MEDIUM (Pickle Present)`, both modes | `STACK_GLOBAL` **is** resolved and `collections.OrderedDict` **is** legitimately allowlisted — real state_dicts are OrderedDicts. That verdict is the baseline every pickle gets, not a signal about this file. |
| `nullifai-7z-container` | `CRITICAL (Non-Standard Container: 7z)` | Right severity, earned from the container. The archive is never unpacked, so the `os.system` inside is never disassembled. |
| `cve-2025-1889-nonstandard-extension` | `No AI models found` | The one outright miss. `config.p` is never opened; zero artifacts, clean run on a file carrying a payload. |

The shadowpickle note is the substantive one, and it's a stronger statement than
the claim it replaces: the gap is the ceiling on static allowlist analysis — a
malicious call to an allowlisted global and a legitimate one are the same opcodes
— not a parsing failure.

## What this deliberately does not change

**No `expected` verdict moves, and no score moves.** Every evasion technique stays
at `expected=detected`, so the gate keeps counting all three against us.
`floor.json` and `baseline.json` are byte-identical after regeneration.

That restraint is the point. Adding an "accepted miss" tier would raise the
headline ratio by redefinition rather than detection, and would break the
property that makes `--check` meaningful. The field explains a gap; it never
excuses one — stated in a comment on the field so it survives future releases.

## Verification

- `aisbom bypass-scorecard --check` → exit 0, gate passed
- `pytest --cov=aisbom --cov-fail-under=85` → 677 passed, coverage 91.17%
- `git diff --exit-code tests/corpus/floor.json tests/corpus/baseline.json` → no change
- Diff is purely additive: +35 `corpus.py`, +6 generated doc, +2 `CHANGELOG.md`

## Follow-up (not in this PR)

The published v1.3.0 release body still carries the original claim. It needs
editing separately — the changelog is unaffected and already accurate.
