### PR TITLE
fix(scanner): scan single-file targets; fail on unusable ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- **Scanning a single model file works.** `aisbom scan model.pt` — the form this README documents for `--strict` and `--lint` — discovered nothing and exited `0`, because local discovery only ever enumerated the *contents of a directory*. A malicious file named directly on the command line reported "No AI models found" and passed clean, while the same file scanned via its parent directory was correctly CRITICAL. Single files are now first-class targets for every supported format, and a file gets the same verdict whichever way it is reached.
+- **An unusable scan target now fails instead of passing.** A path that does not exist (or a broken symlink, or a named file no scanner can read) previously produced an empty SBOM and exit `0` — indistinguishable from a genuinely clean repo, so a typo'd path in CI turned the gate green permanently. These now report what went wrong and exit `1`. `--no-fail-on-risk` does not suppress it: that flag governs risk findings, not a broken target. An empty directory is still a clean scan and still exits `0`.
+
 - **The bypass scorecard now publishes why each uncaught case is uncaught.** Cases that are not fully caught carry a `limitation` note, rendered into `docs/bypass-scorecard.md` alongside the verdict: what AIsbom actually reports, why that is the wrong reason, and what closing the gap would take. No case's `expected` verdict changes — every evasion technique in the corpus remains one a correct scanner should catch, so the gate keeps counting all three against us. The note explains a gap; it never excuses one.
 
 ## 1.3.0 — 2026-08-15

--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ xattr -d com.apple.quarantine aisbom-macos-*
 
 ## Common workflows
 
+### Scan targets and exit codes
+
+`scan` accepts a directory, a single model file, a `hf://` repo, or an HTTPS URL. A directory is walked recursively; a single file is scanned on its own.
+
+| Exit | Meaning |
+|---|---|
+| `0` | Scan completed, no CRITICAL risk |
+| `1` | The scan could not be completed — target missing or unreadable, a file failed to parse, or a remote fetch failed |
+| `2` | A **CRITICAL** risk was found (suppress with `--no-fail-on-risk`) |
+
+`--no-fail-on-risk` governs risk findings only. An unusable target still exits `1`, so a typo'd path in CI fails loudly instead of passing as a clean scan.
+
 ### Scan a Hugging Face model
 
 ```bash

--- a/aisbom/cli.py
+++ b/aisbom/cli.py
@@ -607,7 +607,11 @@ def scan(
             )
         console.print(table)
     else:
-        console.print("[yellow]No AI models found.[/yellow]")
+        # "No AI models found" is a claim about the target's contents, so it
+        # must not be printed when the target was never scanned at all (#125).
+        # The target error itself is rendered below.
+        if not any(e.get('target_error') for e in results['errors']):
+            console.print("[yellow]No AI models found.[/yellow]")
 
     # LINT OUTPUT (Migration Report)
     lint_failures = [a for a in results['artifacts'] if a.get('details', {}).get('lint_report')]
@@ -633,9 +637,20 @@ def scan(
     if results['dependencies']:
         console.print(f"\n📦 Found [bold]{len(results['dependencies'])}[/bold] Python libraries.")
 
-    # Parse errors only — fetch failures already printed their status-aware
-    # message to stderr above and don't fit the "Could not parse" framing.
-    parse_errors = [e for e in results['errors'] if not e.get('fetch_failure')]
+    # Unusable targets (#125): the path was missing or nothing could scan it,
+    # so nothing was examined. Printed to stderr like fetch failures — it is a
+    # failed instruction, not a finding about the model.
+    for err in [e for e in results['errors'] if e.get('target_error')]:
+        err_console.print(
+            f"[bold red]✖[/bold red] Cannot scan [yellow]{err['file']}[/yellow]: {err['error']}"
+        )
+
+    # Parse errors only — fetch failures and target errors already printed
+    # their own message to stderr and don't fit the "Could not parse" framing.
+    parse_errors = [
+        e for e in results['errors']
+        if not e.get('fetch_failure') and not e.get('target_error')
+    ]
     if parse_errors:
         console.print("\n[bold red]⚠️ Errors Encountered:[/bold red]")
         for err in parse_errors:

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -235,22 +235,38 @@ class DeepScanner:
                     continue
         else:
             root = Path(self.root_path)
-            for full_path in root.rglob("*"):
-                if full_path.is_file():
-                    ext = full_path.suffix.lower()
-
-                    if ext in PYTORCH_EXTENSIONS:
-                        self.artifacts.append(self._inspect_pytorch(full_path))
-                    elif ext == SAFETENSORS_EXTENSION:
-                        self.artifacts.append(self._inspect_safetensors(full_path))
-                    elif ext == GGUF_EXTENSION:
-                        self.artifacts.append(self._inspect_gguf(full_path))
-                    elif ext in KERAS_EXTENSIONS:
-                        self.artifacts.append(self._inspect_keras(full_path))
-                    elif ext == ONNX_EXTENSION:
-                        self.artifacts.append(self._inspect_onnx(full_path))
-                    elif full_path.name == REQUIREMENTS_FILENAME:
-                        self._parse_requirements(full_path)
+            # Path.rglob only ever yields the *contents* of a directory, so
+            # before #125 a file target (or a path that did not exist) walked
+            # nothing, recorded no error, and reported a clean scan — a
+            # malicious .pt named directly on the command line exited 0.
+            # Each local target shape is now handled explicitly.
+            if root.is_dir():
+                for full_path in root.rglob("*"):
+                    if full_path.is_file():
+                        # A tree legitimately contains non-model files; an
+                        # unclaimed file here is normal and stays silent.
+                        self._dispatch_local_file(full_path)
+            elif root.is_file():
+                # A single file is a first-class target: README documents
+                # `aisbom scan model.pkl --strict` and `aisbom scan model.pt
+                # --lint`. Unlike the walk above, the user named this exact
+                # file, so an inspector declining it is a failed instruction
+                # rather than an empty result.
+                if not self._dispatch_local_file(root):
+                    self._record_target_error(
+                        str(root),
+                        f"Unsupported file type '{root.suffix or root.name}' — no scanner claimed this file",
+                    )
+            else:
+                # Missing, a broken symlink, or not a regular file (fifo,
+                # socket, device). is_dir()/is_file() both follow symlinks,
+                # so a dangling link lands here and reads as missing.
+                self._record_target_error(
+                    str(root),
+                    "No such file or directory"
+                    if not root.exists()
+                    else "Not a regular file or directory",
+                )
 
         return {"artifacts": self.artifacts, "dependencies": self.dependencies, "errors": self.errors}
 
