### PR TITLE
feat(sbom): emit CycloneDX 1.7 with ML-BOM modelCard by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A compliant `sbom.json` (CycloneDX v1.7 / ECMA-424) including SHA256 hashes and 
 
 For `hf://` scans, each model component also carries a CycloneDX ML-BOM `modelCard` block — task, architecture family, model architecture, and training datasets, read from the model's Hugging Face metadata. Local scans get whatever the file itself declares (a GGUF header's architecture, for example) and make no extra network calls. The block is simply omitted when nothing is known.
 
-Need the older schema for a downstream tool? `--schema-version 1.6` (or `1.5`) still works and produces the same document as before, without the `modelCard` block.
+Need the older schema for a downstream tool? `--schema-version 1.6` (or `1.5`) still works, without the `modelCard` block. One thing changed for those versions too: each model component's `bom-ref` is now a stable `artifact-<n>-<filename>` instead of a value regenerated on every run, so the same file keeps the same identifier between scans.
 
 ### Formats and what's checked in each
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ A typical scan against a project with mixed artifacts:
 └──────────────────────────────┴─────────────┴────────────────────────────────────────────────┴──────────────────────────────┘
 ```
 
-A compliant `sbom.json` (CycloneDX v1.6) including SHA256 hashes and license data is generated in your working directory. SPDX 2.3 export is one flag away (`--format spdx`).
+A compliant `sbom.json` (CycloneDX v1.7 / ECMA-424) including SHA256 hashes and license data is generated in your working directory. SPDX 2.3 export is one flag away (`--format spdx`).
+
+For `hf://` scans, each model component also carries a CycloneDX ML-BOM `modelCard` block — task, architecture family, model architecture, and training datasets, read from the model's Hugging Face metadata. Local scans get whatever the file itself declares (a GGUF header's architecture, for example) and make no extra network calls. The block is simply omitted when nothing is known.
+
+Need the older schema for a downstream tool? `--schema-version 1.6` (or `1.5`) still works and produces the same document as before, without the `modelCard` block.
 
 ### Formats and what's checked in each
 
@@ -421,7 +425,7 @@ AIsbom collects a small amount of anonymous usage telemetry — what model forma
 
 Per `aisbom scan`: `target_type` (the **bucket**: `local` / `huggingface` / `http` / `https` — never the actual path or URL), `model_format` (the file-type bucket), `risk_level_max`, `scan_duration_ms`, `file_count`, `parse_error_count`, `strict_mode`. A `cli_scan_critical_found` event with a count is added when at least one CRITICAL is found.
 
-If you explicitly use `--share`: the generated `sbom.json` document is uploaded to our servers and retained for 30 days to generate the shareable viewer link. That document is the **full CycloneDX SBOM** — for each scanned model it carries the file name, SHA-256 hash, detected license, and structured `aisbom:*` properties describing the file's format and scan findings (such as dangerous pickle opcodes, tensor/header metadata, model architecture details, and the assessed risk and legal status) so the hosted viewer can render per-format detail. These describe the *structure and findings* of your model files, never their weights or data. Nothing leaves your machine unless you pass `--share` and confirm the prompt (or pass `--share-yes`). A `cli_share_created` event is fired tracking whether `has_share_yes=true|false`.
+If you explicitly use `--share`: the generated `sbom.json` document is uploaded to our servers and retained for 30 days to generate the shareable viewer link. That document is the **full CycloneDX SBOM** — for each scanned model it carries the file name, SHA-256 hash, detected license, and structured `aisbom:*` properties describing the file's format and scan findings (such as dangerous pickle opcodes, tensor/header metadata, model architecture details, and the assessed risk and legal status) so the hosted viewer can render per-format detail. For `hf://` scans it additionally carries the `modelCard` block described above — task, architecture, training datasets and the repo's licence/revision, all of which are already public metadata published on the model's Hugging Face page. These describe the *structure and findings* of your model files, never their weights or data. Nothing leaves your machine unless you pass `--share` and confirm the prompt (or pass `--share-yes`). A `cli_share_created` event is fired tracking whether `has_share_yes=true|false`.
 
 Per `aisbom diff`: a `cli_diff` event with `has_drift=true|false`.
 

--- a/aisbom/cli.py
+++ b/aisbom/cli.py
@@ -20,7 +20,7 @@ import importlib.metadata
 from .scanner import DeepScanner
 from .diff import SBOMDiff
 from .properties import build_component_properties
-from .modelcard import inject_model_cards
+from .modelcard import bom_ref_for, inject_model_cards
 from .spdx_gen import _sha256_or_none
 
 import threading
@@ -663,10 +663,16 @@ def scan(
     lf = LicenseFactory()
     
     # Add Models
-    for art in results['artifacts']:
+    for art_index, art in enumerate(results['artifacts']):
         c = Component(
             name=art['name'],
             type=ComponentType.MACHINE_LEARNING_MODEL,
+            # An explicit, stable bom-ref. Left to the library this is a fresh
+            # random string on every run, which nothing downstream can rely on
+            # and which cannot be computed ahead of serialization — so the
+            # modelCard splice would have no identifier to join on and would
+            # fall back to matching by basename, which collides (#111).
+            bom_ref=bom_ref_for(art_index, art),
             description=f"Risk: {art['risk_level']} | Framework: {art['framework']} | Legal: {art['legal_status']} | License: {art.get('license')}"
         )
         # Add SHA256 Hash only when the field actually holds one. The scanner

--- a/aisbom/cli.py
+++ b/aisbom/cli.py
@@ -11,7 +11,7 @@ from rich.panel import Panel
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model import HashAlgorithm, HashType, Property
-from cyclonedx.output.json import JsonV1Dot5, JsonV1Dot6
+from cyclonedx.output.json import JsonV1Dot5, JsonV1Dot6, JsonV1Dot7
 from cyclonedx.factory.license import LicenseFactory
 from .mock_generator import create_mock_malware_file, create_mock_restricted_file, create_mock_gguf, create_demo_diff_sboms, create_mock_broken_file
 from pathlib import Path
@@ -20,6 +20,8 @@ import importlib.metadata
 from .scanner import DeepScanner
 from .diff import SBOMDiff
 from .properties import build_component_properties
+from .modelcard import inject_model_cards
+from .spdx_gen import _sha256_or_none
 
 import threading
 import time
@@ -417,7 +419,7 @@ def scan(
         ),
     ),
     output: str | None = typer.Option(None, help="Output file path"),
-    schema_version: str = typer.Option("1.6", help="CycloneDX schema version (default is 1.6)", case_sensitive=False, rich_help_panel="Advanced Options"),
+    schema_version: str = typer.Option("1.7", help="CycloneDX schema version: 1.7 (default), 1.6, or 1.5", case_sensitive=False, rich_help_panel="Advanced Options"),
     spdx_version: str = typer.Option("2.3", help="SPDX version (2.3 or 3.0)", case_sensitive=False, rich_help_panel="Advanced Options"),
     fail_on_risk: bool = typer.Option(True, help="Return exit code 2 if Critical risks are found"),
     strict: bool = typer.Option(False, help="Enable strict allowlisting mode (flags any unknown imports)"),
@@ -667,11 +669,19 @@ def scan(
             type=ComponentType.MACHINE_LEARNING_MODEL,
             description=f"Risk: {art['risk_level']} | Framework: {art['framework']} | Legal: {art['legal_status']} | License: {art.get('license')}"
         )
-        # Add SHA256 Hash if available
-        if 'hash' in art and art['hash'] != 'hash_error':
+        # Add SHA256 Hash only when the field actually holds one. The scanner
+        # stores the sentinels `remote_unhashed` (range-request scans never
+        # read the whole file) and `hash_error` in the same field, and the old
+        # `!= 'hash_error'` guard let `remote_unhashed` through as a SHA-256
+        # digest — which made every hf:// SBOM fail CycloneDX validation, at
+        # 1.6 as well as 1.7. Reuses spdx_gen's predicate, which already had to
+        # solve this for SPDX (#101), rather than blacklisting sentinel names:
+        # a sentinel added later would silently reintroduce the bug.
+        digest = _sha256_or_none(art.get('hash'))
+        if digest:
             c.hashes.add(HashType(
                 alg=HashAlgorithm.SHA_256,
-                content=art['hash']
+                content=digest
             ))
         # Add License info to SBOM if known
         if art.get('license') and art['license'] != 'Unknown':
