### PR TITLE
fix(scanner): discover pickle payloads by content, not file extension

### DIFF
--- a/aisbom/corpus.py
+++ b/aisbom/corpus.py
@@ -313,14 +313,6 @@ CASES: tuple[BypassCase, ...] = (
             "so nothing is scanned. Fixed in picklescan 0.0.22."
         ),
         builder=_build_nonstandard_extension,
-        limitation=(
-            "The only outright miss in the corpus: the scan reports `No AI models found` "
-            "and emits zero artifacts, so a user gets a clean run on a file carrying a "
-            "payload. Nothing subtle blocks this — discovery is extension-driven and "
-            "`.p` is not on the list. picklescan closed it in 0.0.22 and AIsbom has not, "
-            "which is precisely why the case stays on the scorecard at "
-            "`expected=detected`."
-        ),
     ),
     BypassCase(
         id="cve-2025-1944-zip-filename-tamper",

--- a/aisbom/safety.py
+++ b/aisbom/safety.py
@@ -1149,3 +1149,64 @@ def looks_like_pickle_stream(data: bytes) -> bool:
     except Exception:
         return False
     return False
+
+
+class _NullWriter:
+    """Sink for `pickletools.dis`, which validates by writing a listing."""
+
+    def write(self, _text: str) -> None:
+        pass
+
+
+def head_looks_like_pickle(data: bytes) -> tuple[bool, bool]:
+    """Does the head of a file begin with a genuinely valid pickle?
+
+    Used by discovery on files no extension claimed, where the question is not
+    "what does this pickle import" but the earlier one: is this a pickle at
+    all? Getting that wrong in either direction is expensive — miss it and a
+    payload is invisible, over-claim it and every SBOM fills with phantom
+    components — so the bar here is deliberately higher than elsewhere.
+
+    Parsing as opcodes is *not* enough, and assuming it was is a trap worth
+    recording: `.` is the STOP opcode, so on a "reaches STOP" test every CSS
+    file that opens with a class selector is a pickle. Measured against a real
+    `node_modules`, that rule claimed JavaScript, stylesheets, TypeScript
+    declarations and a man page.
+
+    So the head must *validate*: `pickletools.dis` walks the stack, and a
+    pickle that pops from an empty stack or ends holding anything other than
+    one object is rejected. Validation runs against the prefix ending at the
+    first STOP rather than the whole buffer, so a payload followed by a corrupt
+    tail — the nullifAI shape — is still recognized instead of being thrown
+    out along with its own garbage.
+
+    Returns `(is_pickle, may_be_truncated)`. The second flag is the caller's
+    escalation signal: opcodes parsed cleanly but no STOP appeared, which is
+    what a real pickle larger than the read window looks like.
+
+    Disassembly only. The stream is never unpickled.
+    """
+    if not data:
+        return (False, False)
+
+    stop_at = None
+    parsed = 0
+    try:
+        for opcode, _arg, pos in pickletools.genops(io.BytesIO(data)):
+            parsed += 1
+            if opcode.name == "STOP":
+                stop_at = pos + 1
+                break
+    except Exception:
+        pass
+
+    if stop_at is None:
+        # No complete pickle in view. Worth a bigger read only if something
+        # actually parsed; a file that yielded nothing is simply not a pickle.
+        return (False, parsed > 0)
+
+    try:
+        pickletools.dis(io.BytesIO(data[:stop_at]), out=_NullWriter())
+    except Exception:
+        return (False, False)
+    return (True, False)

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -13,6 +13,7 @@ from aisbom import protobuf_reader as pb
 from aisbom.safety import (
     PICKLE_SCAN_INCOMPLETE,
     _threat_kind as _jinja_threat_kind,
+    head_looks_like_pickle,
     jinja_threats_are_critical,
     looks_like_pickle_stream,
     onnx_domain_is_custom,
@@ -43,6 +44,20 @@ PICKLE_VARIANT_EXTENSIONS = {'.pkl', '.pickle', '.joblib', '.dill', '.npy', '.np
 # HTTP Range request per call and gets the tighter one.
 PICKLE_VARIANT_MAX_SCAN_BYTES = 16 * 1024 * 1024
 PICKLE_VARIANT_MAX_REMOTE_SCAN_BYTES = 2 * 1024 * 1024
+
+# Discovery by content, for files no extension claims (CVE-2025-1889). The
+# attacker names the file, so the suffix cannot be the thing that decides
+# whether we look inside it. Every unclaimed file gets its head disassembled.
+#
+# The first read is small because it is paid on *every* unclaimed file in a
+# tree — the READMEs, the parquet, the images. Non-pickles are rejected here
+# for a few kilobytes: they hold no valid pickle and are never re-read.
+PICKLE_SNIFF_BYTES = 64 * 1024
+# A head that *did* parse opcodes cleanly and then ran out of data may be a
+# real pickle whose STOP sits past the window, so it earns a larger read. The
+# ceiling is the variant inspector's own budget on purpose: discovery is
+# exactly as far-sighted as the inspection that follows it, never further.
+PICKLE_SNIFF_MAX_BYTES = PICKLE_VARIANT_MAX_SCAN_BYTES
 
 # How many members of an `.npz` are opened. An archive is attacker-controlled,
 # so the member count is bounded like every other declared length.
@@ -325,9 +340,58 @@ class DeepScanner:
             self.artifacts.append(self._inspect_pickle_variant(full_path))
         elif full_path.name == REQUIREMENTS_FILENAME:
             self._parse_requirements(full_path)
+        elif self._sniff_is_pickle(full_path):
+            # Nothing claimed this file by name, but its bytes read as a
+            # pickle. This is the CVE-2025-1889 class: `config.p`, `weights.dat`,
+            # a file with no extension at all. The inspector below already
+            # decides what a file *is* from its contents rather than its
+            # suffix — only discovery was still trusting the name.
+            self.artifacts.append(self._inspect_pickle_variant(full_path))
         else:
             return False
         return True
+
+    def _sniff_is_pickle(self, full_path: Path) -> bool:
+        """Decide by content whether an unclaimed file is a pickle.
+
+        Reads a small head first and gives up on it unless opcodes actually
+        parsed, which is what keeps a walk over a tree full of parquet and PNGs
+        cheap: those yield zero opcodes and are never opened a second time.
+
+        Known limit, stated rather than hidden: a pickle whose *first* opcode
+        carries an argument longer than the whole sniff budget parses zero
+        opcodes here and is not discovered by content. Reaching that requires
+        a single 16MB-plus literal ahead of the payload. Files carrying a
+        recognized model extension are unaffected — they never reach this path.
+        """
+        try:
+            size = full_path.stat().st_size
+        except OSError:
+            return False
+        if not size:
+            return False
+
+        budget = PICKLE_SNIFF_BYTES
+        while True:
+            try:
+                with open(full_path, "rb") as handle:
+                    head = handle.read(min(budget, PICKLE_SNIFF_MAX_BYTES))
+            except OSError:
+                return False
+
+            verdict, truncated = head_looks_like_pickle(head)
+            if verdict:
+                return True
+            # Settled: either the head held a complete pickle and it failed
+            # validation, or nothing parsed at all. Reading more cannot change
+            # the answer. This is the branch nearly every file in a real
+            # repository takes.
+            if not truncated:
+                return False
+            # We saw the whole file, or spent the budget.
+            if len(head) >= size or budget >= PICKLE_SNIFF_MAX_BYTES:
+                return False
+            budget *= 8
 
     def _record_target_error(self, target: str, message: str) -> None:
         """Record an unusable scan target as a structured, non-fatal error.

--- a/docs/bypass-scorecard.md
+++ b/docs/bypass-scorecard.md
@@ -7,7 +7,7 @@ past a model scanner, reproduced here as an inert artifact and scanned with
 AIsbom's own engine. Artifacts are synthesized, never copied from live malware,
 and are only ever disassembled — no pickle in this corpus is executed.
 
-**8 of 11** evasion cases are caught in at least one scan mode.
+**9 of 11** evasion cases are caught in at least one scan mode.
 
 `blocklist` is the default mode (flag known-dangerous globals); `strict` is
 `--strict` (allowlist — anything unrecognized is flagged). A ⚠️ partial means
@@ -21,7 +21,7 @@ reports the wrong reason.
 | `nullifai-7z-container`<br>Model packed with 7z instead of ZIP | container-format | ⚠️ partial | ⚠️ partial | [ReversingLabs — nullifAI (malicious models on Hugging Face)](https://www.reversinglabs.com/blog/rl-identifies-malware-ml-model-hosted-on-hugging-face) |
 | `nullifai-broken-stream`<br>Deliberately broken pickle stream, payload first | broken-stream | ✅ detected | ✅ detected | [ReversingLabs — nullifAI (malicious models on Hugging Face)](https://www.reversinglabs.com/blog/rl-identifies-malware-ml-model-hosted-on-hugging-face) |
 | `cve-2025-1716-pip-main`<br>Code execution via pip.main() | unlisted-global | ✅ detected | ✅ detected | [Sonatype — CVE-2025-1716](https://www.sonatype.com/security-advisories/cve-2025-1716) |
-| `cve-2025-1889-nonstandard-extension`<br>Payload in a file with a non-standard extension | file-extension | ❌ missed | ❌ missed | [Sonatype — CVE-2025-1889](https://www.sonatype.com/security-advisories/cve-2025-1889) |
+| `cve-2025-1889-nonstandard-extension`<br>Payload in a file with a non-standard extension | file-extension | ✅ detected | ✅ detected | [Sonatype — CVE-2025-1889](https://www.sonatype.com/security-advisories/cve-2025-1889) |
 | `cve-2025-1944-zip-filename-tamper`<br>ZIP local-header filename differs from the central directory | zip-tampering | ✅ detected | ✅ detected | [Sonatype — CVE-2025-1944](https://www.sonatype.com/security-advisories/cve-2025-1944) |
 | `cve-2025-1945-zip-flag-bits`<br>ZIP general-purpose flag bits modified | zip-tampering | ✅ detected | ✅ detected | [Sonatype — CVE-2025-1945](https://www.sonatype.com/security-advisories/cve-2025-1945) |
 | `cve-2025-10155-extension-confusion`<br>Bare pickle wearing a PyTorch extension | file-extension | ✅ detected | ✅ detected | [JFrog — CVE-2025-10155](https://jfrog.com/blog/unveiling-3-zero-day-vulnerabilities-in-picklescan/) |
@@ -88,8 +88,6 @@ Reaches execution through a global nobody thought to blocklist: pip.main() insta
 **A correct scanner should:** detected
 
 The pickle is named config.p. Extension-driven discovery never opens it, so nothing is scanned. Fixed in picklescan 0.0.22.
-
-**Current limitation:** The only outright miss in the corpus: the scan reports `No AI models found` and emits zero artifacts, so a user gets a clean run on a file carrying a payload. Nothing subtle blocks this — discovery is extension-driven and `.p` is not on the list. picklescan closed it in 0.0.22 and AIsbom has not, which is precisely why the case stays on the scorecard at `expected=detected`.
 
 ### `cve-2025-1944-zip-filename-tamper` — ZIP local-header filename differs from the central directory
 

--- a/tests/corpus/baseline.json
+++ b/tests/corpus/baseline.json
@@ -29,8 +29,8 @@
       "strict": "detected"
     },
     "cve-2025-1889-nonstandard-extension": {
-      "blocklist": "missed",
-      "strict": "missed"
+      "blocklist": "detected",
+      "strict": "detected"
     },
     "cve-2025-1944-zip-filename-tamper": {
       "blocklist": "detected",

--- a/tests/corpus/floor.json
+++ b/tests/corpus/floor.json
@@ -29,8 +29,8 @@
       "strict": "detected"
     },
     "cve-2025-1889-nonstandard-extension": {
-      "blocklist": "missed",
-      "strict": "missed"
+      "blocklist": "detected",
+      "strict": "detected"
     },
     "cve-2025-1944-zip-filename-tamper": {
       "blocklist": "detected",

--- a/tests/test_content_discovery.py
+++ b/tests/test_content_discovery.py
@@ -1,0 +1,240 @@
+"""Discovery by content, for files no extension claims.
+
+The scanner used to decide what to open purely from a file's suffix. That is
+the whole of CVE-2025-1889: name the payload `config.p` and nothing ever opens
+it, so the scan reports "No AI models found" and exits 0 — a clean bill of
+health on a directory carrying a reverse shell.
+
+Adding `.p` to the extension list would flip the published corpus case and fix
+nothing, because the technique is *any* unexpected suffix, not that one. The
+attacker picks the name; we do not get to enumerate their choices. So an
+unclaimed file is now sniffed by its bytes.
+
+Two directions are tested here and both matter equally. Missing a payload is
+the bug we are closing; claiming ordinary repository files as models would be
+a worse one, because it would put noise in every SBOM and train users to
+ignore findings. The false-positive half of this file is not padding.
+
+Nothing is ever unpickled. Sniffing is `pickletools` disassembly plus the
+stack validation `pickletools.dis` performs — the same read-only path the rest
+of the scanner uses. Parsing as opcodes alone proved far too weak a test; see
+the real-world false positives at the bottom of this file.
+"""
+
+import pytest
+
+from aisbom.mock_generator import (
+    harmless_reduce_pickle,
+    harmless_stack_global_pickle,
+)
+from aisbom.scanner import DeepScanner
+
+
+def scan_dir(tmp_path, name, blob, strict=False):
+    """Write one file into its own directory and scan the directory."""
+    holder = tmp_path / f"holder_{name.replace('/', '_')}"
+    holder.mkdir(exist_ok=True)
+    (holder / name).write_bytes(blob)
+    return DeepScanner(str(holder), strict_mode=strict).scan()
+
+
+def artifacts_of(results):
+    return results["artifacts"]
+
+
+# --- the evasion class: any suffix at all ---------------------------------
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "config.p",          # the CVE-2025-1889 proof of concept verbatim
+        "payload.dat",       # the same trick with a different suffix
+        "weights.model",     # plausible-looking, still unlisted
+        "checkpoint.bin.1",  # a rotated/suffixed name
+        "state.cfg",         # wearing a config file's clothes
+        "blob",              # no extension at all
+        ".hidden",           # dotfile: suffix parsing must not swallow it
+    ],
+)
+def test_a_payload_is_found_whatever_the_file_is_called(tmp_path, filename):
+    """The fix has to close the class, not the one filename in the CVE."""
+    results = scan_dir(tmp_path, filename, harmless_reduce_pickle("os", "system"))
+    found = artifacts_of(results)
+    assert len(found) == 1, found
+    assert "CRITICAL" in found[0]["risk_level"]
+    assert "os.system" in found[0]["risk_level"]
+
+
+def test_a_protocol_4_payload_is_found_under_an_odd_name(tmp_path):
+    """Protocol 0 is printable ASCII; protocol 4 is binary. Both must sniff."""
+    results = scan_dir(tmp_path, "payload.dat", harmless_stack_global_pickle("os", "system"))
+    found = artifacts_of(results)
+    assert len(found) == 1, found
+    assert "CRITICAL" in found[0]["risk_level"]
+
+
+def test_a_sniffed_file_is_claimed_as_a_single_file_target(tmp_path):
+    """`aisbom scan payload.dat` — named directly, not found by a walk."""
+    target = tmp_path / "payload.dat"
+    target.write_bytes(harmless_reduce_pickle("os", "system"))
+    results = DeepScanner(str(target)).scan()
+    assert results["errors"] == []
+    assert len(results["artifacts"]) == 1
+    assert "CRITICAL" in results["artifacts"][0]["risk_level"]
+
+
+def test_a_sniffed_payload_is_flagged_in_strict_mode_too(tmp_path):
+    results = scan_dir(tmp_path, "payload.dat", harmless_reduce_pickle("os", "system"), strict=True)
+    found = artifacts_of(results)
+    assert len(found) == 1, found
+    assert "CRITICAL" in found[0]["risk_level"]
+
+
+# --- the other direction: ordinary files stay unclaimed -------------------
+
+ORDINARY_FILES = [
+    ("README.md", b"# A project\n\nSome prose about the project.\n"),
+    ("config.json", b'{\n  "name": "demo",\n  "version": 2\n}\n'),
+    ("notes.txt", b"Nothing here. Consider the following list:\n- one\n- two\n"),
+    ("train.py", b"import torch\n\n\ndef main():\n    print('hi')\n"),
+    ("data.csv", b"col_a,col_b\n1,2\n3,4\n"),
+    ("logo.png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 512),
+    ("archive.tar", b"\x00" * 1024),
+    ("empty", b""),
+    ("LICENSE", b"MIT License\n\nCopyright (c) 2026\n"),
+    ("Makefile", b"all:\n\tcargo build\n"),
+    ("index.html", b"<!doctype html>\n<html><body>hi</body></html>\n"),
+    ("script.sh", b"#!/bin/sh\nset -eu\necho hello\n"),
+]
+
+
+@pytest.mark.parametrize("filename,blob", ORDINARY_FILES, ids=[f[0] for f in ORDINARY_FILES])
+def test_ordinary_repository_files_are_not_claimed_as_models(tmp_path, filename, blob):
+    """A scanner that flags everything is as useless as one that flags nothing.
+
+    These are the files that sit beside a model in every real repository. If
+    sniffing claims them, every SBOM gains phantom components and the finding
+    list stops meaning anything.
+    """
+    results = scan_dir(tmp_path, filename, blob)
+    assert artifacts_of(results) == []
+
+
+def test_a_text_file_beginning_with_a_valid_opcode_byte_is_not_claimed(tmp_path):
+    """`c` is the GLOBAL opcode and also how a great many words start.
+
+    The sniff must be a real disassembly, not a first-byte guess, or every
+    `config.yaml` and `changelog.md` in the tree becomes a model.
+    """
+    for text in (b"changelog for the project\n", b"config values follow\n",
+                 b"Nothing to see\n", b"Some notes\n", b"Installation guide\n"):
+        results = scan_dir(tmp_path, "doc_%d.txt" % len(text), text)
+        assert artifacts_of(results) == [], text
+
+
+def test_requirements_are_still_parsed_as_dependencies(tmp_path):
+    """The named-file branch must keep winning over the sniff."""
+    results = scan_dir(tmp_path, "requirements.txt", b"torch==2.4.0\nnumpy==1.26.4\n")
+    assert artifacts_of(results) == []
+    assert len(results["dependencies"]) == 2
+
+
+def test_an_unusable_named_target_is_still_an_error(tmp_path):
+    """`aisbom scan notes.txt` must still fail loudly rather than sniff-and-shrug."""
+    target = tmp_path / "notes.txt"
+    target.write_bytes(b"just some prose\n")
+    results = DeepScanner(str(target)).scan()
+    assert results["artifacts"] == []
+    assert len(results["errors"]) == 1
+
+
+# --- cost: the walk must not read whole files to decide -------------------
+
+def test_a_large_unclaimed_file_is_not_read_in_full(tmp_path):
+    """Sniffing happens on a bounded head read.
+
+    A repository can hold gigabytes of parquet, checkpoints and archives that
+    no inspector wants. Deciding "not a pickle" must cost a few kilobytes per
+    file, not the whole file, or the walk becomes unusable on real trees.
+    """
+    from aisbom import scanner as scanner_mod
+
+    holder = tmp_path / "big"
+    holder.mkdir()
+    big = holder / "dataset.parquet"
+    big.write_bytes(b"PAR1" + b"\x00" * (4 * 1024 * 1024))
+
+    reads = []
+    real_open = open
+
+    def counting_open(path, *args, **kwargs):
+        handle = real_open(path, *args, **kwargs)
+        if str(path) == str(big):
+            real_read = handle.read
+
+            def tracked(size=-1):
+                data = real_read(size)
+                reads.append(len(data))
+                return data
+
+            handle.read = tracked
+        return handle
+
+    scanner_mod.open = counting_open
+    try:
+        results = DeepScanner(str(holder)).scan()
+    finally:
+        del scanner_mod.open
+
+    assert artifacts_of(results) == []
+    assert reads, "the file was never opened, so the sniff did not run"
+    assert max(reads) <= scanner_mod.PICKLE_SNIFF_BYTES
+
+
+# --- the trap that a real tree caught ------------------------------------
+
+# Found by scanning an actual `node_modules` (5,101 files) rather than by
+# imagination: an earlier version of this sniff accepted anything that parsed
+# as opcodes and reached STOP, and claimed eleven files. `.` *is* the STOP
+# opcode, so a stylesheet opening with a class selector was a one-opcode
+# "pickle". These are the real filenames and shapes that were wrongly claimed.
+REAL_WORLD_FALSE_POSITIVES = [
+    ("prettify.css", b".com{color:#93a1a1}.str{color:#2aa198}\n"),
+    ("marked.1", b".TH marked 1 \"2026\"\n.SH NAME\nmarked \\- a markdown parser\n"),
+    ("index.d.ts", b"export declare function parse(s: string): string;\n"),
+    ("threads.js", b"'use strict';\nmodule.exports = { run() { return 1; } };\n"),
+    ("cli-api.js", b"export { createCli } from './cli.js';\n"),
+    ("node.js", b"process.exit(0);\n"),
+]
+
+
+@pytest.mark.parametrize(
+    "filename,blob", REAL_WORLD_FALSE_POSITIVES, ids=[f[0] for f in REAL_WORLD_FALSE_POSITIVES]
+)
+def test_files_that_a_weaker_sniff_wrongly_claimed(tmp_path, filename, blob):
+    results = scan_dir(tmp_path, filename, blob)
+    assert artifacts_of(results) == []
+
+
+def test_a_lone_stop_opcode_is_not_a_pickle(tmp_path):
+    """`.` parses and reaches STOP, but pops from an empty stack.
+
+    This single byte is the whole reason the sniff validates the stack instead
+    of trusting the disassembler's syntax walk.
+    """
+    results = scan_dir(tmp_path, "styles.css", b".")
+    assert artifacts_of(results) == []
+
+
+def test_a_valid_payload_followed_by_a_corrupt_tail_is_still_found(tmp_path):
+    """The nullifAI shape, wearing an unlisted extension.
+
+    Validation runs on the prefix ending at the first STOP, so garbage after a
+    complete pickle does not get the file thrown out along with it. Truncating
+    the stream is otherwise a way to opt out of being scanned.
+    """
+    blob = harmless_reduce_pickle("os", "system") + b"\x00\xff\xfe garbage tail \x01"
+    results = scan_dir(tmp_path, "payload.dat", blob)
+    found = artifacts_of(results)
+    assert len(found) == 1, found
+    assert "CRITICAL" in found[0]["risk_level"]


### PR DESCRIPTION
## The gap

Discovery decided what to open from a file's suffix alone. That is the whole of [CVE-2025-1889](https://www.sonatype.com/security-advisories/cve-2025-1889): name the payload `config.p` and nothing ever opens it, so the scan reports `No AI models found` and **exits 0** — a clean bill of health on a directory carrying a reverse shell.

The inspector was never the problem. `_inspect_pickle_variant` already decides what a file *is* from its bytes. Only discovery still trusted the name.

## Why not just add `.p`

Because it protects nobody. The technique is *any* unexpected suffix — the attacker picks the name — so a one-line extension addition would flip the published corpus case while leaving `weights.dat` wide open. That is exactly the laundering `tests/corpus/floor.json` exists to prevent.

## What landed

Unclaimed files are sniffed by content, and the bar is deliberately high in **both** directions. A missed payload is the bug being closed; claiming ordinary repository files as models would be worse, filling every SBOM with phantom components until findings stop meaning anything.

**Parsing as opcodes proved far too weak a test.** `.` is the STOP opcode, so on a "reaches STOP" rule every stylesheet opening with a class selector is a one-opcode pickle. Measured against a real 5,101-file `node_modules`, that first rule claimed **11 files** — 5 JavaScript/TypeScript files, a stylesheet, a man page. The sniff now validates the pickle stack via `pickletools.dis`, and those six filenames are regression tests in `tests/test_content_discovery.py`.

Validation runs on the prefix ending at the first STOP rather than the whole buffer, so a payload followed by a corrupt tail — the nullifAI shape — is still recognized instead of being discarded along with its own garbage.

Reads are bounded: 64KB per unclaimed file, escalating only when opcodes parsed cleanly and no STOP appeared, capped at the variant inspector's own budget so discovery is exactly as far-sighted as the inspection that follows it.

**Known limit, stated rather than hidden:** a pickle whose *first* opcode carries an argument longer than the entire sniff budget parses nothing here and is not discovered by content. Reaching that needs a single 16MB-plus literal ahead of the payload.

## Scorecard

**8/11 → 9/11.** `cve-2025-1889-nonstandard-extension` moves from `missed` to `detected` in both modes; the floor is raised accordingly, locking it in.

## Verification

- `poetry run pytest` — **824 passed, 91.38% coverage** (gate 85%).
- `aisbom bypass-scorecard --check` — gate green at 9/11.
- **False positives, 7 real source trees** (site, SPA, shared, package, scripts, docs, product): **0 artifacts**.
- **False positives, 5,101-file `node_modules`**: 11 → **0**.
- **Cost**: that same walk takes **1.52s** and claims nothing — no regression against the pre-change 1.72s.
- End to end: a directory of `config.p`, `payload.dat`, `weights.model` and `blob` reports all four as `CRITICAL (RCE Detected: os.system)` and exits **2**; `README.md` and `settings.json` beside them stay unclaimed.