@@ -260,6 +276,46 @@ class DeepScanner:
         if target.startswith("http://") or target.startswith("https://"):
             return [target]
         return []
+
+    def _dispatch_local_file(self, full_path: Path) -> bool:
+        """Inspect one local file by extension.
+
+        Shared by the directory walk and the single-file target path so the
+        two cannot drift apart (#125). Returns True if an inspector claimed
+        the file; callers decide whether declining it is noteworthy.
+        """
+        ext = full_path.suffix.lower()
+
+        if ext in PYTORCH_EXTENSIONS:
+            self.artifacts.append(self._inspect_pytorch(full_path))
+        elif ext == SAFETENSORS_EXTENSION:
+            self.artifacts.append(self._inspect_safetensors(full_path))
+        elif ext == GGUF_EXTENSION:
+            self.artifacts.append(self._inspect_gguf(full_path))
+        elif ext in KERAS_EXTENSIONS:
+            self.artifacts.append(self._inspect_keras(full_path))
+        elif ext == ONNX_EXTENSION:
+            self.artifacts.append(self._inspect_onnx(full_path))
+        elif full_path.name == REQUIREMENTS_FILENAME:
+            self._parse_requirements(full_path)
+        else:
+            return False
+        return True
+
+    def _record_target_error(self, target: str, message: str) -> None:
+        """Record an unusable scan target as a structured, non-fatal error.
+
+        Lands in results['errors'] so the CLI's `errors → exit 1` path fires.
+        Tagged `target_error` to keep it out of both the fetch-failure
+        rendering (which expects a live exception) and the "Could not parse"
+        list — the target was never readable enough to parse. An empty
+        directory is *not* this: that is a legitimate clean scan.
+        """
+        self.errors.append({
+            "file": target,
+            "error": message,
+            "target_error": True,
+        })
 
     def _record_fetch_error(self, target: str, exc: Exception) -> None:
         """Record a remote fetch failure as a structured, non-fatal error.

--- a/tests/test_local_targets.py
+++ b/tests/test_local_targets.py
@@ -1,0 +1,206 @@
+"""Local scan-target shapes: a single file, a directory, and unusable paths.
+
+`Path.rglob` only ever yields the *contents* of a directory. The local branch
+of `DeepScanner.scan()` used it as its only discovery mechanism, so a target
+that was a regular file — or a path that did not exist at all — walked nothing,
+recorded no error, and produced a clean `exit 0`. A malicious `.pt` named
+directly on the command line reported "No AI models found" while the identical
+file scanned via its parent directory was correctly CRITICAL (#125).
+
+That is the worst possible failure mode for a CI gate: the tool reports success
+and emits a well-formed SBOM asserting zero components. These tests pin the
+distinction the fix rests on — *nothing to report* (an empty directory, exit 0)
+versus *nothing was examined* (an unusable target, exit 1) — since both used to
+look identical from the outside.
+
+The README documents the single-file form for both flagship security features
+(`aisbom scan model.pkl --strict`, `aisbom scan model.pt --lint`), so those
+invocations are covered explicitly rather than only via a directory.
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+from aisbom.cli import app
+from aisbom.mock_generator import create_mock_gguf, create_mock_restricted_file
+from aisbom.scanner import DeepScanner
+from tests.test_scanner_cli import _write_malicious_pt
+
+runner = CliRunner()
+
+
+def _unwrapped(text: str) -> str:
+    """Strip all whitespace so assertions survive rich's line wrapping.
+
+    Absolute temp paths are longer than the 80-column test terminal, and rich
+    breaks them mid-token, so a plain `path in output` check fails for a
+    message that rendered correctly.
+    """
+    return "".join(text.split())
+
+
+# --- a single file is a first-class target -------------------------------
+
+
+@pytest.mark.parametrize("flags", [[], ["--strict"], ["--lint"]])
+def test_single_malicious_file_target_is_critical(tmp_path, flags):
+    """The regression itself: a malicious file named directly must exit 2.
+
+    Parametrized over the two modes the README documents with a file target,
+    because the bug was in target discovery and so was mode-independent.
+    """
+    model = tmp_path / "mock_malware.pt"
+    _write_malicious_pt(model)
+
+    result = runner.invoke(app, ["scan", str(model), *flags])
+
+    assert result.exit_code == 2
+    assert "No AI models found" not in result.output
+
+
+def test_single_file_and_parent_directory_agree(tmp_path):
+    """A file must get the same verdict whichever way it is reached.
+
+    This is the invariant the bug broke, and the cheapest guard against the
+    file path and the directory walk drifting apart again.
+    """
+    _write_malicious_pt(tmp_path / "mock_malware.pt")
+
+    via_file = DeepScanner(str(tmp_path / "mock_malware.pt")).scan()
+    via_dir = DeepScanner(str(tmp_path)).scan()
+
+    assert len(via_file["artifacts"]) == len(via_dir["artifacts"]) == 1
+    assert via_file["artifacts"][0]["risk_level"] == via_dir["artifacts"][0]["risk_level"]
+    assert "CRITICAL" in via_file["artifacts"][0]["risk_level"]
+    assert via_file["errors"] == []
+
+
+@pytest.mark.parametrize(
+    "make_file, expected_name",
+    [
+        (create_mock_restricted_file, "mock_restricted.safetensors"),
+        (create_mock_gguf, "mock_restricted.gguf"),
+    ],
+)
+def test_single_file_target_works_for_every_format(tmp_path, make_file, expected_name):
+    """Single-file targets are not a PyTorch-only affordance."""
+    make_file(tmp_path)
+
+    results = DeepScanner(str(tmp_path / expected_name)).scan()
+
+    assert [a["name"] for a in results["artifacts"]] == [expected_name]
+    assert results["errors"] == []
+
+
+def test_single_requirements_file_target_parses_dependencies(tmp_path):
+    """`requirements.txt` is matched by name, so it works as a target too."""
+    reqs = tmp_path / "requirements.txt"
+    reqs.write_text("torch==2.1.0\nrequests>=2.0\n")
+
+    results = DeepScanner(str(reqs)).scan()
+
+    assert len(results["dependencies"]) == 2
+    assert results["errors"] == []
+
+
+# --- unusable targets are errors, not empty results ----------------------
+
+
+def test_nonexistent_target_is_an_error(tmp_path):
+    """Exit 1, and the message must name the path that could not be scanned."""
+    missing = tmp_path / "does-not-exist.pt"
+
+    result = runner.invoke(app, ["scan", str(missing)])
+
+    output = _unwrapped(result.output)
+    assert result.exit_code == 1
+    assert _unwrapped(str(missing)) in output
+    assert _unwrapped("Cannot scan") in output
+    assert _unwrapped("No such file or directory") in output
+    # The old behavior. It is a claim about the target's contents and must not
+    # appear when the target was never opened.
+    assert "No AI models found" not in result.output
+
+
+def test_nonexistent_target_records_a_structured_error(tmp_path):
+    results = DeepScanner(str(tmp_path / "nope")).scan()
+
+    assert len(results["errors"]) == 1
+    error = results["errors"][0]
+    assert error["target_error"] is True
+    assert "No such file or directory" in error["error"]
+    # Fetch-failure rendering expects a live exception; target errors must not
+    # be mistaken for one.
+    assert not error.get("fetch_failure")
+
+
+def test_unsupported_single_file_target_is_an_error(tmp_path):
+    """Naming a file no scanner claims is a failed instruction, not a result.
+
+    Distinct from the directory walk, where skipping a non-model file is
+    correct — see the sibling test below.
+    """
+    notes = tmp_path / "notes.txt"
+    notes.write_text("not a model\n")
+
+    result = runner.invoke(app, ["scan", str(notes)])
+
+    assert result.exit_code == 1
+    assert _unwrapped(str(notes)) in _unwrapped(result.output)
+    assert _unwrapped("Unsupported file type") in _unwrapped(result.output)
+
+
+def test_broken_symlink_target_is_an_error(tmp_path):
+    """`is_dir()`/`is_file()` follow symlinks, so a dangling link reads missing."""
+    link = tmp_path / "dangling"
+    link.symlink_to(tmp_path / "nowhere")
+
+    results = DeepScanner(str(link)).scan()
+
+    assert len(results["errors"]) == 1
+    assert results["errors"][0]["target_error"] is True
+
+
+# --- the other side of the line: genuinely clean scans stay exit 0 -------
+
+
+def test_empty_directory_is_still_a_clean_scan(tmp_path):
+    """Guard against over-correcting: nothing to report is not an error."""
+    result = runner.invoke(app, ["scan", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "No AI models found" in result.output
+
+
+def test_directory_walk_still_ignores_unsupported_files(tmp_path):
+    """A tree legitimately contains non-model files; that is not an error."""
+    (tmp_path / "README.md").write_text("# notes\n")
+    (tmp_path / "notes.txt").write_text("not a model\n")
+
+    results = DeepScanner(str(tmp_path)).scan()
+
+    assert results["artifacts"] == []
+    assert results["errors"] == []
+
+
+# --- interaction with the risk gate --------------------------------------
+
+
+def test_no_fail_on_risk_does_not_suppress_a_target_error(tmp_path):
+    """`--fail-on-risk` governs risk findings only, never a broken target.
+
+    A pipeline that opts out of risk-gating still needs to hear that its path
+    was wrong, otherwise the flag silently restores the original bug.
+    """
+    result = runner.invoke(app, ["scan", str(tmp_path / "gone"), "--no-fail-on-risk"])
+
+    assert result.exit_code == 1
+
+
+def test_no_fail_on_risk_still_clears_a_real_critical(tmp_path):
+    """The complement, so the test above cannot pass for the wrong reason."""
+    _write_malicious_pt(tmp_path / "mock_malware.pt")
+
+    result = runner.invoke(app, ["scan", str(tmp_path), "--no-fail-on-risk"])
+
+    assert result.exit_code == 0


### PR DESCRIPTION
## The bug

Local target discovery used `Path.rglob` as its only mechanism. `rglob` yields the *contents of a directory* and nothing else, so a target that was a regular file walked nothing, recorded no error, and exited `0`:

```
$ aisbom scan ./mock_malware.pt     # RCE via posix.system
No AI models found.
exit 0                              # ← silently clean

$ aisbom scan ./fixtures/           # same file, parent directory
mock_malware.pt  CRITICAL (RCE Detected: posix.system)
exit 2                              # ← correct
```

Same file, opposite verdicts. Reproduced in all three modes — default, `--strict`, `--lint`.

The README documents exactly that invocation for both flagship security features: `aisbom scan model.pkl --strict` and `aisbom scan model.pt --lint`. The two examples a security-conscious user is most likely to copy were the two that silently did nothing.

A nonexistent path failed the same way — empty-but-valid SBOM, exit `0`, indistinguishable from a genuinely clean repo. A typo'd path in CI turned the gate green permanently.

## The fix

Each local target shape is now handled explicitly:

- **A single file is a first-class target.** Dispatched through the same extension ladder as the walk, extracted into `_dispatch_local_file` so the two paths cannot drift apart again. Works for every supported format, not just PyTorch.
- **An unusable target is an error, not an empty result.** Missing paths, broken symlinks, and files no scanner claims record a structured `target_error` and exit `1`. `--no-fail-on-risk` does not suppress it — that flag governs risk findings, not a broken target.
- **`No AI models found` is withheld when nothing was examined.** It is a claim about the target's contents, so it must not appear when the target was never opened.

Deliberately unchanged: an empty directory is still a clean scan at exit `0`, and the directory walk still skips non-model files silently. Skipping a `README.md` inside a tree is correct; being handed one as *the* target is a failed instruction.

## Exit-code contract

| Exit | Meaning |
|---|---|
| `0` | Scan completed, no CRITICAL risk |
| `1` | Scan could not be completed — target missing/unreadable, parse failure, or remote fetch failure |
| `2` | CRITICAL risk found (suppress with `--no-fail-on-risk`) |

Only the `1` row is new for local targets; it matches what the remote fetch-failure path already does.

## Verification

- **694 passed**, coverage **91.25%** (was 679 / 91.17% — 15 new tests, no existing test changed).
- **The new tests were run against the unfixed code: 12 of 15 fail.** The 3 that pass are the deliberate guard-against-over-correction cases (empty directory, directory walk ignoring non-model files, `--no-fail-on-risk` still clearing a real CRITICAL), which must pass both before and after.
- **Full CLI snapshot diff against `main` shows exactly one change** — the missing-target case going `exit 0` → `exit 1` with its new message. Every other captured surface is byte-identical: `--help`/`--version`/`info`, `scan` in terminal/markdown/JSON/SPDX form, `--strict`, `--lint`, `--no-fail-on-risk`, `diff`, the unknown-flag error path, and the emitted CycloneDX and SPDX documents.
- **Bypass scorecard unchanged at 8/11**, gate passes. `cve-2025-1889-nonstandard-extension` shares the `No AI models found` symptom but is an extension-matching gap, not this bug, and its verdict did not move.
- **SBOM output valid on the new paths**: single-file scan emits a 1-component CycloneDX document (was 0) and a 1-package SPDX document; the target-error case still emits a valid 0-component document.
- **Frozen binary rebuilt and smoke-tested** (macOS arm64), since `binaries.yml` never runs on PRs: single malicious file → `2`, nonexistent → `1`, empty dir → `0`, fixtures dir → `2`, and `posix.system` still detected inside the bundle.

## Behavior change to be aware of

A path that previously exited `0` while scanning nothing now exits `1`. Any pipeline passing a file path was getting no scanning at all before this change, so nothing that genuinely worked is affected — but a pipeline that was silently green on a bad path will now fail, which is the point.

Closes the local-target side of this gap; the remote fetch-failure equivalent was fixed previously.
