### PR TITLE
fix(scanner): re-read when a large first argument hid the pickle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+- **A 64KB literal ahead of a payload no longer hides it from discovery.** v1.3.2 identifies unclaimed files by content, reading a 64KB head and re-reading with a larger budget only when that head looked like an unfinished pickle. The signal for "unfinished" was *at least one opcode parsed* — and a pickle that opens with a single literal bigger than the first read completes **no** opcodes, so the larger read never happened and the file was never discovered.
+
+  The practical effect: the limit v1.3.2 documented as needing "a 16MB-plus literal" was in fact reachable with roughly **64KB**. Measured on the released code, a 65,000-byte pad was caught and a 70,000-byte pad was not.
+
+  Discovery now also re-reads when the first opcode declares an argument that runs past the buffer. Length-prefixed arguments are read exactly; newline-terminated ones are admitted only for the few opcodes that can genuinely begin a pickle, and only when the following byte matches what that opcode's argument must start with — which is what keeps a parquet file (`PAR1`, where `P` is a valid opcode byte) from being re-read to the cap. The documented 16MB ceiling is now the real one: verified caught at 16,773,120 bytes and not discovered at 16,781,312.
+
+  Only affects files whose extension nothing claims. A padded payload under a recognized extension was always caught.
+
 ## 1.3.2 — 2026-08-18
 
 > **New components in your SBOM.** Five extensions that were previously skipped are now scanned, *and* files carrying no recognized extension at all are now opened when their bytes are a pickle — so a repo containing them will produce more components than before and may newly exit `2`. Nothing that was already scanned changes verdict — the old-vs-new differential across the bypass corpus and 134 fixture verdicts is empty in both modes. The scorecard moves from 8/11 to 9/11.

--- a/aisbom/safety.py
+++ b/aisbom/safety.py
@@ -1158,6 +1158,77 @@ class _NullWriter:
         pass
 
 
+# Opcodes whose argument runs to a newline and can plausibly *start* a real
+# pickle while carrying a lot of bytes. Each maps to the characters its
+# argument legitimately begins with, so a file is only re-read when its second
+# byte is consistent with the opcode its first byte claims to be.
+#
+# This guard is why a parquet file is not re-read: it opens `PAR1`, and while
+# `P` is the PERSID opcode, PERSID is not on this list — no real pickle starts
+# with a persistent id, and accepting it would mean re-reading every parquet,
+# ORC and arrow file in a tree up to the sniff cap.
+_NEWLINE_ARG_STARTS = {
+    "S": b"'\"",                  # STRING — always quoted
+    "V": None,                    # UNICODE — raw text, no reliable lead byte
+    "I": b"0123456789+-",         # INT
+    "L": b"0123456789+-",         # LONG
+    "F": b"0123456789+-.",        # FLOAT
+}
+
+
+def _first_argument_overruns(data: bytes) -> bool:
+    """Does `data`'s first opcode declare an argument longer than `data`?
+
+    Discovery reads a bounded head and only re-reads when the head looked like
+    an unfinished pickle. "At least one opcode parsed" is the usual signal, but
+    a pickle that opens with a single huge literal completes *no* opcodes — so
+    without this check a payload hidden behind one 64KB literal is never found,
+    while the documented limit claims 16MB. Measured before it was fixed: a
+    65,000-byte pad was caught and a 70,000-byte pad was not.
+
+    Length-prefixed arguments are read exactly. Newline-terminated ones cannot
+    be measured without the newline, so they are admitted only for the handful
+    of opcodes that can really begin a pickle, and only when the following byte
+    matches what that opcode's argument must start with.
+    """
+    if not data:
+        return False
+    op = pickletools.code2op.get(chr(data[0]))
+    if op is None or op.arg is None:
+        return False
+
+    n = op.arg.n
+    if n >= 0:
+        # A fixed-width argument. These are a handful of bytes; they cannot be
+        # what overran a 64KB read.
+        return False
+
+    if n == pickletools.UP_TO_NEWLINE:
+        if op.code not in _NEWLINE_ARG_STARTS:
+            return False
+        if b"\n" in data:
+            # The terminator is already in view, so the argument is not what
+            # ran off the end — something else failed, and re-reading will not
+            # change that.
+            return False
+        lead = _NEWLINE_ARG_STARTS[op.code]
+        return lead is None or (len(data) > 1 and data[1] in lead)
+
+    # Length-prefixed: read the declared size and believe it only far enough to
+    # decide whether a bigger read would reach the end of the argument.
+    widths = {
+        pickletools.TAKEN_FROM_ARGUMENT1: 1,
+        pickletools.TAKEN_FROM_ARGUMENT4: 4,
+        pickletools.TAKEN_FROM_ARGUMENT4U: 4,
+        pickletools.TAKEN_FROM_ARGUMENT8U: 8,
+    }
+    width = widths.get(n)
+    if width is None or len(data) < 1 + width:
+        return False
+    declared = int.from_bytes(data[1 : 1 + width], "little")
+    return 1 + width + declared > len(data)
+
+
 def head_looks_like_pickle(data: bytes) -> tuple[bool, bool]:
     """Does the head of a file begin with a genuinely valid pickle?
 
@@ -1201,9 +1272,11 @@ def head_looks_like_pickle(data: bytes) -> tuple[bool, bool]:
         pass
 
     if stop_at is None:
-        # No complete pickle in view. Worth a bigger read only if something
-        # actually parsed; a file that yielded nothing is simply not a pickle.
-        return (False, parsed > 0)
+        # No complete pickle in view. Worth a bigger read if something parsed
+        # — or if nothing parsed *because* the very first opcode carries an
+        # argument that runs off the end of the buffer, which is the one way a
+        # genuine pickle yields no opcodes at all.
+        return (False, parsed > 0 or _first_argument_overruns(data))
 
     try:
         pickletools.dis(io.BytesIO(data[:stop_at]), out=_NullWriter())

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -354,15 +354,23 @@ class DeepScanner:
     def _sniff_is_pickle(self, full_path: Path) -> bool:
         """Decide by content whether an unclaimed file is a pickle.
 