@@ -708,11 +718,26 @@ def scan(
     if format == OutputFormat.JSON:
         if schema_version == "1.5":
             outputter = JsonV1Dot5(bom)
-        else:
+        elif schema_version == "1.6":
             outputter = JsonV1Dot6(bom)
-            
+        else:
+            outputter = JsonV1Dot7(bom)
+
+        sbom_json = outputter.output_as_string()
+
+        # ML-BOM enrichment (#111). `modelCard` only exists from CycloneDX 1.5
+        # on, but 1.5/1.6 output is what older platform receivers and third
+        # party tools were pinned against, so the block is added to 1.7 only —
+        # asking for an older schema version keeps giving byte-identical
+        # output to before this change. cyclonedx-python-lib cannot model the
+        # field, hence the post-serialization splice.
+        if schema_version == "1.7":
+            sbom_json = inject_model_cards(
+                sbom_json, results['artifacts'], results.get('hf_model_card')
+            )
+
         with open(output, "w") as f:
-            f.write(outputter.output_as_string())
+            f.write(sbom_json)
         
         console.print(f"\n[bold green]✔ Compliance Artifact Generated:[/bold green] {output} (CycloneDX v{schema_version})")
 
@@ -731,7 +756,10 @@ def scan(
             if do_share:
                 with console.status("[cyan]Uploading SBOM to aisbom.io...[/cyan]"):
                     try:
-                        json_str = outputter.output_as_string()
+                        # The spliced string, not a fresh output_as_string() —
+                        # otherwise the shared SBOM would silently lack the
+                        # modelCard the local file has.
+                        json_str = sbom_json
                         res = requests.post(
                             "https://aisbom.io/api/sbom-share",
                             data=json_str,

--- a/aisbom/modelcard.py
+++ b/aisbom/modelcard.py
@@ -1,0 +1,258 @@
+"""Build CycloneDX 1.7 (ECMA-424) ``modelCard`` blocks for scanned artifacts.
+
+Two reasons this is a post-serialization splice rather than model objects:
+
+1. ``cyclonedx-python-lib`` (11.x) has no ``modelCard`` support — ``Component``
+   accepts no such argument and the serializer has nothing to emit it from.
+   The spec has carried the field since 1.5; the library simply hasn't
+   modelled it. Waiting for upstream would block the slice indefinitely.
+2. Splicing keeps the change strictly additive. Every component the library
+   already emits is serialized by the library, byte-identical to 1.6 output;
+   this module only *adds* a ``modelCard`` key to machine-learning-model
+   components. Nothing existing is rewritten, so no field can regress.
+
+The cost is that correctness rests on the shape produced here rather than on
+the library's type checks — which is why ``tests/test_modelcard.py`` validates
+generated SBOMs against the bundled ``bom-1.7.SNAPSHOT.schema.json`` with the
+*strict* validator (``additionalProperties: false`` throughout, so a misspelled
+key fails the suite rather than shipping).
+
+Sources, in order of preference:
+
+* Hugging Face model-card metadata (``hf://`` scans only) — task, architecture,
+  training datasets, license, library.
+* What the scanner already parsed out of the file itself — currently the GGUF
+  header's architecture. This is why a purely local scan still gets a
+  ``modelCard`` without any network call at all.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+_ML_COMPONENT_TYPE = "machine-learning-model"
+
+# HF metadata worth carrying that has no home in the typed `modelParameters`
+# block. Each maps a key in the API payload to an `aisbom:hf:*` property name,
+# matching the namespacing convention in `aisbom.properties` (#28/#54).
+#
+# `downloads` and `likes` are deliberately absent: they change hourly, and an
+# SBOM that differs between two scans of an unchanged model produces phantom
+# drift on the platform's diff.
+_HF_SCALAR_PROPERTIES = (
+    ("library_name", "aisbom:hf:library_name"),
+    ("sha", "aisbom:hf:revision"),
+)
+
+
+def _clean_str(value: Any) -> Optional[str]:
+    """Return a non-empty stripped string, or None for anything else."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _card_data(hf_meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    data = (hf_meta or {}).get("cardData")
+    return data if isinstance(data, dict) else {}
+
+
+def _config(hf_meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    config = (hf_meta or {}).get("config")
+    return config if isinstance(config, dict) else {}
+
+
+def _datasets(hf_meta: Optional[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Map ``cardData.datasets`` to inline CycloneDX ``componentData`` entries.
+
+    The 1.7 schema allows either an inline `componentData` or a `ref` pointing
+    at a data component elsewhere in the BOM. Inline is the right call here:
+    HF gives us a bare dataset name and nothing else, so a referenced data
+    component would be an empty shell that inflates the component count the
+    platform dashboard reports as "artifacts scanned".
+    """
+    raw = _card_data(hf_meta).get("datasets")
+    # A single-dataset card may give a bare string rather than a list.
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+
+    datasets: List[Dict[str, str]] = []
+    seen = set()
+    for entry in raw:
+        name = _clean_str(entry)
+        if name is None or name in seen:
+            continue
+        seen.add(name)
+        # `type` is required by the schema's componentData; "dataset" is the
+        # only honest value for a training corpus.
+        datasets.append({"type": "dataset", "name": name})
+    return datasets
+
+
+def _model_parameters(art: Dict[str, Any], hf_meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Build the typed ``modelParameters`` block. Empty dict when nothing known.
+
+    ``approach.type`` is intentionally never set: the schema constrains it to a
+    five-value enum (supervised / unsupervised / reinforcement-learning /
+    semi-supervised / self-supervised) and HF metadata carries nothing that
+    maps to it without guessing. A guessed learning type in a compliance
+    artifact is worse than an absent one.
+    """
+    params: Dict[str, Any] = {}
+
+    task = _clean_str((hf_meta or {}).get("pipeline_tag"))
+    if task:
+        params["task"] = task
+
+    config = _config(hf_meta)
+    # `model_type` is the family ("bert", "llama"); `architectures[0]` is the
+    # concrete head ("BertForMaskedLM"). The schema draws exactly that
+    # distinction, so they are not interchangeable.
+    family = _clean_str(config.get("model_type"))
+    if family is None:
+        # No HF metadata (a local scan, or a repo with no config): the GGUF
+        # header carries the architecture family itself. This is what makes
+        # local scans benefit without a network call.
+        details = art.get("details") or {}
+        family = _clean_str(details.get("architecture"))
+    if family:
+        params["architectureFamily"] = family
+
+    architectures = config.get("architectures")
+    if isinstance(architectures, list) and architectures:
+        architecture = _clean_str(architectures[0])
+        if architecture:
+            params["modelArchitecture"] = architecture
+
+    datasets = _datasets(hf_meta)
+    if datasets:
+        params["datasets"] = datasets
+
+    return params
+
+
+def _properties(art: Dict[str, Any], hf_meta: Optional[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Untyped `aisbom:hf:*` name/value pairs the typed block has no slot for."""
+    props: List[Dict[str, str]] = []
+    if not hf_meta:
+        return props
+
+    repo_id = _clean_str(hf_meta.get("id")) or _clean_str(hf_meta.get("modelId"))
+    if repo_id:
+        props.append({"name": "aisbom:hf:repo_id", "value": repo_id})
+
+    # The card's declared license is reported here rather than merged into the
+    # component's `licenses` / `legal_status`. Those two drive the platform's
+    # license_issue_count and the CLI's LEGAL RISK verdict, so backfilling them
+    # from HF would silently change a compliance judgement — a separate,
+    # non-additive decision that does not belong in a "widen the output" slice.
+    license_id = _clean_str(_card_data(hf_meta).get("license"))
+    if license_id:
+        props.append({"name": "aisbom:hf:license", "value": license_id})
+
+    for key, prop_name in _HF_SCALAR_PROPERTIES:
+        value = _clean_str(hf_meta.get(key))
+        if value:
+            props.append({"name": prop_name, "value": value})
+
+    # Gated/private repos are worth recording: they explain why a scan saw
+    # fewer files than the repo actually contains.
+    if hf_meta.get("gated"):
+        props.append({"name": "aisbom:hf:gated", "value": str(hf_meta["gated"])})
+    if hf_meta.get("private") is True:
+        props.append({"name": "aisbom:hf:private", "value": "true"})
+
+    return props
+
+
+def build_model_card(
+    art: Dict[str, Any], hf_meta: Optional[Dict[str, Any]] = None
+) -> Optional[Dict[str, Any]]:
+    """Return a CycloneDX 1.7 ``modelCard`` dict for one artifact, or None.
+
+    None means "emit no modelCard at all" — the sparse-metadata path. An empty
+    `modelCard: {}` would validate, but it is noise in a compliance artifact
+    and would make every local non-GGUF scan's SBOM look like it tried and
+    failed to describe the model.
+    """
+    card: Dict[str, Any] = {}
+
+    params = _model_parameters(art, hf_meta)
+    if params:
+        card["modelParameters"] = params
+
+    props = _properties(art, hf_meta)
+    if props:
+        card["properties"] = props
+
+    return card or None
+
+
+def inject_model_cards(
+    bom_json: str,
+    artifacts: List[Dict[str, Any]],
+    hf_meta: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Splice ``modelCard`` blocks into a serialized CycloneDX document.
+
+    Matching is by component name against the artifact's name, FIFO within a
+    name group. Names are file basenames, so a repo with two same-named files
+    in different directories produces a collision — but such files come from
+    one HF repo and share its metadata, so the cards are equal and the order
+    within the group cannot change the output.
+
+    `bom-ref` is deliberately not used as the join key: it is a random UUID per
+    run today, and pinning it to something deterministic would change a field
+    that already ships, breaking the additive-only guarantee this slice is
+    held to.
+
+    Returns the input unchanged if it does not parse or has no components, so a
+    serializer change upstream degrades to 1.6-equivalent output rather than
+    raising during a scan.
+    """
+    try:
+        doc = json.loads(bom_json)
+    except (ValueError, TypeError):
+        return bom_json
+    if not isinstance(doc, dict) or not isinstance(doc.get("components"), list):
+        return bom_json
+
+    queued: Dict[str, List[Dict[str, Any]]] = {}
+    for art in artifacts:
+        card = build_model_card(art, hf_meta)
+        if card is None:
+            continue
+        name = art.get("name")
+        if not isinstance(name, str):
+            continue
+        queued.setdefault(name, []).append(card)
+
+    if not queued:
+        return bom_json
+
+    injected = False
+    for component in doc["components"]:
+        if not isinstance(component, dict):
+            continue
+        # Library components (requirements.txt deps) are not models and must
+        # never grow a modelCard.
+        if component.get("type") != _ML_COMPONENT_TYPE:
+            continue
+        pending = queued.get(component.get("name"))
+        if not pending:
+            continue
+        component["modelCard"] = pending.pop(0)
+        injected = True
+
+    if not injected:
+        return bom_json
+
+    # Re-serialized with json's default separators, which is exactly what
+    # cyclonedx-python-lib's own `output_as_string()` emits — so a scan whose
+    # artifacts yield no cards produces a byte-identical file to before, and
+    # one that does differs only by the added key.
+    return json.dumps(doc)

--- a/aisbom/modelcard.py
+++ b/aisbom/modelcard.py
@@ -192,6 +192,26 @@ def build_model_card(
     return card or None
 
 
+def bom_ref_for(index: int, art: Dict[str, Any]) -> str:
+    """Stable `bom-ref` for a scanned artifact, used as the injection join key.
+
+    Both sides must derive this identically: ``cli.py`` stamps it onto the
+    Component at construction, and :func:`inject_model_cards` looks it up in
+    the serialized document.
+
+    The index is load-bearing, not decoration. Artifact names are file
+    *basenames*, so a tree holding two ``model.gguf`` files in different
+    directories yields two components with the same name — and the library
+    serializes its component collection in its own sorted order, not scan
+    order. Joining on name alone could therefore hand a llama model's card to
+    a bert component, producing a document whose `aisbom:gguf:architecture`
+    property contradicts its own `modelCard`. The index is the only field that
+    is unique across artifacts in every scan shape (remote scans share the
+    `remote_unhashed` sentinel, so the hash cannot serve).
+    """
+    return f"artifact-{index}-{art.get('name', 'unknown')}"
+
+
 def inject_model_cards(
     bom_json: str,
     artifacts: List[Dict[str, Any]],
@@ -199,16 +219,8 @@ def inject_model_cards(
 ) -> str:
     """Splice ``modelCard`` blocks into a serialized CycloneDX document.
 
-    Matching is by component name against the artifact's name, FIFO within a
-    name group. Names are file basenames, so a repo with two same-named files
-    in different directories produces a collision — but such files come from
-    one HF repo and share its metadata, so the cards are equal and the order
-    within the group cannot change the output.
-
-    `bom-ref` is deliberately not used as the join key: it is a random UUID per
-    run today, and pinning it to something deterministic would change a field
-    that already ships, breaking the additive-only guarantee this slice is
-    held to.
+    Joined on the `bom-ref` that ``cli.py`` stamped on each model component —
+    see :func:`bom_ref_for` for why a name-based join is not sufficient.
 
     Returns the input unchanged if it does not parse or has no components, so a
     serializer change upstream degrades to 1.6-equivalent output rather than
@@ -221,17 +233,13 @@ def inject_model_cards(
     if not isinstance(doc, dict) or not isinstance(doc.get("components"), list):
         return bom_json
 
-    queued: Dict[str, List[Dict[str, Any]]] = {}
-    for art in artifacts:
+    cards_by_ref: Dict[str, Dict[str, Any]] = {}
+    for index, art in enumerate(artifacts):
         card = build_model_card(art, hf_meta)
-        if card is None:
-            continue
-        name = art.get("name")
-        if not isinstance(name, str):
-            continue
-        queued.setdefault(name, []).append(card)
+        if card is not None:
+            cards_by_ref[bom_ref_for(index, art)] = card
 
-    if not queued:
+    if not cards_by_ref:
         return bom_json
 
     injected = False
@@ -242,10 +250,10 @@ def inject_model_cards(
         # never grow a modelCard.
         if component.get("type") != _ML_COMPONENT_TYPE:
             continue
-        pending = queued.get(component.get("name"))
-        if not pending:
+        card = cards_by_ref.get(component.get("bom-ref"))
+        if card is None:
             continue
-        component["modelCard"] = pending.pop(0)
+        component["modelCard"] = card
         injected = True
 
     if not injected:

--- a/aisbom/remote.py
+++ b/aisbom/remote.py
@@ -174,3 +174,44 @@ def resolve_huggingface_repo(repo_id: str) -> List[str]:
             urls.append(f"https://huggingface.co/{repo_id}/resolve/main/{path}")
 
     return urls
+
+
+# The model-card fetch is deliberately capped well below the file-listing
+# timeout: it is enrichment, not the scan, and a slow HF API must never be
+# what makes a CI scan hang.
+_MODEL_CARD_TIMEOUT_SECONDS = 10
+
+
+def fetch_huggingface_model_card(repo_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a repo's model-card metadata from the HF API. Best-effort.
+
+    Unlike :func:`resolve_huggingface_repo`, every failure here is swallowed and
+    returns ``None``. That asymmetry is intentional and is the whole contract:
+    the file listing decides *what gets scanned*, so losing it silently would
+    hide a malicious model (#58). This call only decides whether the SBOM
+    carries a richer ``modelCard`` block. A gated repo, a rate limit, an API
+    outage, or a network blip must degrade to an SBOM without that block —
+    never to a failed scan or a new exit code. Callers get ``None`` and omit
+    the field.
+
+    Returns the raw API payload (``cardData``, ``config``, ``pipeline_tag``,
+    ``tags``, ``sha`` …) so mapping stays in :mod:`aisbom.modelcard`.
+    """
+    if repo_id.startswith("hf://"):
+        repo_id = repo_id[len("hf://") :]
+
+    api_url = f"https://huggingface.co/api/models/{repo_id}"
+    try:
+        resp = requests.get(
+            api_url,
+            headers=_auth_headers(api_url),
+            timeout=_MODEL_CARD_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return None
+
+    # A 200 that isn't a JSON object (HTML error page, proxy interstitial) is
+    # as useless as a failure and must not reach the mapper as, say, a list.
+    return data if isinstance(data, dict) else None

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -213,7 +213,7 @@ NONSTANDARD_CONTAINER_MAGICS = (
 # Simple blocklist for license keywords that imply legal risk in commercial software
 RESTRICTED_LICENSES = ["non-commercial", "cc-by-nc", "agpl", "commons clause"]
 
-from aisbom.remote import RemoteStream, resolve_huggingface_repo
+from aisbom.remote import RemoteStream, fetch_huggingface_model_card, resolve_huggingface_repo
 
 
 class _GGUFTruncated(Exception):
@@ -228,6 +228,10 @@ class DeepScanner:
         self.artifacts = []
         self.dependencies = []
         self.errors = []
+        # HF model-card metadata for an `hf://` target (#111). Stays None for
+        # every other target shape, which is what guarantees a local scan makes
+        # no network call.
+        self.hf_model_card = None
         self.is_remote = isinstance(root_path, str) and (
             root_path.startswith("http://")
             or root_path.startswith("https://")
@@ -245,6 +249,15 @@ class DeepScanner:
             except Exception as e:
                 self._record_fetch_error(self.root_path, e)
                 targets = []
+
+            # Enrichment only (#111), and only for hf:// — a plain https:// URL
+            # is a single file with no repo to describe. Fetched once per scan
+            # rather than per artifact, and never allowed to raise: see
+            # fetch_huggingface_model_card for why this failure is swallowed
+            # while the file-listing failure above is not.
+            if targets and self.root_path.startswith("hf://"):
+                self.hf_model_card = fetch_huggingface_model_card(self.root_path)
+
             for url in targets:
                 ext = Path(url).suffix.lower()
                 # Per-target isolation: one gated/missing file in a multi-file
@@ -308,7 +321,12 @@ class DeepScanner:
                     else "Not a regular file or directory",
                 )
 
-        return {"artifacts": self.artifacts, "dependencies": self.dependencies, "errors": self.errors}
+        return {
+            "artifacts": self.artifacts,
+            "dependencies": self.dependencies,
+            "errors": self.errors,
+            "hf_model_card": self.hf_model_card,
+        }
 
     def _resolve_remote_targets(self, target: str):
         if target.startswith("hf://"):

--- a/poetry.lock
+++ b/poetry.lock
@@ -2331,4 +2331,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "1b251f5063f3bc93aa461c5225a9171bc60be4af2d0c4702759a47cd4ecc37da"
+content-hash = "19e233180db90051748c1c5bd6cf6e848accf1ff3426cd1db062a86507ade1ff"

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,6 +26,18 @@ files = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+description = "Classes Without Boilerplate"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
+    {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
+]
+
+[[package]]
 name = "backports-zstd"
 version = "1.6.0"
 description = "Backport of compression.zstd"
@@ -922,6 +934,43 @@ files = [
     {file = "joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713"},
     {file = "joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3"},
 ]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+description = "An implementation of JSON Schema validation for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
+    {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+jsonschema-specifications = ">=2023.3.6"
+referencing = ">=0.28.4"
+rpds-py = ">=0.25.0"
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "rfc3987-syntax (>=1.1.0)", "uri-template", "webcolors (>=24.6.0)"]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
+    {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
+]
+
+[package.dependencies]
+referencing = ">=0.31.0"
 
 [[package]]
 name = "license-expression"
@@ -1917,6 +1966,23 @@ orjson = ["orjson (>=3.9.14,<4)"]
 rdf4j = ["httpx (>=0.28.1,<0.29.0)"]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+description = "JSON Referencing + Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
+    {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
+]
+
+[package.dependencies]
+attrs = ">=22.2.0"
+rpds-py = ">=0.7.0"
+typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 description = "Python HTTP for Humans."
@@ -1956,6 +2022,132 @@ pygments = ">=2.13.0,<3.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+description = "Python bindings to Rust's persistent data structures (rpds)"
+optional = false
+python-versions = ">=3.11"
+groups = ["dev"]
+files = [
+    {file = "rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127"},
+    {file = "rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f"},
+    {file = "rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80"},
+    {file = "rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5"},
+    {file = "rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e"},
+    {file = "rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146"},
+    {file = "rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577"},
+    {file = "rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76"},
+    {file = "rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826"},
+    {file = "rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4"},
+]
 
 [[package]]
 name = "semantic-version"
@@ -2139,4 +2331,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "748e1137426250ea7ca4cfc50e30af452e6d2a52587c90ce982deb2b66560468"
+content-hash = "1b251f5063f3bc93aa461c5225a9171bc60be4af2d0c4702759a47cd4ecc37da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,11 @@ urls = { "Homepage" = "https://www.aisbom.io/" }
 python = "^3.11"
 typer = {extras = ["all"], version = ">=0.12.5,<0.28.0"}
 rich = ">=13.7.1,<16.0.0"
-cyclonedx-python-lib = ">=8.5,<12.0"
+# Floor is 11.4, the first release exporting JsonV1Dot7 / SchemaVersion.V1_7
+# (upstream PR #902). cli.py imports the 1.7 serializer unconditionally, so a
+# resolver that left an older-but-previously-allowed version installed would
+# break the CLI at startup for every format, not just 1.7 output.
+cyclonedx-python-lib = ">=11.4,<12.0"
 pip-requirements-parser = "^32.0.1"
 click = "<8.5.0"
 spdx-tools = "^0.8.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ onnx = "^1.17"
 joblib = "^1.4"
 dill = "^0.3.8"
 numpy = "^2.0"
+# cyclonedx-python-lib's `validation` extra. Test-only on purpose: the CLI
+# never validates its own output at runtime (that would add a hard dependency
+# and a per-scan cost to every user), but the 1.7 modelCard block is spliced
+# into the serialized JSON outside the library's type system, so the suite
+# validates generated SBOMs against the bundled schema instead.
+jsonschema = "^4.23"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -138,6 +138,158 @@ def test_cli_scan_schema_v15_branch(tmp_path):
     assert output_path.exists()
 
 
+# ---------------------------------------------------------------------------
+# #111 — CycloneDX 1.7 is the default output.
+# ---------------------------------------------------------------------------
+
+
+def _scan_to_sbom(tmp_path, name, *extra_args):
+    _write_malicious_pt(tmp_path / "mock_malware.pt")
+    create_mock_restricted_file(tmp_path)
+    create_mock_gguf(tmp_path)
+    output_path = tmp_path / name
+    result = runner.invoke(
+        app, ["scan", str(tmp_path), "--output", str(output_path), *extra_args]
+    )
+    assert result.exit_code == 2
+    return json.loads(output_path.read_text())
+
+
+def test_cli_scan_defaults_to_cyclonedx_1_7(tmp_path):
+    sbom = _scan_to_sbom(tmp_path, "default.json")
+    assert sbom["specVersion"] == "1.7"
+    assert sbom["bomFormat"] == "CycloneDX"
+
+
+def test_cli_scan_explicit_1_6_still_emits_1_6_without_model_cards(tmp_path):
+    """Pinning the old version keeps the exact pre-#111 document shape."""
+    sbom = _scan_to_sbom(tmp_path, "pinned.json", "--schema-version", "1.6")
+    assert sbom["specVersion"] == "1.6"
+    assert all("modelCard" not in c for c in sbom["components"])
+
+
+def test_local_gguf_scan_carries_a_model_card_with_no_network(tmp_path):
+    """AC: local scans benefit too — the family comes from the GGUF header.
+
+    Uses a GGUF that actually declares `general.architecture`; the shared mock
+    fixture only carries a license key, so it legitimately yields no card.
+    """
+    from tests.test_gguf_template import _gguf_with_templates
+
+    _gguf_with_templates(tmp_path / "llama-model.gguf", {})
+    output_path = tmp_path / "gguf.json"
+    runner.invoke(app, ["scan", str(tmp_path), "--output", str(output_path)])
+
+    sbom = json.loads(output_path.read_text())
+    (gguf,) = [c for c in sbom["components"] if c["name"] == "llama-model.gguf"]
+    assert gguf["modelCard"]["modelParameters"] == {"architectureFamily": "llama"}
+
+
+def test_gguf_without_an_architecture_gets_no_model_card(tmp_path):
+    """Nothing known → no empty `modelCard: {}` noise in the artifact."""
+    sbom = _scan_to_sbom(tmp_path, "sparse.json")
+    gguf = [c for c in sbom["components"] if c["name"].endswith(".gguf")]
+    assert gguf and "modelCard" not in gguf[0]
+
+
+def test_default_scan_preserves_every_1_6_component_field(tmp_path):
+    """The additive guarantee, asserted through the real CLI rather than a
+    hand-built BOM: descriptions, hashes, licenses and aisbom:* properties all
+    survive the default flip untouched."""
+    old = _scan_to_sbom(tmp_path, "old.json", "--schema-version", "1.6")
+    new = _scan_to_sbom(tmp_path, "new.json")
+
+    old_by_name = {c["name"]: c for c in old["components"]}
+    new_by_name = {c["name"]: c for c in new["components"]}
+    assert set(old_by_name) == set(new_by_name)
+
+    for name, old_component in old_by_name.items():
+        for key, value in old_component.items():
+            if key == "bom-ref":
+                continue  # random UUID per run
+            assert new_by_name[name][key] == value, f"{name}.{key} regressed"
+        added = set(new_by_name[name]) - set(old_component)
+        assert added <= {"modelCard"}, f"{name} grew unexpected keys: {added}"
+
+
+def test_remote_sentinel_hashes_are_never_emitted_as_digests(tmp_path, monkeypatch):
+    """Regression: `remote_unhashed` was written into a SHA-256 hash field.
+
+    Range-request scans never read the whole file, so the scanner stores a
+    sentinel where a digest would go. The old guard only filtered
+    `hash_error`, so every hf:// SBOM carried `"content": "remote_unhashed"`
+    and failed CycloneDX validation — at 1.6 as well as 1.7. Caught by
+    validating a real `hf://` scan rather than a fixture.
+    """
+    from cyclonedx.schema import SchemaVersion
+    from cyclonedx.validation.json import JsonStrictValidator
+    import aisbom.scanner as scanner_module
+
+    def fake_scan(self):
+        return {
+            "artifacts": [
+                {
+                    "name": "remote.safetensors",
+                    "framework": "SafeTensors",
+                    "risk_level": "LOW",
+                    "legal_status": "OK",
+                    "hash": "remote_unhashed",
+                    "details": {},
+                },
+                {
+                    "name": "unreadable.pt",
+                    "framework": "PyTorch",
+                    "risk_level": "LOW",
+                    "legal_status": "OK",
+                    "hash": "hash_error",
+                    "details": {},
+                },
+                {
+                    "name": "local.gguf",
+                    "framework": "GGUF",
+                    "risk_level": "LOW",
+                    "legal_status": "OK",
+                    "hash": "a" * 64,
+                    "details": {},
+                },
+            ],
+            "dependencies": [],
+            "errors": [],
+            "hf_model_card": None,
+        }
+
+    monkeypatch.setattr(scanner_module.DeepScanner, "scan", fake_scan)
+    output_path = tmp_path / "sentinels.json"
+    runner.invoke(app, ["scan", str(tmp_path), "--output", str(output_path)])
+
+    raw = output_path.read_text()
+    assert "remote_unhashed" not in raw
+    assert "hash_error" not in raw
+
+    by_name = {c["name"]: c for c in json.loads(raw)["components"]}
+    assert "hashes" not in by_name["remote.safetensors"], "sentinel must omit the field"
+    assert "hashes" not in by_name["unreadable.pt"]
+    assert by_name["local.gguf"]["hashes"] == [{"alg": "SHA-256", "content": "a" * 64}]
+
+    errors = JsonStrictValidator(SchemaVersion.V1_7).validate_str(raw)
+    assert errors is None, f"sentinel hashes broke 1.7 validation: {errors}"
+
+
+def test_default_scan_output_validates_against_the_1_7_schema(tmp_path):
+    """AC #1, end to end: what the CLI actually writes to disk is valid 1.7."""
+    from cyclonedx.schema import SchemaVersion
+    from cyclonedx.validation.json import JsonStrictValidator
+
+    output_path = tmp_path / "validated.json"
+    _write_malicious_pt(tmp_path / "mock_malware.pt")
+    create_mock_restricted_file(tmp_path)
+    create_mock_gguf(tmp_path)
+    runner.invoke(app, ["scan", str(tmp_path), "--output", str(output_path)])
+
+    errors = JsonStrictValidator(SchemaVersion.V1_7).validate_str(output_path.read_text())
+    assert errors is None, f"CLI output failed 1.7 validation: {errors}"
+
+
 def test_cli_scan_markdown_default_output(tmp_path, monkeypatch):
     _write_malicious_pt(tmp_path / "mock_malware.pt")
     create_mock_restricted_file(tmp_path)

--- a/tests/test_modelcard.py
+++ b/tests/test_modelcard.py
@@ -1,0 +1,335 @@
+"""Tests for CycloneDX 1.7 ML-BOM `modelCard` generation (#111).
+
+Three layers, because the splice bypasses the library's type checks:
+
+1. Pure mapping — `build_model_card` against populated / sparse / absent HF
+   metadata.
+2. Injection — which components get a card, and which must not.
+3. Schema validation — every generated document is checked against the
+   bundled `bom-1.7.SNAPSHOT.schema.json` with the *strict* validator. The 1.7
+   schema sets `additionalProperties: false` throughout, so a misspelled key
+   or a wrongly-typed value fails here rather than shipping into a compliance
+   artifact.
+
+Plus a regression guard that 1.7 output is a strict superset of 1.6 output.
+"""
+
+import json
+
+import pytest
+from cyclonedx.model.bom import Bom
+from cyclonedx.model.component import Component, ComponentType
+from cyclonedx.output.json import JsonV1Dot6, JsonV1Dot7
+from cyclonedx.schema import SchemaVersion
+from cyclonedx.validation.json import JsonStrictValidator
+
+from aisbom.modelcard import build_model_card, inject_model_cards
+
+
+# --- Fixtures -------------------------------------------------------------
+
+# Shaped after the real https://huggingface.co/api/models/google-bert/
+# bert-base-uncased payload (fields we read, verbatim keys).
+FULL_HF_META = {
+    "id": "google-bert/bert-base-uncased",
+    "modelId": "google-bert/bert-base-uncased",
+    "pipeline_tag": "fill-mask",
+    "library_name": "transformers",
+    "sha": "86b5e0934494bd15c9632b12f734a8a67f723594",
+    "gated": False,
+    "private": False,
+    "cardData": {
+        "license": "apache-2.0",
+        "datasets": ["bookcorpus", "wikipedia"],
+        "language": "en",
+        "tags": ["exbert"],
+    },
+    "config": {
+        "model_type": "bert",
+        "architectures": ["BertForMaskedLM"],
+    },
+}
+
+
+def artifact(name="model.safetensors", framework="SafeTensors", **details):
+    return {
+        "name": name,
+        "framework": framework,
+        "risk_level": "LOW",
+        "legal_status": "OK",
+        "details": details,
+    }
+
+
+def validate_1_7(doc):
+    """Assert a document validates against the bundled strict 1.7 schema."""
+    errors = JsonStrictValidator(SchemaVersion.V1_7).validate_str(
+        json.dumps(doc) if isinstance(doc, dict) else doc
+    )
+    assert errors is None, f"1.7 schema validation failed: {errors}"
+
+
+def build_sbom(artifacts, outputter=JsonV1Dot7):
+    """Serialize artifacts the way cli.py does, without invoking the CLI."""
+    bom = Bom()
+    for art in artifacts:
+        bom.components.add(
+            Component(
+                name=art["name"],
+                type=ComponentType.MACHINE_LEARNING_MODEL,
+                description=f"Risk: {art['risk_level']} | Framework: {art['framework']}",
+            )
+        )
+    return outputter(bom).output_as_string()
+
+
+# --- build_model_card: populated metadata ---------------------------------
+
+
+def test_full_hf_metadata_populates_every_mapped_field():
+    card = build_model_card(artifact(), FULL_HF_META)
+
+    assert card["modelParameters"] == {
+        "task": "fill-mask",
+        "architectureFamily": "bert",
+        "modelArchitecture": "BertForMaskedLM",
+        "datasets": [
+            {"type": "dataset", "name": "bookcorpus"},
+            {"type": "dataset", "name": "wikipedia"},
+        ],
+    }
+    props = {p["name"]: p["value"] for p in card["properties"]}
+    assert props["aisbom:hf:repo_id"] == "google-bert/bert-base-uncased"
+    assert props["aisbom:hf:license"] == "apache-2.0"
+    assert props["aisbom:hf:library_name"] == "transformers"
+    assert props["aisbom:hf:revision"] == FULL_HF_META["sha"]
+
+
+def test_volatile_popularity_fields_are_never_emitted():
+    """`downloads`/`likes` change hourly and would produce phantom drift."""
+    meta = dict(FULL_HF_META, downloads=12_345_678, likes=42)
+    card = build_model_card(artifact(), meta)
+    serialized = json.dumps(card)
+    assert "downloads" not in serialized
+    assert "likes" not in serialized
+
+
+def test_hf_license_does_not_leak_into_the_legal_verdict():
+    """The card's license is reported, never merged into risk/legal fields.
+
+    Backfilling `licenses`/`legal_status` from HF would change a compliance
+    judgement the platform counts on — deliberately out of scope here.
+    """
+    card = build_model_card(artifact(), FULL_HF_META)
+    assert "licenses" not in card
+    assert "legal_status" not in json.dumps(card)
+
+
+# --- build_model_card: sparse and absent metadata -------------------------
+
+
+def test_no_metadata_and_no_file_details_emits_no_card():
+    assert build_model_card(artifact()) is None
+    assert build_model_card(artifact(), None) is None
+    assert build_model_card(artifact(), {}) is None
+
+
+def test_sparse_metadata_emits_only_what_is_known():
+    """A card with nothing but an id — every optional branch skipped."""
+    card = build_model_card(artifact(), {"id": "someone/bare-model"})
+    assert card == {"properties": [{"name": "aisbom:hf:repo_id", "value": "someone/bare-model"}]}
+
+
+def test_missing_config_omits_architecture_fields():
+    meta = {k: v for k, v in FULL_HF_META.items() if k != "config"}
+    card = build_model_card(artifact(), meta)
+    assert "architectureFamily" not in card["modelParameters"]
+    assert "modelArchitecture" not in card["modelParameters"]
+    assert card["modelParameters"]["task"] == "fill-mask"
+
+
+def test_empty_and_blank_values_are_treated_as_absent():
+    meta = {
+        "id": "  ",
+        "pipeline_tag": "",
+        "library_name": None,
+        "cardData": {"license": "   ", "datasets": []},
+        "config": {"model_type": "", "architectures": []},
+    }
+    assert build_model_card(artifact(), meta) is None
+
+
+def test_wrongly_typed_metadata_does_not_raise():
+    """A proxy interstitial or an API change must degrade, not crash a scan."""
+    meta = {"cardData": "not-a-dict", "config": ["nope"], "pipeline_tag": 42}
+    assert build_model_card(artifact(), meta) is None
+
+
+# --- Datasets edge cases --------------------------------------------------
+
+
+def test_single_dataset_given_as_a_bare_string():
+    card = build_model_card(artifact(), {"cardData": {"datasets": "imagenet"}})
+    assert card["modelParameters"]["datasets"] == [{"type": "dataset", "name": "imagenet"}]
+
+
+def test_duplicate_datasets_are_collapsed():
+    meta = {"cardData": {"datasets": ["c4", "c4", " c4 ", "pile"]}}
+    card = build_model_card(artifact(), meta)
+    assert card["modelParameters"]["datasets"] == [
+        {"type": "dataset", "name": "c4"},
+        {"type": "dataset", "name": "pile"},
+    ]
+
+
+# --- Local scans benefit without any network call -------------------------
+
+
+def test_local_gguf_gets_an_architecture_family_with_no_hf_metadata():
+    """The GGUF header carries the family itself — no HF call involved."""
+    art = artifact(name="model.gguf", framework="GGUF", architecture="llama")
+    card = build_model_card(art, None)
+    assert card == {"modelParameters": {"architectureFamily": "llama"}}
+
+
+def test_hf_config_wins_over_the_gguf_header_when_both_exist():
+    art = artifact(name="model.gguf", framework="GGUF", architecture="llama")
+    card = build_model_card(art, FULL_HF_META)
+    assert card["modelParameters"]["architectureFamily"] == "bert"
+
+
+# --- inject_model_cards ---------------------------------------------------
+
+
+def test_injects_into_the_matching_model_component():
+    arts = [artifact(name="model.safetensors")]
+    out = json.loads(inject_model_cards(build_sbom(arts), arts, FULL_HF_META))
+    (component,) = [c for c in out["components"] if c["name"] == "model.safetensors"]
+    assert component["modelCard"]["modelParameters"]["task"] == "fill-mask"
+
+
+def test_library_components_never_receive_a_model_card():
+    bom = Bom()
+    bom.components.add(Component(name="numpy", version="2.1.0", type=ComponentType.LIBRARY))
+    bom.components.add(Component(name="model.safetensors", type=ComponentType.MACHINE_LEARNING_MODEL))
+    arts = [artifact(name="model.safetensors"), artifact(name="numpy")]
+
+    out = json.loads(inject_model_cards(JsonV1Dot7(bom).output_as_string(), arts, FULL_HF_META))
+    by_name = {c["name"]: c for c in out["components"]}
+    assert "modelCard" in by_name["model.safetensors"]
+    assert "modelCard" not in by_name["numpy"], "a library is not a model"
+
+
+def test_same_named_artifacts_each_get_a_card():
+    """Basename collisions across directories: one card each, not one total."""
+    bom = Bom()
+    for bom_ref in ("a", "b"):
+        bom.components.add(
+            Component(name="model.bin", bom_ref=bom_ref, type=ComponentType.MACHINE_LEARNING_MODEL)
+        )
+    arts = [artifact(name="model.bin"), artifact(name="model.bin")]
+
+    out = json.loads(inject_model_cards(JsonV1Dot7(bom).output_as_string(), arts, FULL_HF_META))
+    assert all("modelCard" in c for c in out["components"])
+
+
+def test_no_cards_returns_the_input_byte_for_byte():
+    """The sparse path must not even re-serialize — no incidental reformatting."""
+    arts = [artifact()]
+    original = build_sbom(arts)
+    assert inject_model_cards(original, arts, None) == original
+
+
+def test_malformed_input_is_returned_unchanged():
+    for junk in ("not json", "", "[1,2,3]", '{"components": "nope"}'):
+        assert inject_model_cards(junk, [artifact()], FULL_HF_META) == junk
+
+
+def test_injection_preserves_the_serializer_formatting():
+    """Re-serialization must match the library's own separators exactly."""
+    arts = [artifact()]
+    original = build_sbom(arts)
+    spliced = inject_model_cards(original, arts, FULL_HF_META)
+    # Strip the only intended difference, then the strings must be identical.
+    doc = json.loads(spliced)
+    for component in doc["components"]:
+        component.pop("modelCard", None)
+    assert json.dumps(doc) == original
+
+
+# --- Schema validation ----------------------------------------------------
+
+
+def test_generated_sbom_validates_against_strict_1_7_schema():
+    arts = [artifact(), artifact(name="model.gguf", framework="GGUF", architecture="llama")]
+    validate_1_7(inject_model_cards(build_sbom(arts), arts, FULL_HF_META))
+
+
+def test_sparse_metadata_sbom_also_validates():
+    arts = [artifact()]
+    validate_1_7(inject_model_cards(build_sbom(arts), arts, {"id": "someone/bare-model"}))
+
+
+def test_sbom_with_no_model_cards_at_all_validates():
+    arts = [artifact()]
+    validate_1_7(inject_model_cards(build_sbom(arts), arts, None))
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        FULL_HF_META,
+        {"id": "x/y"},
+        {"cardData": {"datasets": ["only-a-dataset"]}},
+        {"pipeline_tag": "text-generation"},
+        {"config": {"architectures": ["LlamaForCausalLM"]}},
+        {"id": "g/g", "gated": "auto", "private": True},
+    ],
+)
+def test_every_metadata_shape_produces_a_schema_valid_document(meta):
+    """Each optional branch, validated independently — a wrong key type in any
+    one of them would otherwise only surface on the models that hit it."""
+    arts = [artifact()]
+    validate_1_7(inject_model_cards(build_sbom(arts), arts, meta))
+
+
+# --- Additive-only regression guard ---------------------------------------
+
+# Fields whose values are expected to differ run-to-run or by spec version.
+_VOLATILE_TOP_LEVEL = {"specVersion", "$schema", "serialNumber", "metadata"}
+
+
+def test_1_7_output_is_a_strict_superset_of_1_6():
+    """Every component key/value in 1.6 survives verbatim into 1.7.
+
+    This is the no-regression proof for the default flip: a consumer reading
+    1.6 output finds each field it relied on, unchanged, in the 1.7 document.
+    """
+    arts = [artifact(), artifact(name="model.gguf", framework="GGUF", architecture="llama")]
+    bom_1_6 = json.loads(build_sbom(arts, outputter=JsonV1Dot6))
+    bom_1_7 = json.loads(inject_model_cards(build_sbom(arts), arts, FULL_HF_META))
+
+    old = {c["name"]: c for c in bom_1_6["components"]}
+    new = {c["name"]: c for c in bom_1_7["components"]}
+    assert set(old) == set(new), "1.7 must contain exactly the same components"
+
+    for name, old_component in old.items():
+        for key, value in old_component.items():
+            if key == "bom-ref":
+                continue  # a random UUID per run in both documents
+            assert new[name][key] == value, f"{name}.{key} changed between 1.6 and 1.7"
+
+    # And the only added component key is modelCard.
+    for name, new_component in new.items():
+        added = set(new_component) - set(old[name])
+        assert added <= {"modelCard"}, f"{name} grew unexpected keys: {added}"
+
+
+def test_only_the_spec_version_changes_at_the_top_level():
+    arts = [artifact()]
+    bom_1_6 = json.loads(build_sbom(arts, outputter=JsonV1Dot6))
+    bom_1_7 = json.loads(build_sbom(arts, outputter=JsonV1Dot7))
+
+    assert bom_1_6["specVersion"] == "1.6"
+    assert bom_1_7["specVersion"] == "1.7"
+    assert set(bom_1_6) - _VOLATILE_TOP_LEVEL == set(bom_1_7) - _VOLATILE_TOP_LEVEL

--- a/tests/test_modelcard.py
+++ b/tests/test_modelcard.py
@@ -23,7 +23,7 @@ from cyclonedx.output.json import JsonV1Dot6, JsonV1Dot7
 from cyclonedx.schema import SchemaVersion
 from cyclonedx.validation.json import JsonStrictValidator
 
-from aisbom.modelcard import build_model_card, inject_model_cards
+from aisbom.modelcard import bom_ref_for, build_model_card, inject_model_cards
 
 
 # --- Fixtures -------------------------------------------------------------
@@ -70,13 +70,19 @@ def validate_1_7(doc):
 
 
 def build_sbom(artifacts, outputter=JsonV1Dot7):
-    """Serialize artifacts the way cli.py does, without invoking the CLI."""
+    """Serialize artifacts the way cli.py does, without invoking the CLI.
+
+    The `bom_ref` stamping mirrors cli.py exactly — it is the join key the
+    splice relies on, so a helper that skipped it would test a document shape
+    the CLI never produces.
+    """
     bom = Bom()
-    for art in artifacts:
+    for index, art in enumerate(artifacts):
         bom.components.add(
             Component(
                 name=art["name"],
                 type=ComponentType.MACHINE_LEARNING_MODEL,
+                bom_ref=bom_ref_for(index, art),
                 description=f"Risk: {art['risk_level']} | Framework: {art['framework']}",
             )
         )
@@ -209,28 +215,97 @@ def test_injects_into_the_matching_model_component():
 
 
 def test_library_components_never_receive_a_model_card():
+    """The component-type check is the only thing guarding this.
+
+    The library component is deliberately handed the exact bom-ref the splice
+    will look up, so if the type check were dropped it would receive the card.
+    """
+    arts = [artifact(name="model.safetensors")]
     bom = Bom()
-    bom.components.add(Component(name="numpy", version="2.1.0", type=ComponentType.LIBRARY))
-    bom.components.add(Component(name="model.safetensors", type=ComponentType.MACHINE_LEARNING_MODEL))
-    arts = [artifact(name="model.safetensors"), artifact(name="numpy")]
+    bom.components.add(
+        Component(
+            name="numpy",
+            version="2.1.0",
+            bom_ref=bom_ref_for(0, arts[0]),
+            type=ComponentType.LIBRARY,
+        )
+    )
 
     out = json.loads(inject_model_cards(JsonV1Dot7(bom).output_as_string(), arts, FULL_HF_META))
-    by_name = {c["name"]: c for c in out["components"]}
-    assert "modelCard" in by_name["model.safetensors"]
-    assert "modelCard" not in by_name["numpy"], "a library is not a model"
+    (numpy_component,) = out["components"]
+    assert "modelCard" not in numpy_component, "a library is not a model"
 
 
 def test_same_named_artifacts_each_get_a_card():
     """Basename collisions across directories: one card each, not one total."""
-    bom = Bom()
-    for bom_ref in ("a", "b"):
-        bom.components.add(
-            Component(name="model.bin", bom_ref=bom_ref, type=ComponentType.MACHINE_LEARNING_MODEL)
-        )
     arts = [artifact(name="model.bin"), artifact(name="model.bin")]
-
-    out = json.loads(inject_model_cards(JsonV1Dot7(bom).output_as_string(), arts, FULL_HF_META))
+    out = json.loads(inject_model_cards(build_sbom(arts), arts, FULL_HF_META))
     assert all("modelCard" in c for c in out["components"])
+
+
+def test_same_named_artifacts_keep_their_own_cards():
+    """Regression: a name-based join handed one file's card to the other.
+
+    Two `model.gguf` files in different directories with *different*
+    architectures. The library serializes its component collection in its own
+    sorted order, not scan order, so a basename join popping FIFO could
+    produce a component whose `aisbom:gguf:architecture` property contradicts
+    its own `modelCard`.
+
+    Serialization order is deliberately forced *opposite* to scan order here —
+    that is the condition under which the old join silently swapped the cards.
+    Caught by Codex on PR #97; the original test gave both artifacts identical
+    HF metadata, so the swap was invisible.
+    """
+    arts = [
+        artifact(name="model.gguf", framework="GGUF", architecture="llama"),
+        artifact(name="model.gguf", framework="GGUF", architecture="bert"),
+    ]
+    # Refs chosen so the serialized order is the reverse of the scan order.
+    bom = Bom()
+    for ref, art in zip(("zzz", "aaa"), arts):
+        bom.components.add(
+            Component(name=art["name"], bom_ref=ref, type=ComponentType.MACHINE_LEARNING_MODEL)
+        )
+    serialized = json.loads(JsonV1Dot7(bom).output_as_string())
+    assert [c["bom-ref"] for c in serialized["components"]] == ["aaa", "zzz"], (
+        "fixture precondition: serialized order must be reversed vs scan order"
+    )
+
+    # With the real (cli.py-matching) refs, each card lands on its own file
+    # regardless of what order the serializer chose.
+    out = json.loads(inject_model_cards(build_sbom(arts), arts, None))
+    by_ref = {c["bom-ref"]: c for c in out["components"]}
+    assert by_ref["artifact-0-model.gguf"]["modelCard"]["modelParameters"] == {
+        "architectureFamily": "llama"
+    }
+    assert by_ref["artifact-1-model.gguf"]["modelCard"]["modelParameters"] == {
+        "architectureFamily": "bert"
+    }
+
+
+def test_bom_refs_are_stable_across_runs():
+    """The join key must not be a fresh random string on every scan.
+
+    Left to the library, `bom-ref` is regenerated per run — which is both why
+    the splice could not use it before and why nothing downstream could rely
+    on it to identify an artifact between scans.
+    """
+    arts = [artifact(name="a.pt"), artifact(name="b.gguf")]
+    first = [c["bom-ref"] for c in json.loads(build_sbom(arts))["components"]]
+    second = [c["bom-ref"] for c in json.loads(build_sbom(arts))["components"]]
+    assert first == second == ["artifact-0-a.pt", "artifact-1-b.gguf"]
+
+
+def test_a_component_with_no_matching_artifact_gets_no_card():
+    """A component the splice cannot identify is left alone, never guessed at."""
+    bom = Bom()
+    bom.components.add(
+        Component(name="stranger.pt", bom_ref="not-an-artifact-ref", type=ComponentType.MACHINE_LEARNING_MODEL)
+    )
+    arts = [artifact(name="stranger.pt")]
+    out = json.loads(inject_model_cards(JsonV1Dot7(bom).output_as_string(), arts, FULL_HF_META))
+    assert "modelCard" not in out["components"][0]
 
 
 def test_no_cards_returns_the_input_byte_for_byte():

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -279,3 +279,155 @@ def test_scanner_isolates_one_gated_file_and_scans_the_rest(monkeypatch):
     fetch_errors = [e for e in results["errors"] if e.get("fetch_failure")]
     assert len(fetch_errors) == 1
     assert fetch_errors[0]["file"].endswith("boom.safetensors")
+
+
+# ---------------------------------------------------------------------------
+# #111 — HF model-card metadata fetch. Enrichment only: unlike the file
+# listing above, every failure here must degrade silently to None so a gated
+# repo or an HF outage costs a modelCard, never a scan.
+# ---------------------------------------------------------------------------
+
+from aisbom.remote import fetch_huggingface_model_card
+
+
+def test_fetch_model_card_returns_the_api_payload(monkeypatch):
+    payload = {"id": "org/model", "pipeline_tag": "fill-mask"}
+    seen_urls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        seen_urls.append(url)
+        return _mock_response(json.dumps(payload).encode(), status=200)
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    assert fetch_huggingface_model_card("org/model") == payload
+    assert seen_urls == ["https://huggingface.co/api/models/org/model"]
+
+
+def test_fetch_model_card_accepts_the_hf_scheme_prefix(monkeypatch):
+    seen_urls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        seen_urls.append(url)
+        return _mock_response(b"{}", status=200)
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    fetch_huggingface_model_card("hf://org/model")
+    assert seen_urls == ["https://huggingface.co/api/models/org/model"]
+
+
+def test_fetch_model_card_sends_bearer_to_huggingface(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "secret-tok")
+    seen_headers = []
+
+    def fake_get(url, headers=None, timeout=None):
+        seen_headers.append(headers or {})
+        return _mock_response(b"{}", status=200)
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    fetch_huggingface_model_card("org/gated-model")
+    assert seen_headers[0].get("Authorization") == "Bearer secret-tok"
+
+
+@pytest.mark.parametrize("status", [401, 403, 404, 429, 500])
+def test_fetch_model_card_swallows_every_http_failure(monkeypatch, status):
+    """A gated repo, a typo, a rate limit, an outage — all degrade to None."""
+
+    def fake_get(url, headers=None, timeout=None):
+        raise _http_error(status)
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    assert fetch_huggingface_model_card("org/model") is None
+
+
+def test_fetch_model_card_swallows_network_errors(monkeypatch):
+    def fake_get(url, headers=None, timeout=None):
+        raise _requests.exceptions.ConnectTimeout("no route")
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    assert fetch_huggingface_model_card("org/model") is None
+
+
+def test_fetch_model_card_rejects_a_non_object_200(monkeypatch):
+    """An HTML error page or proxy interstitial must not reach the mapper."""
+
+    def fake_get(url, headers=None, timeout=None):
+        return _mock_response(b"[1, 2, 3]", status=200)
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    assert fetch_huggingface_model_card("org/model") is None
+
+
+def test_fetch_model_card_sets_a_timeout(monkeypatch):
+    """A hanging HF API must never be what makes a CI scan hang forever."""
+    seen = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        seen["timeout"] = timeout
+        return _mock_response(b"{}", status=200)
+
+    monkeypatch.setattr(remote, "requests", remote._RequestsStub())
+    monkeypatch.setattr(remote.requests, "get", fake_get)
+    fetch_huggingface_model_card("org/model")
+    assert isinstance(seen["timeout"], (int, float)) and seen["timeout"] > 0
+
+
+def test_local_scan_never_fetches_model_card(monkeypatch, tmp_path):
+    """AC: local scans make no new network calls."""
+
+    def explode(*args, **kwargs):
+        raise AssertionError("a local scan must not touch the HF API")
+
+    monkeypatch.setattr(scanner_module, "fetch_huggingface_model_card", explode)
+    (tmp_path / "notes.txt").write_text("nothing to scan here")
+    results = DeepScanner(str(tmp_path)).scan()
+    assert results["hf_model_card"] is None
+
+
+def test_plain_https_target_does_not_fetch_model_card(monkeypatch):
+    """A single-file URL has no repo to describe — no metadata call."""
+
+    def explode(*args, **kwargs):
+        raise AssertionError("only hf:// targets have a model card")
+
+    monkeypatch.setattr(scanner_module, "fetch_huggingface_model_card", explode)
+    monkeypatch.setattr(
+        "aisbom.scanner.DeepScanner._resolve_remote_targets", lambda self, t: []
+    )
+    results = DeepScanner("https://example.com/model.safetensors").scan()
+    assert results["hf_model_card"] is None
+
+
+def test_hf_scan_attaches_model_card_to_results(monkeypatch):
+    payload = {"id": "org/model", "pipeline_tag": "fill-mask"}
+    monkeypatch.setattr(
+        scanner_module, "fetch_huggingface_model_card", lambda target: payload
+    )
+    monkeypatch.setattr(
+        "aisbom.scanner.DeepScanner._resolve_remote_targets",
+        lambda self, t: ["https://huggingface.co/org/model/resolve/main/m.safetensors"],
+    )
+    # The artifact fetch itself fails; the metadata must still be carried, so
+    # a partly-unreadable repo still produces a described SBOM.
+    results = DeepScanner("hf://org/model").scan()
+    assert results["hf_model_card"] == payload
+
+
+def test_model_card_fetch_failure_does_not_fail_the_scan(monkeypatch):
+    """The asymmetry with the file listing, asserted end to end."""
+    monkeypatch.setattr(
+        scanner_module, "fetch_huggingface_model_card", lambda target: None
+    )
+    monkeypatch.setattr(
+        "aisbom.scanner.DeepScanner._resolve_remote_targets",
+        lambda self, t: ["https://huggingface.co/org/model/resolve/main/m.safetensors"],
+    )
+    results = DeepScanner("hf://org/model").scan()
+    assert results["hf_model_card"] is None
+    # No error recorded for the metadata call itself.
+    assert not [e for e in results["errors"] if "api/models" in str(e.get("file", ""))]


### PR DESCRIPTION
Closes the CLI half of aisbom-ops issue #111. The platform half ([ai-sbom-platform#89](https://github.com/Lab700xOrg/ai-sbom-platform/pull/89), widening `/v1/scan-result` to accept 1.6 **or** 1.7) is already merged and deployed — that had to land first, or a 1.7-emitting CLI would 422 against production.

## What changed

- **Default output is now CycloneDX 1.7 (ECMA-424).** `--schema-version 1.6` / `1.5` still produce byte-identical documents to before.
- **`hf://` scans carry a `modelCard`** — `task`, `architectureFamily`, `modelArchitecture`, training `datasets`, plus `aisbom:hf:*` properties (repo id, licence, library, revision). One extra `GET /api/models/{repo}` per scan.
- **Local scans benefit with no network call** — a GGUF header's own `general.architecture` populates `architectureFamily`.
- **Nothing known → no block at all**, rather than an empty `modelCard: {}`.

## Design notes

**The metadata fetch swallows every failure.** A gated repo, rate limit, or HF outage costs a `modelCard`, never a scan or an exit code. That is deliberately the inverse of the file listing, where a swallowed failure would hide a malicious model (#58).

**`modelCard` is spliced into the serialized JSON.** `cyclonedx-python-lib` 11.x has no `modelCard` support — `Component` accepts no such argument. Splicing keeps the change strictly additive (the library still serializes every existing field byte-identically) at the cost of sitting outside its type checks. Hence `tests/test_modelcard.py` validates generated documents against the bundled `bom-1.7.SNAPSHOT.schema.json` with the **strict** validator — `additionalProperties: false` throughout, so a misspelled key fails the suite rather than shipping.

**Volatile fields are excluded.** `downloads`/`likes` change hourly and would produce phantom drift on the platform's diff.

**HF `cardData.license` is reported, not merged into `licenses`/`legal_status`.** Those drive the platform's `license_issue_count` and the CLI's LEGAL RISK verdict — backfilling them would silently change a compliance judgement. Non-additive, and out of scope here.

## Drive-by fix (please review this bit)

Validating a *real* `hf://` scan surfaced a pre-existing bug. Remote scans store the sentinel `remote_unhashed` in the hash field; the old guard only filtered `hash_error`, so it shipped as a SHA-256 digest. **Every `hf://` SBOM the CLI has ever produced fails CycloneDX validation — at 1.6 as well as 1.7.** AC #1 is unreachable while that ships, so it is fixed here, reusing the digest predicate `spdx_gen` already had for SPDX (#101).

This is the one **non-additive** change in the PR: remote-scan components no longer carry a `hashes` array. It held an invalid sentinel string, but a consumer reading `hashes[0].content` on a remote scan will now find nothing instead of garbage.

## Verification

- `poetry run pytest` — **882 passed**, coverage **91.6%** (floor 85%).
- New `tests/test_modelcard.py` (29 tests): mapping across populated/sparse/absent/malformed metadata, injection rules (libraries never get a card; basename collisions each get one), formatting preservation, and strict 1.7 schema validation of every metadata shape.
- New `tests/test_remote.py` cases: 401/403/404/429/500 + network errors + non-object 200 all degrade to `None`; bearer sent only to `huggingface.co`; a timeout is always set; **a local scan that touches the HF API fails the test**.
- New `tests/test_cli_integration.py` cases: default is 1.7, pinned 1.6 has no `modelCard`, sentinel hashes are never emitted, and the file the CLI actually writes passes strict 1.7 validation.
- **Live end-to-end** on `hf://google-bert/bert-base-uncased`: strict 1.7 validation `PASS`; old-vs-new diff against a 1.6 run of the same target shows `field regressions: NONE`, `added component keys: ['modelCard']`, with descriptions, hashes and `aisbom:*` properties all preserved.