-        Reads a small head first and gives up on it unless opcodes actually
-        parsed, which is what keeps a walk over a tree full of parquet and PNGs
-        cheap: those yield zero opcodes and are never opened a second time.
+        Reads a small head first and re-reads with a larger budget only when
+        that head looked like an unfinished pickle, which is what keeps a walk
+        over a tree full of parquet and PNGs cheap: those settle on the first
+        read and are never opened a second time.
 
-        Known limit, stated rather than hidden: a pickle whose *first* opcode
-        carries an argument longer than the whole sniff budget parses zero
-        opcodes here and is not discovered by content. Reaching that requires
-        a single 16MB-plus literal ahead of the payload. Files carrying a
-        recognized model extension are unaffected — they never reach this path.
+        Two things can leave a head unfinished, and both must count. Opcodes
+        may parse cleanly without reaching STOP — an ordinary large pickle. Or
+        *no* opcode completes because the first one carries an argument running
+        past the buffer; `_first_argument_overruns` recognizes that case. The
+        original rule counted only the first, so one 64KB literal ahead of a
+        payload hid it from discovery entirely while the documented limit
+        claimed 16MB.
+
+        Known limit, stated rather than hidden: past PICKLE_SNIFF_MAX_BYTES we
+        stop looking, so a payload behind a literal larger than that is not
+        discovered by content. Files carrying a recognized model extension are
+        unaffected — they never reach this path.
         """
         try:
             size = full_path.stat().st_size

--- a/tests/test_content_discovery.py
+++ b/tests/test_content_discovery.py
@@ -238,3 +238,99 @@ def test_a_valid_payload_followed_by_a_corrupt_tail_is_still_found(tmp_path):
     found = artifacts_of(results)
     assert len(found) == 1, found
     assert "CRITICAL" in found[0]["risk_level"]
+
+
+# --- large first argument: the escalation gap ----------------------------
+
+# Discovery reads a small head, then re-reads with a larger budget only when
+# the head looked like an unfinished pickle. The first version of that rule
+# used "at least one opcode parsed" as the signal, which a pickle can defeat
+# by opening with a single literal bigger than the first read: zero opcodes
+# complete, so no re-read ever happens.
+#
+# Measured, not assumed -- a 65,000-byte pad was found and a 70,000-byte pad
+# was not, so the real bound was the 64KB first read rather than the documented
+# 16MB ceiling. These tests pin the ceiling to what we actually claim.
+
+def padded_first_literal(pad_bytes, proto0=True):
+    """A valid pickle whose FIRST opcode is one huge literal, then the payload.
+
+    Protocol 0 uses a quoted STRING; the binary form uses a length-prefixed
+    BINBYTES. Both are popped, so the stream ends holding exactly one object
+    and is a structurally valid pickle either way.
+    """
+    payload = harmless_reduce_pickle("os", "system")
+    if proto0:
+        return b"S'" + (b"x" * pad_bytes) + b"'\n0" + payload
+    import struct
+
+    return b"B" + struct.pack("<I", pad_bytes) + (b"\x00" * pad_bytes) + b"0" + payload
+
+
+@pytest.mark.parametrize("pad", [70_000, 250_000, 2_000_000])
+def test_a_payload_behind_a_large_protocol0_literal_is_found(tmp_path, pad):
+    """`S'<70KB>'` ahead of the payload must not buy silence."""
+    results = scan_dir(tmp_path, "payload.dat", padded_first_literal(pad))
+    found = artifacts_of(results)
+    assert len(found) == 1, f"pad={pad} evaded discovery"
+    assert "CRITICAL" in found[0]["risk_level"]
+
+
+@pytest.mark.parametrize("pad", [70_000, 2_000_000])
+def test_a_payload_behind_a_large_binary_literal_is_found(tmp_path, pad):
+    """The same trick in a binary protocol, where the length is declared."""
+    results = scan_dir(tmp_path, "payload.dat", padded_first_literal(pad, proto0=False))
+    found = artifacts_of(results)
+    assert len(found) == 1, f"pad={pad} evaded discovery"
+    assert "CRITICAL" in found[0]["risk_level"]
+
+
+def test_the_documented_ceiling_is_the_real_ceiling(tmp_path):
+    """Past the cap we stop looking -- that is the limit we publish."""
+    from aisbom import scanner as scanner_mod
+
+    over = scanner_mod.PICKLE_SNIFF_MAX_BYTES + 1024
+    results = scan_dir(tmp_path, "payload.dat", padded_first_literal(over))
+    assert artifacts_of(results) == []
+
+
+def test_binary_junk_with_no_newline_is_not_re_read(tmp_path):
+    """The cost guard the escalation rule must not break.
+
+    A parquet file opens with `PAR1` -- `P` happens to be a valid opcode byte
+    -- and carries no newline for megabytes. If escalation fires on "first byte
+    could be an opcode", every such file in a tree gets read to the cap.
+    """
+    from aisbom import scanner as scanner_mod
+
+    holder = tmp_path / "cost"
+    holder.mkdir()
+    big = holder / "dataset.parquet"
+    big.write_bytes(b"PAR1" + b"\x00" * (3 * 1024 * 1024))
+
+    reads = []
+    real_open = open
+
+    def counting_open(path, *args, **kwargs):
+        handle = real_open(path, *args, **kwargs)
+        if str(path) == str(big):
+            real_read = handle.read
+
+            def tracked(size=-1):
+                data = real_read(size)
+                reads.append(len(data))
+                return data
+
+            handle.read = tracked
+        return handle
+
+    scanner_mod.open = counting_open
+    try:
+        results = DeepScanner(str(holder)).scan()
+    finally:
+        del scanner_mod.open
+
+    assert artifacts_of(results) == []
+    assert sum(reads) <= scanner_mod.PICKLE_SNIFF_BYTES, (
+        f"parquet was re-read: {reads}"
+    )


### PR DESCRIPTION
## The bug

v1.3.2 added content-based discovery for files no extension claims. It reads a 64KB head and re-reads with a larger budget only when that head looked like an *unfinished* pickle.

The signal for "unfinished" was **at least one opcode parsed**. A pickle that opens with a single literal larger than the first read completes **zero** opcodes — so the larger read never happened, and the file was never discovered.

That makes the limit v1.3.2 documented as needing "a 16MB-plus literal ahead of the payload" actually reachable with roughly **64KB** — a ~254× overstatement of the difficulty, published in the GitHub release notes, the changelog, and the docstring shipped in the wheel.

Measured on the released code:

```
first-literal    65,000 B: CRITICAL (RCE Detected: os.system)
first-literal    70,000 B: NOT DISCOVERED
first-literal 1,000,000 B: NOT DISCOVERED
```

## The fix

Discovery now also re-reads when the **first opcode declares an argument that runs past the buffer** — the one way a genuine pickle yields no opcodes at all.

- **Length-prefixed arguments** (`BINBYTES`, `BINUNICODE`, `BINBYTES8`, …) are read exactly from their size prefix. No guessing.
- **Newline-terminated arguments** can't be measured without the terminator, so they're admitted only for the handful of opcodes that can genuinely begin a pickle (`STRING`, `UNICODE`, `INT`, `LONG`, `FLOAT`), only when no newline is already in view, and only when the next byte matches what that opcode's argument must start with.

That last guard is what preserves the cost property. A parquet file opens `PAR1`, and `P` *is* the PERSID opcode — but no real pickle begins with a persistent id, so PERSID is not on the list and parquet still settles on the first 64KB instead of being re-read to the cap. There's a test asserting exactly that.

## Verification

- `poetry run pytest` — **831 passed, 91.38% coverage**.
- Every previously-evading pad is now caught: 70,000 B / 250,000 B / 1,000,000 B / 2,000,000 B, in both the protocol-0 quoted-string and binary length-prefixed shapes.
- **The documented ceiling is now the real one** — caught at 16,773,120 bytes, not discovered at 16,781,312.
- **Cost unchanged**: 5,101-file `node_modules` walk still yields **0 artifacts in 0.83s**, and the parquet re-read guard is a test (`test_binary_junk_with_no_newline_is_not_re_read`).
- `aisbom bypass-scorecard --check` — gate green, 9/11 unchanged.
- Scope confirmed by probe: discovery-only. The same padded payloads under a claimed extension (`.pkl`) were always caught, and a payload *followed* by a huge literal was always caught.

Release notes and changelog for v1.3.2 need the corrected figure regardless of this fix; that's handled alongside the next release.
