### PR TITLE
feat(vex): emit OpenVEX and CycloneDX VEX from scan results (#113)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,10 @@ jobs:
           poetry run aisbom scan . --format spdx --output sbom.spdx.json --no-fail-on-risk
           poetry run aisbom scan . --format spdx --spdx-version 3.0 --output sbom.spdx3.json --no-fail-on-risk
           poetry run aisbom scan . --format json --output sbom.json --no-fail-on-risk
+
+      - name: Smoke Test #11 - VEX Export (OpenVEX & CycloneDX VEX)
+        run: |
+          poetry run aisbom scan . --vex --output vex-sbom.json --no-fail-on-risk
+          test -s vex-sbom.openvex.json
+          test -s vex-sbom.vex.cdx.json
+          poetry run aisbom scan . --vex --vex-baseline vex-sbom.json --output vex-rescan.json --no-fail-on-risk

--- a/README.md
+++ b/README.md
@@ -263,6 +263,52 @@ filled with placeholders**, so a consumer can tell "not asserted" from
 "asserted as unknown". `--spdx-version` defaults to `2.3`; existing output is
 unchanged.
 
+### VEX export (exploitability statements)
+
+An SBOM says what is in the model. A VEX document says which of those findings
+actually matter. FDA §524B has required VEX alongside the SBOM since March
+2026.
+
+```bash
+aisbom scan . --vex --output sbom.json
+```
+
+That writes `sbom.openvex.json` (OpenVEX 0.2.0) and `sbom.vex.cdx.json`
+(CycloneDX VEX) next to the SBOM. Use `--vex-format openvex` or
+`--vex-format cyclonedx` for just one. Every statement addresses the SBOM's
+own components by serial number and `bom-ref`, so the documents join without
+guesswork — which is why `--vex` requires the CycloneDX output format.
+
+Statuses follow the VEX vocabulary. The valuable ones are usually the
+negatives: a `.safetensors` model gets a `not_affected` statement for pickle
+deserialization RCE with justification `vulnerable_code_not_present`, which is
+the machine-readable form of "you can stop asking about this one". A scan that
+could not read a pickle stream to completion reports `under_investigation`
+rather than a clean result.
+
+**These identifiers are AIsbom finding classes, not CVE identifiers.** They
+name categories of content found *inside a model file* — a pickle stream
+importing `os.system`, a Keras Lambda layer, a Jinja chat template with a
+sandbox escape. None of those have a CVE, because the file itself is the
+payload rather than a published component with a patchable defect. The full
+registry is at [`docs/vex-finding-classes.md`](docs/vex-finding-classes.md)
+and each identifier resolves under `https://aisbom.io/vex/`. CVE-keyed
+statements about your `requirements.txt` pins are a separate, additive
+concern and arrive with OSV mapping.
+
+#### Remediation evidence (`fixed`)
+
+`fixed` is the one status a single scan cannot honestly assert — it is a claim
+about change over time. Pass a previous SBOM and findings that were present
+then and are absent now are reported as `fixed`:
+
+```bash
+aisbom scan . --vex --vex-baseline last-release-sbom.json --output sbom.json
+```
+
+Baselines predating structured findings still work: the finding is recovered
+from the component description rather than reported as a spurious `fixed`.
+
 ---
 
 ## Use as a GitHub Action

--- a/aisbom/cli.py
+++ b/aisbom/cli.py
@@ -21,6 +21,12 @@ from .scanner import DeepScanner
 from .diff import SBOMDiff
 from .properties import build_component_properties
 from .modelcard import bom_ref_for, inject_model_cards
+from .vex import (
+    baseline_findings,
+    derive_statements,
+    generate_cyclonedx_vex,
+    generate_openvex,
+)
 from .spdx_gen import _sha256_or_none
 
 import threading
@@ -377,10 +383,85 @@ class OutputFormat(str, Enum):
     SPDX = "spdx"
 
 
+class VexFormat(str, Enum):
+    OPENVEX = "openvex"
+    CYCLONEDX = "cyclonedx"
+    BOTH = "both"
+
+
 # `--spdx-version` values the emitter can actually honour. 2.3 stays the
 # default so existing `--format spdx` output is unchanged; 3.0 emits the
 # AI Profile JSON-LD from `spdx3_gen`.
 _SPDX_VERSIONS = {"2.3", "3.0"}
+
+def _vex_paths(output: str) -> tuple[str, str]:
+    """Derive the two VEX filenames from the SBOM's own output path.
+
+    ``sbom.json`` yields ``sbom.openvex.json`` and ``sbom.vex.cdx.json``, so the
+    three files sort together and it is obvious which SBOM they describe.
+    """
+    stem = output[: -len(".json")] if output.endswith(".json") else output
+    return f"{stem}.openvex.json", f"{stem}.vex.cdx.json"
+
+
+def _emit_vex(
+    *,
+    sbom_json: str,
+    artifacts: list[dict],
+    output: str,
+    vex_format: "VexFormat",
+    baseline_path: str | None,
+    schema_version: str,
+) -> None:
+    """Write the VEX document(s) that accompany a just-written SBOM.
+
+    The serial number is read back out of the serialized SBOM rather than off
+    the ``Bom`` object: it is the value the file on disk actually carries, and
+    it is what makes every statement's product reference resolvable.
+    """
+    serial = json.loads(sbom_json).get("serialNumber")
+
+    baseline = None
+    if baseline_path:
+        try:
+            baseline = baseline_findings(baseline_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            # A bad baseline must not silently produce a document claiming
+            # every finding is `fixed` — that is the one failure mode of this
+            # feature a consumer could act on and be badly wrong.
+            err_console.print(
+                f"[bold red]✖ Could not read VEX baseline[/bold red] "
+                f"{baseline_path}: {exc}"
+            )
+            raise typer.Exit(code=1)
+
+    statements = derive_statements(artifacts, baseline)
+    openvex_path, cyclonedx_path = _vex_paths(output)
+
+    if vex_format in (VexFormat.OPENVEX, VexFormat.BOTH):
+        with open(openvex_path, "w") as f:
+            f.write(generate_openvex(statements, sbom_serial=serial))
+        console.print(
+            f"[bold green]✔ VEX Generated:[/bold green] {openvex_path} (OpenVEX 0.2.0)"
+        )
+
+    if vex_format in (VexFormat.CYCLONEDX, VexFormat.BOTH):
+        with open(cyclonedx_path, "w") as f:
+            f.write(generate_cyclonedx_vex(
+                statements, sbom_serial=serial, spec_version=schema_version
+            ))
+        console.print(
+            f"[bold green]✔ VEX Generated:[/bold green] {cyclonedx_path} "
+            f"(CycloneDX v{schema_version} VEX)"
+        )
+
+    affected = sum(1 for s in statements if s.status == "affected")
+    fixed = sum(1 for s in statements if s.status == "fixed")
+    summary = f"[dim]{len(statements)} VEX statement(s): {affected} affected"
+    if fixed:
+        summary += f", {fixed} fixed since baseline"
+    console.print(summary + ".[/dim]")
+
 
 def _generate_markdown(results: dict) -> str:
     """Render a GitHub-flavored Markdown report for CI artifacts."""
@@ -448,6 +529,28 @@ def scan(
             "uploaded SBOM becomes publicly viewable for 30 days."
         ),
     ),
+    vex: bool = typer.Option(
+        False,
+        "--vex",
+        help=(
+            "Also emit VEX documents alongside the SBOM, stating per finding "
+            "whether each scanned artifact is actually affected."
+        ),
+        rich_help_panel="Advanced Options",
+    ),
+    vex_format: VexFormat = typer.Option(
+        VexFormat.BOTH,
+        help="VEX flavor to emit with --vex: openvex, cyclonedx, or both.",
+        rich_help_panel="Advanced Options",
+    ),
+    vex_baseline: str | None = typer.Option(
+        None,
+        help=(
+            "A previous CycloneDX SBOM. Findings present there and absent now "
+            "are reported with VEX status `fixed`."
+        ),
+        rich_help_panel="Advanced Options",
+    ),
 ):
     """
     Deep Introspection Scan: Analyzes binary headers and dependency manifests.
@@ -465,6 +568,25 @@ def scan(
         console.print(
             f"[bold red]✖ Unsupported SPDX version:[/bold red] {spdx_version} "
             f"(expected one of: {', '.join(sorted(_SPDX_VERSIONS))})"
+        )
+        raise typer.Exit(code=1)
+
+    # Rejected up front for the same reason. VEX statements address components
+    # by the CycloneDX document's serial number and bom-refs, so a VEX file
+    # emitted next to a Markdown report or an SPDX document would reference a
+    # document the run never wrote — a dangling cross-reference is worse than
+    # a refusal, and the user finds out now rather than after the scan.
+    if vex and format != OutputFormat.JSON:
+        console.print(
+            "[bold red]✖ --vex requires --format json[/bold red] — VEX "
+            "statements reference the CycloneDX SBOM's components by bom-ref, "
+            f"which a '{format.value}' run does not produce."
+        )
+        raise typer.Exit(code=1)
+
+    if vex and vex_baseline and not Path(vex_baseline).is_file():
+        console.print(
+            f"[bold red]✖ VEX baseline not found:[/bold red] {vex_baseline}"
         )
         raise typer.Exit(code=1)
 
@@ -762,6 +884,16 @@ def scan(
             f.write(sbom_json)
         
         console.print(f"\n[bold green]✔ Compliance Artifact Generated:[/bold green] {output} (CycloneDX v{schema_version})")
+
+        if vex:
+            _emit_vex(
+                sbom_json=sbom_json,
+                artifacts=results['artifacts'],
+                output=output,
+                vex_format=vex_format,
+                baseline_path=vex_baseline,
+                schema_version=schema_version,
+            )
 
         has_content = bool(results.get('artifacts') or results.get('dependencies'))
         if share and has_content:

--- a/aisbom/scanner.py
+++ b/aisbom/scanner.py
@@ -625,6 +625,11 @@ class DeepScanner:
                         # The member is there but could not be read at all. A
                         # loader that does not verify integrity the way we do
                         # would still run it, so this is not a clean bill.
+                        # The structured marker matters as much as the label:
+                        # without it a consumer reading properties rather than
+                        # prose (the VEX emitter, #113) sees an empty threat
+                        # list and concludes the member was inspected and clean.
+                        meta["details"]["scan_incomplete"] = True
                         meta["risk_level"] = "MEDIUM (Unreadable Pickle Member)"
                     elif pickle_files:
                         meta["risk_level"] = "MEDIUM (Pickle Present)"
@@ -865,6 +870,12 @@ class DeepScanner:
                 details["scan_incomplete"] = True
                 meta["risk_level"] = "MEDIUM (Pickle Scan Incomplete)"
             elif unreadable:
+                # Named but never opened — no standard-library decompressor
+                # exists for lz4/zstd. Carries the same structured marker as a
+                # truncated stream: nothing in this container was inspected, so
+                # a consumer reading properties must not read the empty threat
+                # list as a clean result (#113).
+                details["scan_incomplete"] = True
                 meta["risk_level"] = f"MEDIUM (Unscanned Container: {unreadable})"
             elif carries_pickle:
                 meta["risk_level"] = "MEDIUM (Pickle Present)"

--- a/aisbom/vex.py
+++ b/aisbom/vex.py
@@ -350,9 +350,20 @@ def signals_from_artifact(art: Dict[str, Any]) -> Dict[str, Any]:
     details = art.get("details") or {}
     fmt = sig["format"]
 
+    # An inspection that raised produced whatever it had reached and stopped.
+    # The scanner records that as `error` — at the artifact level in most
+    # inspectors and under `details` in the GGUF one — and the resulting detail
+    # dict is simply sparse, which is indistinguishable from "looked and found
+    # nothing" unless it is treated as incompleteness here. It feeds the
+    # per-format flags below so it routes through the same
+    # `under_investigation` paths rather than needing its own branch.
+    inspection_error = bool(art.get("error") or details.get("error"))
+
     if fmt in _PICKLE_BEARING_FORMATS:
         sig["pickle_opcodes"] = list(details.get("threats") or [])
-        sig["pickle_scan_incomplete"] = bool(details.get("scan_incomplete"))
+        sig["pickle_scan_incomplete"] = (
+            bool(details.get("scan_incomplete")) or inspection_error
+        )
         sig["pickle_code_objects"] = bool(details.get("dill_code_objects"))
     elif fmt == "keras":
         sig["keras_threats"] = list(details.get("threats") or [])
@@ -361,13 +372,17 @@ def signals_from_artifact(art: Dict[str, Any]) -> Dict[str, Any]:
         # after the cut would never have been seen — padding a config with
         # harmless layers is cheap and keeps the archive small and loadable.
         # A config that was never located at all cannot be cleared either.
-        sig["keras_incomplete"] = bool(details.get("truncated")) or not details.get(
-            "config_found"
+        sig["keras_incomplete"] = (
+            bool(details.get("truncated"))
+            or not details.get("config_found")
+            or inspection_error
         )
     elif fmt == "gguf":
         sig["gguf_template_present"] = bool(details.get("chat_template_present"))
         sig["gguf_template_threats"] = list(details.get("chat_template_threats") or [])
-        sig["gguf_metadata_truncated"] = bool(details.get("metadata_truncated"))
+        sig["gguf_metadata_truncated"] = (
+            bool(details.get("metadata_truncated")) or inspection_error
+        )
     elif fmt == "onnx":
         sig["onnx_custom_ops"] = len(details.get("custom_ops") or [])
         external = details.get("external_data") or []
@@ -382,8 +397,10 @@ def signals_from_artifact(art: Dict[str, Any]) -> Dict[str, Any]:
         # streamed re-walk did cover in full still reports truncated — this
         # errs toward "we may not have finished looking", which is the safe
         # direction for a compliance claim. See the follow-ups on #113.
-        sig["onnx_incomplete"] = bool(details.get("truncated")) or not details.get(
-            "parsed", True
+        sig["onnx_incomplete"] = (
+            bool(details.get("truncated"))
+            or not details.get("parsed", True)
+            or inspection_error
         )
     return sig
 
@@ -613,17 +630,46 @@ def _classify(cls: FindingClass, sig: Dict[str, Any]) -> Optional[tuple]:
     return None  # pragma: no cover - every class is handled above
 
 
+def _prior_for(
+    art: Dict[str, Any],
+    digest: Optional[str],
+    baseline: Optional[BaselineIndex],
+    name_counts: Dict[str, int],
+) -> Dict[str, str]:
+    """Find this artifact's findings in the baseline, or nothing.
+
+    Content hash first, then a basename unique on *both* sides. Anything
+    ambiguous yields no prior: a missed ``fixed`` costs the document a nice-to
+    -have, while a mis-attributed one asserts a remediation that never
+    happened. See :class:`BaselineIndex`.
+    """
+    if baseline is None:
+        return {}
+    if digest and digest in baseline.by_hash:
+        return baseline.by_hash[digest]
+    name = art.get("name")
+    if name and name_counts.get(name) == 1:
+        return baseline.by_name.get(name, {})
+    return {}
+
+
 def derive_statements(
     artifacts: Sequence[Dict[str, Any]],
-    baseline: Optional[Dict[str, Dict[str, Any]]] = None,
+    baseline: Optional[BaselineIndex] = None,
 ) -> List[VexStatement]:
     """Build the VEX statements for one scan.
 
-    ``baseline`` is the mapping returned by :func:`baseline_findings`. A class
+    ``baseline`` is the index returned by :func:`baseline_findings`. A class
     that was ``affected`` in the baseline and is ``not_affected`` now becomes
     ``fixed`` — the only way AIsbom can honestly assert that status, since a
     single scan observes one point in time.
     """
+    name_counts: Dict[str, int] = {}
+    for art in artifacts:
+        name = art.get("name")
+        if name:
+            name_counts[name] = name_counts.get(name, 0) + 1
+
     statements: List[VexStatement] = []
     for index, art in enumerate(artifacts):
         sig = signals_from_artifact(art)
@@ -631,7 +677,7 @@ def derive_statements(
             continue
         ref = bom_ref_for(index, art)
         digest = _sha256_or_none(art.get("hash"))
-        prior = (baseline or {}).get(ref, {})
+        prior = _prior_for(art, digest, baseline, name_counts)
 
         for cls in VEX_FINDING_CLASSES:
             classified = _classify(cls, sig)
@@ -668,13 +714,51 @@ def derive_statements(
     return statements
 
 
-def baseline_findings(sbom: Any) -> Dict[str, Dict[str, str]]:
-    """Map ``bom-ref -> {finding class id: status}`` from a previous SBOM.
+@dataclass(frozen=True)
+class BaselineIndex:
+    """A previous scan's findings, addressable by an identity that survives it.
+
+    **Not** keyed on ``bom-ref``. That identifier embeds the artifact's
+    enumeration index (``artifact-<n>-<name>``, see
+    :func:`aisbom.modelcard.bom_ref_for`), which is stable *within* a scan —
+    which is all #111 needed it for — and not across two. Adding one file
+    earlier in the tree shifts every later index, so matching on it would miss
+    a genuinely remediated finding and report ``not_affected`` instead of
+    ``fixed``.
+
+    The serious case is worse than a miss. Artifact names are basenames, so a
+    tree holding ``a/model.pt`` and ``b/model.pt`` yields two components whose
+    refs differ only by index. If their order swaps between scans, the affected
+    baseline entry lands on the *other*, always-clean artifact and the document
+    claims it was fixed — a fabricated remediation, in the artifact whose whole
+    purpose is evidencing remediation.
+
+    So identity is content first, name second, and neither when ambiguous:
+
+    * ``by_hash`` — SHA-256 is unforgeable identity, but only proves the file
+      is byte-identical. Remediation usually *changes* the file, so this mostly
+      serves to disambiguate same-named artifacts rather than to find fixes.
+    * ``by_name`` — holds only names that appear exactly once in the baseline.
+      A duplicated basename is dropped rather than guessed at.
+
+    The caller additionally requires the name to be unique in the *current*
+    scan. Where identity cannot be established, no prior is claimed and the
+    finding is simply reported on its own merits — a missed ``fixed`` is a
+    disappointing document; a fabricated one is a false statement.
+    """
+
+    by_hash: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    by_name: Dict[str, Dict[str, str]] = field(default_factory=dict)
+
+
+def baseline_findings(sbom: Any) -> BaselineIndex:
+    """Build a :class:`BaselineIndex` of ``{finding class id: status}`` from a
+    previous CycloneDX SBOM.
 
     Accepts a path, a JSON string or an already-parsed document. Only
     ``affected`` entries matter to the caller (they are what a later scan can
-    report as ``fixed``), but the full classification is returned so the
-    mapping stays useful if that changes.
+    report as ``fixed``), but the full classification is kept so the mapping
+    stays useful if that changes.
     """
     if isinstance(sbom, dict):
         document = sbom
@@ -685,11 +769,11 @@ def baseline_findings(sbom: Any) -> Dict[str, Dict[str, str]]:
                 text = fh.read()
         document = json.loads(text)
 
-    findings: Dict[str, Dict[str, str]] = {}
+    by_hash: Dict[str, Dict[str, str]] = {}
+    by_name: Dict[str, Dict[str, str]] = {}
+    seen_names: Dict[str, int] = {}
+
     for component in document.get("components") or []:
-        ref = component.get("bom-ref")
-        if not ref:
-            continue
         sig = signals_from_component(component)
         if sig["format"] is None:
             continue
@@ -698,8 +782,24 @@ def baseline_findings(sbom: Any) -> Dict[str, Dict[str, str]]:
             classified = _classify(cls, sig)
             if classified is not None:
                 per_class[cls.id] = classified[0]
-        findings[ref] = per_class
-    return findings
+
+        for entry in component.get("hashes") or []:
+            if str(entry.get("alg")).upper().replace("_", "-") == "SHA-256":
+                digest = _sha256_or_none(entry.get("content"))
+                if digest:
+                    by_hash[digest] = per_class
+
+        name = component.get("name")
+        if name:
+            seen_names[name] = seen_names.get(name, 0) + 1
+            by_name[name] = per_class
+
+    # A basename that occurs more than once identifies nothing.
+    for name, count in seen_names.items():
+        if count > 1:
+            by_name.pop(name, None)
+
+    return BaselineIndex(by_hash=by_hash, by_name=by_name)
 
 
 # --------------------------------------------------------------------------

--- a/aisbom/vex.py
+++ b/aisbom/vex.py
@@ -1,0 +1,933 @@
+"""VEX (Vulnerability Exploitability eXchange) output — OpenVEX + CycloneDX VEX.
+
+Why the statements are keyed on AIsbom finding classes
+------------------------------------------------------
+
+VEX exists to say, per vulnerability, whether a product is actually affected.
+That normally means a CVE. AIsbom has no CVE feed: what it detects is content
+*inside a model file* — a pickle stream importing ``os.system``, a Keras Lambda
+layer carrying marshalled code, a Jinja chat template with a sandbox escape.
+None of those have a CVE and none ever will, because they are not defects in a
+published component; the file itself is the payload.
+
+So the statements are keyed on a small, stable vocabulary of **finding
+classes** owned by AIsbom (``VEX_FINDING_CLASSES`` below). Deliberate
+consequences of that choice:
+
+* They are **not** CVE identifiers and are never shaped like one. The docs and
+  the README say so in those words. A compliance artifact that implied a CVE
+  association it does not have would be worse than one that omits the finding.
+* ``aliases`` is supported by both emitters and is **empty for every class
+  today**. The CVEs AIsbom's bypass corpus knows (CVE-2025-1889/1944/1945,
+  CVE-2025-10155/10156/10157, CVE-2025-1716) are vulnerabilities in
+  *picklescan* — a different scanner failing to detect something — not in the
+  scanned model. Aliasing a finding to one would be a factual error.
+* The vocabulary is **coarse on purpose**: seven class-level IDs, not one per
+  opcode. A small vocabulary is cheap to keep stable forever; a granular one is
+  not, and these strings are permanent the moment they reach a customer.
+* Each class carries a dereferenceable ``@id`` under ``https://aisbom.io/vex/``
+  so a consumer meeting an unfamiliar identifier can resolve it, and CycloneDX
+  output names AIsbom as the ``source`` rather than leaving the ID an orphan.
+
+Compatibility policy
+--------------------
+
+These identifiers live in documents on other people's disks — an FDA
+submission folder, a CI artifact, an audit archive — long after the scan that
+produced them. Two things depend on them, and both fail *silently* rather than
+loudly: automated rules ("fail the build if ``AISBOM-PICKLE-RCE`` is
+affected"), and longitudinal comparison, where a renamed class reads as one
+finding resolved and a different one opened — the exact wrong conclusion in the
+document meant to prevent wrong conclusions.
+
+The promise is therefore not "a class is never renamed" — that is a promise
+about future judgement, which is hard to keep. It is **a consumer is never
+broken**:
+
+1. A class is never deleted, and an identifier is never reused for a different
+   meaning.
+2. If a class is renamed, the successor carries the old identifier in
+   ``aliases``, so a rule matching the old string keeps matching. This is what
+   the VEX ``aliases`` field is for — it means "other names for this same
+   finding", which a retired identifier is. (The same field also carries real
+   CVE identifiers when one applies; both uses are "another name for this".)
+3. Every identifier ever published is listed in
+   :data:`PUBLISHED_FINDING_CLASS_IDS`, which is **append-only**, and a test
+   asserts each one is still resolvable — either currently emitted or aliased
+   by its successor. That makes the policy mechanically enforced rather than a
+   comment someone has to remember.
+
+When OSV/CVE mapping for the dependency components lands, those statements join
+the same ``statements`` list with no change visible to a consumer — the
+emitters take a list of :class:`VexStatement` and do not care where one came
+from.
+
+Scoping of negative statements
+------------------------------
+
+A ``not_affected`` claim is only worth making where AIsbom actually looked. A
+class is therefore asserted — positively or negatively — only for the formats
+listed in its ``formats`` set, and never for a format the class cannot arise in
+(no ONNX custom-operator statement about a ``.safetensors``).
+
+The one non-obvious exclusion is Keras. ``AISBOM-PICKLE-RCE`` covers every
+format whose pickle content AIsbom disassembles, plus the formats that
+structurally cannot carry a pickle stream at all (SafeTensors, GGUF, ONNX) —
+for which the negative is the strongest claim in the document. Keras is in
+neither group: ``_inspect_keras`` reads the model config with
+``scan_keras_config``, not ``scan_pickle_stream``, so a pickle embedded in a
+``.keras`` container is not disassembled. Asserting ``not_affected`` there
+would be an over-claim, so Keras receives only its own class.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+from .modelcard import bom_ref_for
+from .properties import _FRAMEWORK_TO_FORMAT, _PICKLE_BEARING_FORMATS
+from .spdx_gen import _sha256_or_none, _tool_version
+
+# The released OpenVEX context IRI. The spec pins the document's `@context`, so
+# this is not a formatting preference.
+OPENVEX_CONTEXT = "https://openvex.dev/ns/v0.2.0"
+
+# Where a finding class ID resolves. Making the identifier dereferenceable is
+# what keeps an unfamiliar namespace usable to a consumer rather than opaque.
+VEX_NAMESPACE = "https://aisbom.io/vex/"
+
+VEX_AUTHOR = "AIsbom"
+
+# The four OpenVEX statuses. CycloneDX names the same concepts differently, so
+# OpenVEX is treated as canonical and mapped on emit.
+STATUS_AFFECTED = "affected"
+STATUS_NOT_AFFECTED = "not_affected"
+STATUS_FIXED = "fixed"
+STATUS_UNDER_INVESTIGATION = "under_investigation"
+
+# The single justification AIsbom ever asserts. OpenVEX offers five and
+# CycloneDX nine, and the two vocabularies do not line up: mapping more of them
+# would mean choosing an inexact CycloneDX analogue for at least one, which in
+# a compliance artifact is a lie with extra steps. `vulnerable_code_not_present`
+# maps exactly onto CycloneDX's `code_not_present`, and it is also the only
+# justification AIsbom can actually support from a static read of a file — it
+# never observes an execute path, a perimeter control or a runtime mitigation.
+JUSTIFICATION_CODE_NOT_PRESENT = "vulnerable_code_not_present"
+
+# OpenVEX status -> CycloneDX `analysis.state`.
+_CDX_STATE = {
+    STATUS_AFFECTED: "exploitable",
+    STATUS_NOT_AFFECTED: "not_affected",
+    STATUS_FIXED: "resolved",
+    STATUS_UNDER_INVESTIGATION: "in_triage",
+}
+
+# OpenVEX justification -> CycloneDX `analysis.justification`.
+_CDX_JUSTIFICATION = {
+    JUSTIFICATION_CODE_NOT_PRESENT: "code_not_present",
+}
+
+# Format tokens (as `properties.py` assigns them) that cannot carry a pickle
+# stream at all. The negative pickle-RCE statement on these is a structural
+# claim about the format, not a result of disassembly.
+_PICKLE_FREE_FORMATS = frozenset({"safetensors", "gguf", "onnx"})
+
+# Formats the pickle-RCE class is assertable on, positively or negatively.
+_PICKLE_RCE_FORMATS = frozenset(_PICKLE_BEARING_FORMATS) | _PICKLE_FREE_FORMATS
+
+
+@dataclass(frozen=True)
+class FindingClass:
+    """One entry in AIsbom's VEX vocabulary.
+
+    This table is the single source of truth for the namespace: the emitters,
+    ``docs/vex-finding-classes.md`` and the pinned-ID test all read it, so a
+    class cannot be added, renamed or dropped in only one of those places.
+    """
+
+    id: str
+    title: str
+    description: str
+    #: Remediation text used as `action_statement` on an `affected` statement.
+    action: str
+    #: Format tokens this class may be asserted on. See the module docstring.
+    formats: frozenset
+    #: Real CVE/GHSA identifiers for the same issue. Empty for every class
+    #: today — see the module docstring for why.
+    aliases: tuple = ()
+
+    @property
+    def iri(self) -> str:
+        return f"{VEX_NAMESPACE}{self.id}"
+
+
+VEX_FINDING_CLASSES: tuple = (
+    FindingClass(
+        id="AISBOM-PICKLE-RCE",
+        title="Pickle stream imports a code-executing global",
+        description=(
+            "The artifact carries a Python pickle stream whose opcodes import a "
+            "global that executes code when the stream is deserialized "
+            "(os.system, subprocess.Popen, builtins.eval and similar). "
+            "Deserialization is the execution — no separate trigger is needed."
+        ),
+        action=(
+            "Do not load this file with torch.load/pickle.load. Obtain the model "
+            "in a non-executable format (SafeTensors) or from a trusted source, "
+            "and treat the file as active malware rather than as a defective "
+            "dependency to patch."
+        ),
+        formats=_PICKLE_RCE_FORMATS,
+    ),
+    FindingClass(
+        id="AISBOM-PICKLE-CODE-OBJECT",
+        title="Serialized Python code objects embedded in the pickle stream",
+        description=(
+            "The pickle stream carries dill-serialized code objects — whole "
+            "Python functions marshalled into the file. The bytecode is "
+            "reconstructed on load, so what the model does is not limited to "
+            "what its declared imports suggest."
+        ),
+        action=(
+            "Do not load this file outside an isolated sandbox. Re-export the "
+            "model from its source framework so that weights, not code, are "
+            "what is serialized."
+        ),
+        formats=frozenset(_PICKLE_BEARING_FORMATS),
+    ),
+    FindingClass(
+        id="AISBOM-PICKLE-UNSCANNED",
+        title="Pickle data present but not fully disassembled",
+        description=(
+            "A pickle stream was found but could not be read to completion — a "
+            "truncated or malformed stream, an unreadable archive member, or a "
+            "container AIsbom does not decompress. Absence of a finding here is "
+            "not evidence of absence: this is the nullifAI evasion class, where "
+            "a deliberately broken stream is used to end a scan early."
+        ),
+        action=(
+            "Re-scan the artifact from its original archive, or decompress the "
+            "container and scan the members individually, before loading it."
+        ),
+        formats=frozenset(_PICKLE_BEARING_FORMATS),
+    ),
+    FindingClass(
+        id="AISBOM-KERAS-LAMBDA-RCE",
+        title="Keras Lambda layer or marshalled code object executes on load",
+        description=(
+            "The Keras model config declares a Lambda layer or carries a "
+            "marshalled Python code object. keras.models.load_model "
+            "reconstructs and can invoke it, so loading the model runs "
+            "attacker-chosen bytecode."
+        ),
+        action=(
+            "Load with safe_mode=True (Keras 3), or rebuild the layer in your "
+            "own code and load weights only. Do not load with "
+            "safe_mode=False or on Keras 2."
+        ),
+        formats=frozenset({"keras"}),
+    ),
+    FindingClass(
+        id="AISBOM-GGUF-TEMPLATE-INJECTION",
+        title="GGUF chat template contains a sandbox escape or dangerous call",
+        description=(
+            "The Jinja chat template stored in the GGUF metadata contains "
+            "constructs that reach outside the template sandbox or invoke "
+            "dangerous callables. The template is evaluated on every inference "
+            "request, so this executes at serving time rather than at load."
+        ),
+        action=(
+            "Replace the chat template with one you control, or serve the model "
+            "through a runtime that does not evaluate the embedded template."
+        ),
+        formats=frozenset({"gguf"}),
+    ),
+    FindingClass(
+        id="AISBOM-ONNX-CUSTOM-OP",
+        title="ONNX graph references operators outside the standard domains",
+        description=(
+            "The graph calls operators that are not part of the standard ONNX "
+            "domains, so executing it requires loading a third-party operator "
+            "library. What that library does is outside the model file and "
+            "outside this scan."
+        ),
+        action=(
+            "Identify and review the operator library the graph requires before "
+            "running inference, or re-export the model using standard operators."
+        ),
+        formats=frozenset({"onnx"}),
+    ),
+    FindingClass(
+        id="AISBOM-ONNX-EXTERNAL-DATA",
+        title="ONNX tensor data stored outside the model file",
+        description=(
+            "Tensor data is held in separate files referenced by the graph, so "
+            "the model's weights are not covered by this artifact's hash. A "
+            "reference that resolves outside the model directory additionally "
+            "turns loading the model into a read of a file the author chose."
+        ),
+        action=(
+            "Scan and pin the external tensor files alongside the model, and "
+            "reject any reference that resolves outside the model directory."
+        ),
+        formats=frozenset({"onnx"}),
+    ),
+)
+
+FINDING_CLASSES_BY_ID: Dict[str, FindingClass] = {
+    c.id: c for c in VEX_FINDING_CLASSES
+}
+
+#: Every finding-class identifier this project has ever published, in the order
+#: it was introduced. **Append-only.**
+#:
+#: Deleting an entry is what silently breaks somebody's build gate, so the test
+#: suite asserts each of these is still resolvable: either emitted by a class in
+#: ``VEX_FINDING_CLASSES``, or listed in a current class's ``aliases`` because
+#: it was renamed. Adding a class means adding it here too; retiring one means
+#: aliasing it from its successor, never removing the line.
+PUBLISHED_FINDING_CLASS_IDS: tuple = (
+    "AISBOM-PICKLE-RCE",
+    "AISBOM-PICKLE-CODE-OBJECT",
+    "AISBOM-PICKLE-UNSCANNED",
+    "AISBOM-KERAS-LAMBDA-RCE",
+    "AISBOM-GGUF-TEMPLATE-INJECTION",
+    "AISBOM-ONNX-CUSTOM-OP",
+    "AISBOM-ONNX-EXTERNAL-DATA",
+)
+
+
+@dataclass(frozen=True)
+class VexStatement:
+    """One assertion: a finding class, a product, a status and why."""
+
+    finding_class: FindingClass
+    product_ref: str
+    product_id: str
+    product_hash: Optional[str]
+    status: str
+    justification: Optional[str] = None
+    status_notes: str = ""
+    action_statement: Optional[str] = None
+
+
+# --------------------------------------------------------------------------
+# Signals — the one shape both derivation paths agree on.
+#
+# A live scan reads the scanner's `details` dict; a baseline SBOM reads the
+# `aisbom:*` component properties. Normalising both into the same dict is what
+# keeps the taxonomy in one place: `_classify` is written once, against
+# signals, and never learns which side it came from.
+# --------------------------------------------------------------------------
+
+def _empty_signals() -> Dict[str, Any]:
+    return {
+        "format": None,
+        "pickle_opcodes": [],
+        "pickle_scan_incomplete": False,
+        "pickle_code_objects": False,
+        "keras_threats": [],
+        "keras_lambda_layers": [],
+        "keras_incomplete": False,
+        "gguf_template_present": False,
+        "gguf_template_threats": [],
+        "gguf_metadata_truncated": False,
+        "onnx_custom_ops": 0,
+        "onnx_external_data": 0,
+        "onnx_external_escape": False,
+        "onnx_incomplete": False,
+    }
+
+
+def signals_from_artifact(art: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalise a scanner artifact dict into the shared signal shape."""
+    sig = _empty_signals()
+    sig["format"] = _FRAMEWORK_TO_FORMAT.get(art.get("framework"))
+    details = art.get("details") or {}
+    fmt = sig["format"]
+
+    if fmt in _PICKLE_BEARING_FORMATS:
+        sig["pickle_opcodes"] = list(details.get("threats") or [])
+        sig["pickle_scan_incomplete"] = bool(details.get("scan_incomplete"))
+        sig["pickle_code_objects"] = bool(details.get("dill_code_objects"))
+    elif fmt == "keras":
+        sig["keras_threats"] = list(details.get("threats") or [])
+        sig["keras_lambda_layers"] = list(details.get("lambda_layers") or [])
+        # The config read stops at a byte budget, and a Lambda layer sitting
+        # after the cut would never have been seen — padding a config with
+        # harmless layers is cheap and keeps the archive small and loadable.
+        # A config that was never located at all cannot be cleared either.
+        sig["keras_incomplete"] = bool(details.get("truncated")) or not details.get(
+            "config_found"
+        )
+    elif fmt == "gguf":
+        sig["gguf_template_present"] = bool(details.get("chat_template_present"))
+        sig["gguf_template_threats"] = list(details.get("chat_template_threats") or [])
+        sig["gguf_metadata_truncated"] = bool(details.get("metadata_truncated"))
+    elif fmt == "onnx":
+        sig["onnx_custom_ops"] = len(details.get("custom_ops") or [])
+        external = details.get("external_data") or []
+        sig["onnx_external_data"] = len(external)
+        sig["onnx_external_escape"] = any(
+            str(t).startswith("ONNX_EXTERNAL_DATA_ESCAPE:")
+            for t in (details.get("threats") or [])
+        )
+        # A graph read only to the byte budget may hold custom operators or
+        # external-data entries past the cut. ``details["truncated"]`` is
+        # computed from the buffered read, so a large *local* file that the
+        # streamed re-walk did cover in full still reports truncated — this
+        # errs toward "we may not have finished looking", which is the safe
+        # direction for a compliance claim. See the follow-ups on #113.
+        sig["onnx_incomplete"] = bool(details.get("truncated")) or not details.get(
+            "parsed", True
+        )
+    return sig
+
+
+_RCE_DESC_RE = re.compile(r"RCE Detected:\s*([^)]*)\)")
+
+
+def signals_from_component(component: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalise a serialized CycloneDX component into the shared signal shape.
+
+    Reads the structured ``aisbom:*`` properties that #53/#54 added. A baseline
+    SBOM produced before those shipped carries none, so the pickle-RCE signal
+    degrades to the ``description`` string — which has always named the
+    offending globals — rather than silently reporting a clean baseline and
+    turning every pre-existing finding into a spurious ``fixed``.
+    """
+    sig = _empty_signals()
+    props: Dict[str, List[str]] = {}
+    for prop in component.get("properties") or []:
+        name = prop.get("name")
+        if name:
+            props.setdefault(name, []).append(prop.get("value"))
+
+    fmt_values = props.get("aisbom:format")
+    sig["format"] = fmt_values[0] if fmt_values else None
+
+    if props:
+        sig["pickle_opcodes"] = list(props.get("aisbom:pickle:opcode") or [])
+        sig["pickle_scan_incomplete"] = "true" in (
+            props.get("aisbom:pickle:scan_incomplete") or []
+        )
+        sig["pickle_code_objects"] = "true" in (
+            props.get("aisbom:pickle:dill_code_objects") or []
+        )
+        sig["keras_threats"] = list(props.get("aisbom:keras:threat") or [])
+        sig["keras_lambda_layers"] = [
+            v for csv in (props.get("aisbom:keras:lambda_layers") or [])
+            for v in str(csv).split(",") if v
+        ]
+        sig["gguf_template_present"] = "present" in (
+            props.get("aisbom:gguf:chat_template") or []
+        )
+        sig["gguf_template_threats"] = list(
+            props.get("aisbom:gguf:chat_template_threat") or []
+        )
+        custom_op_count = props.get("aisbom:onnx:custom_op_count")
+        sig["onnx_custom_ops"] = int(custom_op_count[0]) if custom_op_count else 0
+        external_count = props.get("aisbom:onnx:external_data_count")
+        sig["onnx_external_data"] = int(external_count[0]) if external_count else 0
+        sig["onnx_external_escape"] = any(
+            str(t).startswith("ONNX_EXTERNAL_DATA_ESCAPE:")
+            for t in (props.get("aisbom:onnx:threat") or [])
+        )
+        return sig
+
+    # Pre-#54 baseline: recover what the description string carries.
+    description = component.get("description") or ""
+    match = _RCE_DESC_RE.search(description)
+    if match:
+        sig["pickle_opcodes"] = [
+            part.strip() for part in match.group(1).split(",") if part.strip()
+        ]
+    framework = re.search(r"Framework:\s*([^|]+)", description)
+    if framework:
+        sig["format"] = _FRAMEWORK_TO_FORMAT.get(framework.group(1).strip())
+    return sig
+
+
+def _classify(cls: FindingClass, sig: Dict[str, Any]) -> Optional[tuple]:
+    """Return ``(status, notes)`` for one class against one artifact's signals.
+
+    ``None`` means the class is not assertable here — either the format is
+    outside its scope, or AIsbom did not look. That is different from
+    ``not_affected``, which is a claim.
+    """
+    fmt = sig.get("format")
+    if fmt is None or fmt not in cls.formats:
+        return None
+
+    if cls.id == "AISBOM-PICKLE-RCE":
+        opcodes = sig["pickle_opcodes"]
+        if opcodes:
+            return (
+                STATUS_AFFECTED,
+                "Pickle disassembly found code-executing global(s): "
+                + ", ".join(str(o) for o in opcodes)
+                + ". The file is the payload, not a component with a patchable "
+                "defect — there is no fixed version to upgrade to.",
+            )
+        if fmt in _PICKLE_FREE_FORMATS:
+            return (
+                STATUS_NOT_AFFECTED,
+                f"The {fmt} format carries no Python pickle stream, so no "
+                "deserialization code path exists in this artifact.",
+            )
+        if sig["pickle_scan_incomplete"]:
+            # The stream was not read to the end, so "no dangerous global" is
+            # not something this scan is entitled to assert.
+            return (
+                STATUS_UNDER_INVESTIGATION,
+                "The pickle stream could not be disassembled to completion, so "
+                "the absence of a code-executing global is not established.",
+            )
+        return (
+            STATUS_NOT_AFFECTED,
+            "The pickle stream was disassembled in full and imports no "
+            "code-executing global.",
+        )
+
+    if cls.id == "AISBOM-PICKLE-CODE-OBJECT":
+        if sig["pickle_code_objects"]:
+            return (
+                STATUS_AFFECTED,
+                "The stream carries dill-serialized code objects.",
+            )
+        if sig["pickle_scan_incomplete"]:
+            return (
+                STATUS_UNDER_INVESTIGATION,
+                "The pickle stream could not be disassembled to completion.",
+            )
+        return (
+            STATUS_NOT_AFFECTED,
+            "No serialized code objects were found in the pickle stream.",
+        )
+
+    if cls.id == "AISBOM-PICKLE-UNSCANNED":
+        if sig["pickle_scan_incomplete"]:
+            return (
+                STATUS_UNDER_INVESTIGATION,
+                "Pickle data was found but not read to completion, so this scan "
+                "does not establish what the stream contains.",
+            )
+        return (
+            STATUS_NOT_AFFECTED,
+            "The pickle data in this artifact was read to completion.",
+        )
+
+    if cls.id == "AISBOM-KERAS-LAMBDA-RCE":
+        if sig["keras_threats"] or sig["keras_lambda_layers"]:
+            named = ", ".join(dict.fromkeys(sig["keras_lambda_layers"]))
+            detail = f" Lambda layer(s): {named}." if named else ""
+            return (
+                STATUS_AFFECTED,
+                "The Keras model config declares executable content."
+                + detail
+                + " Loading the model reconstructs and can invoke it.",
+            )
+        if sig["keras_incomplete"]:
+            return (
+                STATUS_UNDER_INVESTIGATION,
+                "The Keras model config was not read in full, so a Lambda layer "
+                "declared beyond the read limit would not have been seen.",
+            )
+        return (
+            STATUS_NOT_AFFECTED,
+            "The Keras model config declares no Lambda layer and carries no "
+            "marshalled code object.",
+        )
+
+    if cls.id == "AISBOM-GGUF-TEMPLATE-INJECTION":
+        if sig["gguf_template_threats"]:
+            return (
+                STATUS_AFFECTED,
+                "The embedded Jinja chat template contains: "
+                + "; ".join(str(t) for t in sig["gguf_template_threats"])
+                + ".",
+            )
+        if sig["gguf_metadata_truncated"]:
+            return (
+                STATUS_UNDER_INVESTIGATION,
+                "The GGUF metadata block did not fit the scan window, so any "
+                "chat template beyond it was never read.",
+            )
+        if sig["gguf_template_present"]:
+            return (
+                STATUS_NOT_AFFECTED,
+                "The embedded chat template was inspected and contains no "
+                "sandbox escape or dangerous call.",
+            )
+        return (
+            STATUS_NOT_AFFECTED,
+            "The GGUF metadata carries no chat template.",
+        )
+
+    if cls.id == "AISBOM-ONNX-CUSTOM-OP":
+        if sig["onnx_custom_ops"]:
+            return (
+                STATUS_AFFECTED,
+                f"The graph references {sig['onnx_custom_ops']} operator(s) "
+                "outside the standard ONNX domains.",
+            )
+        if sig["onnx_incomplete"]:
+            return (
+                STATUS_UNDER_INVESTIGATION,
+                "The ONNX graph was not walked in full, so an operator beyond "
+                "the read limit would not have been seen.",
+            )
+        return (
+            STATUS_NOT_AFFECTED,
+            "Every operator in the graph belongs to a standard ONNX domain.",
+        )
+
+    if cls.id == "AISBOM-ONNX-EXTERNAL-DATA":
+        if sig["onnx_external_data"]:
+            escape = (
+                " At least one reference resolves outside the model directory."
+                if sig["onnx_external_escape"]
+                else ""
+            )
+            return (
+                STATUS_AFFECTED,
+                f"The graph stores tensor data in {sig['onnx_external_data']} "
+                "file(s) outside the model, which this artifact's hash does not "
+                "cover." + escape,
+            )
+        if sig["onnx_incomplete"]:
+            return (
+                STATUS_UNDER_INVESTIGATION,
+                "The ONNX graph was not walked in full, so an external-data "
+                "entry beyond the read limit would not have been seen.",
+            )
+        return (
+            STATUS_NOT_AFFECTED,
+            "All tensor data is stored inside the model file.",
+        )
+
+    return None  # pragma: no cover - every class is handled above
+
+
+def derive_statements(
+    artifacts: Sequence[Dict[str, Any]],
+    baseline: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> List[VexStatement]:
+    """Build the VEX statements for one scan.
+
+    ``baseline`` is the mapping returned by :func:`baseline_findings`. A class
+    that was ``affected`` in the baseline and is ``not_affected`` now becomes
+    ``fixed`` — the only way AIsbom can honestly assert that status, since a
+    single scan observes one point in time.
+    """
+    statements: List[VexStatement] = []
+    for index, art in enumerate(artifacts):
+        sig = signals_from_artifact(art)
+        if sig["format"] is None:
+            continue
+        ref = bom_ref_for(index, art)
+        digest = _sha256_or_none(art.get("hash"))
+        prior = (baseline or {}).get(ref, {})
+
+        for cls in VEX_FINDING_CLASSES:
+            classified = _classify(cls, sig)
+            if classified is None:
+                continue
+            status, notes = classified
+
+            if (
+                status == STATUS_NOT_AFFECTED
+                and prior.get(cls.id) == STATUS_AFFECTED
+            ):
+                status = STATUS_FIXED
+                notes = (
+                    "Present in the baseline SBOM and absent from this scan. "
+                    + notes
+                )
+
+            statements.append(
+                VexStatement(
+                    finding_class=cls,
+                    product_ref=ref,
+                    product_id="",  # filled in by the emitters, which know the serial
+                    product_hash=digest,
+                    status=status,
+                    justification=(
+                        JUSTIFICATION_CODE_NOT_PRESENT
+                        if status == STATUS_NOT_AFFECTED
+                        else None
+                    ),
+                    status_notes=notes,
+                    action_statement=cls.action if status == STATUS_AFFECTED else None,
+                )
+            )
+    return statements
+
+
+def baseline_findings(sbom: Any) -> Dict[str, Dict[str, str]]:
+    """Map ``bom-ref -> {finding class id: status}`` from a previous SBOM.
+
+    Accepts a path, a JSON string or an already-parsed document. Only
+    ``affected`` entries matter to the caller (they are what a later scan can
+    report as ``fixed``), but the full classification is returned so the
+    mapping stays useful if that changes.
+    """
+    if isinstance(sbom, dict):
+        document = sbom
+    else:
+        text = sbom
+        if not (isinstance(sbom, str) and sbom.lstrip().startswith("{")):
+            with open(sbom, "r") as fh:
+                text = fh.read()
+        document = json.loads(text)
+
+    findings: Dict[str, Dict[str, str]] = {}
+    for component in document.get("components") or []:
+        ref = component.get("bom-ref")
+        if not ref:
+            continue
+        sig = signals_from_component(component)
+        if sig["format"] is None:
+            continue
+        per_class = {}
+        for cls in VEX_FINDING_CLASSES:
+            classified = _classify(cls, sig)
+            if classified is not None:
+                per_class[cls.id] = classified[0]
+        findings[ref] = per_class
+    return findings
+
+
+# --------------------------------------------------------------------------
+# Emitters
+# --------------------------------------------------------------------------
+
+def _timestamp(value: Optional[datetime] = None) -> str:
+    return (value or datetime.now(timezone.utc)).isoformat(timespec="seconds")
+
+
+def _product_id(sbom_serial: str, ref: str) -> str:
+    """Address a component inside the SBOM this scan produced.
+
+    The serial number identifies the document and the fragment identifies the
+    component within it, so a consumer holding both files can join them without
+    guessing — which is what makes the VEX statements about *this* scan rather
+    than about a filename that may recur across scans.
+    """
+    return f"{sbom_serial}#{ref}"
+
+
+def generate_openvex(
+    statements: Sequence[VexStatement],
+    *,
+    sbom_serial: str,
+    timestamp: Optional[datetime] = None,
+    document_id: Optional[str] = None,
+) -> str:
+    """Serialize statements as an OpenVEX 0.2.0 document."""
+    now = _timestamp(timestamp)
+    doc: Dict[str, Any] = {
+        "@context": OPENVEX_CONTEXT,
+        "@id": document_id or f"{sbom_serial}#openvex",
+        "author": VEX_AUTHOR,
+        "timestamp": now,
+        "version": 1,
+        "tooling": f"aisbom-cli/{_tool_version()}",
+        "statements": [],
+    }
+
+    for stmt in statements:
+        cls = stmt.finding_class
+        vulnerability: Dict[str, Any] = {
+            "@id": cls.iri,
+            "name": cls.id,
+            "description": cls.description,
+        }
+        if cls.aliases:
+            vulnerability["aliases"] = list(cls.aliases)
+
+        product: Dict[str, Any] = {"@id": _product_id(sbom_serial, stmt.product_ref)}
+        if stmt.product_hash:
+            product["hashes"] = {"sha-256": stmt.product_hash}
+
+        entry: Dict[str, Any] = {
+            "vulnerability": vulnerability,
+            "timestamp": now,
+            "products": [product],
+            "status": stmt.status,
+        }
+        if stmt.justification:
+            entry["justification"] = stmt.justification
+        if stmt.status_notes:
+            entry["status_notes"] = stmt.status_notes
+        if stmt.action_statement:
+            entry["action_statement"] = stmt.action_statement
+            entry["action_statement_timestamp"] = now
+        doc["statements"].append(entry)
+
+    return json.dumps(doc, indent=2)
+
+
+def generate_cyclonedx_vex(
+    statements: Sequence[VexStatement],
+    *,
+    sbom_serial: str,
+    timestamp: Optional[datetime] = None,
+    spec_version: str = "1.7",
+) -> str:
+    """Serialize statements as a CycloneDX VEX document.
+
+    One ``vulnerabilities`` entry per finding class, with every product carrying
+    that class's status listed under ``affects``. That is the shape CycloneDX
+    models — a vulnerability affecting components — where OpenVEX models a
+    statement per assertion, so the two documents carry the same facts in each
+    format's own idiom rather than one being a transliteration of the other.
+
+    Built as JSON directly rather than through ``cyclonedx-python-lib``'s
+    ``Vulnerability`` model: the library scopes one ``analysis`` block per
+    vulnerability, but AIsbom routinely reaches different conclusions about the
+    same class on different artifacts in one scan (a repository holding both a
+    malicious ``.pt`` and a clean ``.safetensors``). Splitting those into one
+    ``analysis`` per state is what keeps each component's status truthful.
+    """
+    now = _timestamp(timestamp)
+
+    # Group by (class, status) so each analysis block describes exactly the
+    # components it is true of.
+    grouped: Dict[tuple, List[VexStatement]] = {}
+    for stmt in statements:
+        grouped.setdefault((stmt.finding_class.id, stmt.status), []).append(stmt)
+
+    vulnerabilities = []
+    for (class_id, status), group in grouped.items():
+        # Taken from the statement, never looked up in the module-level table.
+        # A statement is self-contained by design, and the emitters must not
+        # require its class to be one AIsbom currently ships: OSV-sourced CVE
+        # statements will not be in `VEX_FINDING_CLASSES` at all, and neither
+        # is a retired class being aliased through a rename. Re-deriving it
+        # from the registry raised KeyError in both cases.
+        cls = group[0].finding_class
+        analysis: Dict[str, Any] = {"state": _CDX_STATE[status]}
+        justification = group[0].justification
+        if justification and justification in _CDX_JUSTIFICATION:
+            analysis["justification"] = _CDX_JUSTIFICATION[justification]
+        detail = "; ".join(dict.fromkeys(s.status_notes for s in group if s.status_notes))
+        if detail:
+            analysis["detail"] = detail
+
+        entry: Dict[str, Any] = {
+            "bom-ref": f"vex-{class_id}-{status}",
+            "id": class_id,
+            "source": {"name": VEX_AUTHOR, "url": cls.iri},
+            "description": cls.description,
+            "detail": cls.title,
+            "analysis": analysis,
+            "affects": [{"ref": s.product_ref} for s in group],
+        }
+        if cls.aliases:
+            entry["references"] = [
+                {"id": alias, "source": {"name": "NVD"}} for alias in cls.aliases
+            ]
+        if status == STATUS_AFFECTED:
+            entry["recommendation"] = cls.action
+        vulnerabilities.append(entry)
+
+    doc = {
+        "$schema": f"http://cyclonedx.org/schema/bom-{spec_version}.schema.json",
+        "bomFormat": "CycloneDX",
+        "specVersion": spec_version,
+        "serialNumber": sbom_serial,
+        "version": 1,
+        "metadata": {
+            "timestamp": now,
+            "tools": {
+                "components": [
+                    {
+                        "type": "application",
+                        "name": "aisbom-cli",
+                        "version": _tool_version(),
+                    }
+                ]
+            },
+        },
+        "externalReferences": [
+            {
+                "type": "bom",
+                "url": sbom_serial,
+                "comment": "The CycloneDX SBOM these statements describe.",
+            }
+        ],
+        "vulnerabilities": vulnerabilities,
+    }
+    return json.dumps(doc, indent=2)
+
+
+def finding_classes_markdown() -> str:
+    """Render the registry that ``docs/vex-finding-classes.md`` publishes.
+
+    Generated from the table rather than written by hand so the published
+    registry cannot drift from the vocabulary the CLI actually emits; a test
+    asserts the file on disk matches this output.
+    """
+    lines = [
+        "<!-- Generated from aisbom/vex.py by tests/test_vex.py. Do not edit by hand. -->",
+        "",
+        "# AIsbom VEX finding classes",
+        "",
+        "These are **AIsbom finding classes, not CVE identifiers.** They name",
+        "categories of content AIsbom detects inside a model file — things that",
+        "have no CVE and never will, because the file itself is the payload",
+        "rather than a published component with a patchable defect.",
+        "",
+        "They appear as the `vulnerability.name` of an OpenVEX statement and",
+        "the `id` of a CycloneDX VEX entry, and resolve under "
+        f"`{VEX_NAMESPACE}`.",
+        "",
+        "CVE-keyed statements about a project's Python dependencies are a",
+        "separate, additive concern and arrive with OSV mapping; they will join",
+        "the same document without changing anything below.",
+        "",
+        "## Compatibility policy",
+        "",
+        "These identifiers outlive the scan that produced them — they sit in",
+        "submission folders, CI artifacts and audit archives. If one changed",
+        "meaning or vanished, a build gate matching it would stop firing",
+        "silently, and a year-on-year comparison would read the change as a",
+        "finding resolved and a different one opened.",
+        "",
+        "So the guarantee is **not** that a class is never renamed. It is that",
+        "a consumer is never broken:",
+        "",
+        "1. A class is **never deleted**, and an identifier is **never reused**",
+        "   for a different meaning.",
+        "2. If a class is renamed, its successor carries the old identifier in",
+        "   `aliases`, so a rule matching the old string keeps matching.",
+        "3. Every identifier ever published is tracked in an append-only list",
+        "   in `aisbom/vex.py`, and the test suite fails if any of them stops",
+        "   being resolvable. The policy is enforced, not merely stated.",
+        "",
+        "`aliases` carries real CVE identifiers too, where one applies. Both",
+        "uses mean the same thing: another name for this same finding.",
+        "",
+        "## Classes",
+        "",
+    ]
+    for cls in VEX_FINDING_CLASSES:
+        lines.extend([
+            f"## `{cls.id}`",
+            "",
+            f"**{cls.title}**",
+            "",
+            cls.description,
+            "",
+            f"- **Applies to:** {', '.join(sorted(cls.formats))}",
+            f"- **Identifier:** {cls.iri}",
+            f"- **Aliases:** {', '.join(cls.aliases) if cls.aliases else 'none'}",
+            f"- **Remediation:** {cls.action}",
+            "",
+        ])
+    return "\n".join(lines)

--- a/docs/vex-finding-classes.md
+++ b/docs/vex-finding-classes.md
@@ -1,0 +1,116 @@
+<!-- Generated from aisbom/vex.py by tests/test_vex.py. Do not edit by hand. -->
+
+# AIsbom VEX finding classes
+
+These are **AIsbom finding classes, not CVE identifiers.** They name
+categories of content AIsbom detects inside a model file — things that
+have no CVE and never will, because the file itself is the payload
+rather than a published component with a patchable defect.
+
+They appear as the `vulnerability.name` of an OpenVEX statement and
+the `id` of a CycloneDX VEX entry, and resolve under `https://aisbom.io/vex/`.
+
+CVE-keyed statements about a project's Python dependencies are a
+separate, additive concern and arrive with OSV mapping; they will join
+the same document without changing anything below.
+
+## Compatibility policy
+
+These identifiers outlive the scan that produced them — they sit in
+submission folders, CI artifacts and audit archives. If one changed
+meaning or vanished, a build gate matching it would stop firing
+silently, and a year-on-year comparison would read the change as a
+finding resolved and a different one opened.
+
+So the guarantee is **not** that a class is never renamed. It is that
+a consumer is never broken:
+
+1. A class is **never deleted**, and an identifier is **never reused**
+   for a different meaning.
+2. If a class is renamed, its successor carries the old identifier in
+   `aliases`, so a rule matching the old string keeps matching.
+3. Every identifier ever published is tracked in an append-only list
+   in `aisbom/vex.py`, and the test suite fails if any of them stops
+   being resolvable. The policy is enforced, not merely stated.
+
+`aliases` carries real CVE identifiers too, where one applies. Both
+uses mean the same thing: another name for this same finding.
+
+## Classes
+
+## `AISBOM-PICKLE-RCE`
+
+**Pickle stream imports a code-executing global**
+
+The artifact carries a Python pickle stream whose opcodes import a global that executes code when the stream is deserialized (os.system, subprocess.Popen, builtins.eval and similar). Deserialization is the execution — no separate trigger is needed.
+
+- **Applies to:** gguf, joblib, numpy, onnx, pickle, safetensors
+- **Identifier:** https://aisbom.io/vex/AISBOM-PICKLE-RCE
+- **Aliases:** none
+- **Remediation:** Do not load this file with torch.load/pickle.load. Obtain the model in a non-executable format (SafeTensors) or from a trusted source, and treat the file as active malware rather than as a defective dependency to patch.
+
+## `AISBOM-PICKLE-CODE-OBJECT`
+
+**Serialized Python code objects embedded in the pickle stream**
+
+The pickle stream carries dill-serialized code objects — whole Python functions marshalled into the file. The bytecode is reconstructed on load, so what the model does is not limited to what its declared imports suggest.
+
+- **Applies to:** joblib, numpy, pickle
+- **Identifier:** https://aisbom.io/vex/AISBOM-PICKLE-CODE-OBJECT
+- **Aliases:** none
+- **Remediation:** Do not load this file outside an isolated sandbox. Re-export the model from its source framework so that weights, not code, are what is serialized.
+
+## `AISBOM-PICKLE-UNSCANNED`
+
+**Pickle data present but not fully disassembled**
+
+A pickle stream was found but could not be read to completion — a truncated or malformed stream, an unreadable archive member, or a container AIsbom does not decompress. Absence of a finding here is not evidence of absence: this is the nullifAI evasion class, where a deliberately broken stream is used to end a scan early.
+
+- **Applies to:** joblib, numpy, pickle
+- **Identifier:** https://aisbom.io/vex/AISBOM-PICKLE-UNSCANNED
+- **Aliases:** none
+- **Remediation:** Re-scan the artifact from its original archive, or decompress the container and scan the members individually, before loading it.
+
+## `AISBOM-KERAS-LAMBDA-RCE`
+
+**Keras Lambda layer or marshalled code object executes on load**
+
+The Keras model config declares a Lambda layer or carries a marshalled Python code object. keras.models.load_model reconstructs and can invoke it, so loading the model runs attacker-chosen bytecode.
+
+- **Applies to:** keras
+- **Identifier:** https://aisbom.io/vex/AISBOM-KERAS-LAMBDA-RCE
+- **Aliases:** none
+- **Remediation:** Load with safe_mode=True (Keras 3), or rebuild the layer in your own code and load weights only. Do not load with safe_mode=False or on Keras 2.
+
+## `AISBOM-GGUF-TEMPLATE-INJECTION`
+
+**GGUF chat template contains a sandbox escape or dangerous call**
+
+The Jinja chat template stored in the GGUF metadata contains constructs that reach outside the template sandbox or invoke dangerous callables. The template is evaluated on every inference request, so this executes at serving time rather than at load.
+
+- **Applies to:** gguf
+- **Identifier:** https://aisbom.io/vex/AISBOM-GGUF-TEMPLATE-INJECTION
+- **Aliases:** none
+- **Remediation:** Replace the chat template with one you control, or serve the model through a runtime that does not evaluate the embedded template.
+
+## `AISBOM-ONNX-CUSTOM-OP`
+
+**ONNX graph references operators outside the standard domains**
+
+The graph calls operators that are not part of the standard ONNX domains, so executing it requires loading a third-party operator library. What that library does is outside the model file and outside this scan.
+
+- **Applies to:** onnx
+- **Identifier:** https://aisbom.io/vex/AISBOM-ONNX-CUSTOM-OP
+- **Aliases:** none
+- **Remediation:** Identify and review the operator library the graph requires before running inference, or re-export the model using standard operators.
+
+## `AISBOM-ONNX-EXTERNAL-DATA`
+
+**ONNX tensor data stored outside the model file**
+
+Tensor data is held in separate files referenced by the graph, so the model's weights are not covered by this artifact's hash. A reference that resolves outside the model directory additionally turns loading the model into a read of a file the author chose.
+
+- **Applies to:** onnx
+- **Identifier:** https://aisbom.io/vex/AISBOM-ONNX-EXTERNAL-DATA
+- **Aliases:** none
+- **Remediation:** Scan and pin the external tensor files alongside the model, and reject any reference that resolves outside the model directory.

--- a/tests/schemas/openvex-0.2.0.schema.json
+++ b/tests/schemas/openvex-0.2.0.schema.json
@@ -1,0 +1,317 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/openvex/spec/openvex_json_schema_0.2.0.json",
+    "title": "OpenVEX",
+    "description": "OpenVEX is an implementation of the Vulnerability Exploitability Exchange (VEX for short) that is designed to be minimal, compliant, interoperable, and embeddable.",
+    "type": "object",
+    "$defs": {
+        "vulnerability": {
+            "type": "object",
+            "properties": {
+                "@id": {
+                    "type": "string",
+                    "format": "iri",
+                    "description": "An Internationalized Resource Identifier (IRI) identifying the struct."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "A string with the main identifier used to name the vulnerability."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional free form text describing the vulnerability."
+                },
+                "aliases": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "A list of strings enumerating other names under which the vulnerability may be known."
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false
+        },
+        "identifiers": {
+            "type": "object",
+            "properties": {
+                "purl": {
+                    "type": "string",
+                    "description": "Package URL"
+                },
+                "cpe22": {
+                    "type": "string",
+                    "description": "Common Platform Enumeration v2.2"
+                },
+                "cpe23": {
+                    "type": "string",
+                    "description": "Common Platform Enumeration v2.3"
+                }
+            },
+            "additionalProperties": false,
+            "anyOf": [
+                { "required": ["purl"] },
+                { "required": ["cpe22"] },
+                { "required": ["cpe23"] }
+              ]
+        },
+        "hashes": {
+            "type": "object",
+            "properties": {
+                "md5": {
+                    "type": "string"
+                },
+                "sha1": {
+                    "type": "string"
+                },
+                "sha-256": {
+                    "type": "string"
+                },
+                "sha-384": {
+                    "type": "string"
+                },
+                "sha-512": {
+                    "type": "string"
+                },
+                "sha3-224": {
+                    "type": "string"
+                },
+                "sha3-256": {
+                    "type": "string"
+                },
+                "sha3-384": {
+                    "type": "string"
+                },
+                "sha3-512": {
+                    "type": "string"
+                },
+                "blake2s-256": {
+                    "type": "string"
+                },
+                "blake2b-256": {
+                    "type": "string"
+                },
+                "blake2b-512": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "subcomponent": {
+            "type": "object",
+            "properties": {
+                "@id": {
+                    "type": "string",
+                    "format": "iri",
+                    "description": "Optional IRI identifying the component to make it externally referenceable."
+                },
+                "identifiers": {
+                    "$ref": "#/$defs/identifiers",
+                    "description": "Optional IRI identifying the component to make it externally referenceable."
+                },
+                "hashes": {
+                    "$ref": "#/$defs/hashes",
+                    "description": "Map of cryptographic hashes of the component."
+                }
+            },
+            "additionalProperties": false,
+            "anyOf": [
+                { "required": ["@id"] },
+                { "required": ["identifiers"] }
+              ]
+        },
+        "component": {
+            "type": "object",
+            "properties": {
+                "@id": {
+                    "type": "string",
+                    "format": "iri",
+                    "description": "Optional IRI identifying the component to make it externally referenceable."
+                },
+                "identifiers": {
+                    "$ref": "#/$defs/identifiers",
+                    "description": "A map of software identifiers where the key is the type and the value the identifier."
+                },
+                "hashes": {
+                    "$ref": "#/$defs/hashes",
+                    "description": "Map of cryptographic hashes of the component."
+                },
+                "subcomponents": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "description": "List of subcomponent structs describing the subcomponents subject of the VEX statement.",
+                    "items": {
+                        "$ref": "#/$defs/subcomponent"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "anyOf": [
+                { "required": ["@id"] },
+                { "required": ["identifiers"] }
+              ]
+        }
+    },
+    "properties": {
+        "@context": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL linking to the OpenVEX context definition."
+        },
+        "@id": {
+            "type": "string",
+            "format": "iri",
+            "description": "The IRI identifying the VEX document."
+        },
+        "author": {
+            "type": "string",
+            "description": "Author is the identifier for the author of the VEX statement."
+        },
+        "role": {
+            "type": "string",
+            "description": "Role describes the role of the document author."
+        },
+        "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp defines the time at which the document was issued."
+        },
+        "last_updated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date of last modification to the document."
+        },
+        "version": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Version is the document version."
+        },
+        "tooling": {
+            "type": "string",
+            "description": "Tooling expresses how the VEX document and contained VEX statements were generated."
+        },
+        "statements": {
+            "type": "array",
+            "uniqueItems": true,
+            "minItems": 1,
+            "description": "A statement is an assertion made by the document's author about the impact a vulnerability has on one or more software 'products'.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "@id": {
+                        "type": "string",
+                        "format": "iri",
+                        "description": "Optional IRI identifying the statement to make it externally referenceable."
+                    },
+                    "version": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Optional integer representing the statement's version number."
+                    },
+                    "vulnerability": {
+                        "$ref": "#/$defs/vulnerability",
+                        "description": "A struct identifying the vulnerability."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp is the time at which the information expressed in the statement was known to be true."
+                    },
+                    "last_updated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the statement was last updated."
+                    },
+                    "products": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "description": "List of product structs that the statement applies to.",
+                        "items": {
+                            "$ref": "#/$defs/component"
+                        }
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "not_affected",
+                            "affected",
+                            "fixed",
+                            "under_investigation"
+                        ],
+                        "description": "A VEX statement MUST provide the status of the vulnerabilities with respect to the products and components listed in the statement."
+                    },
+                    "supplier": {
+                        "type": "string",
+                        "description": "Supplier of the product or subcomponent."
+                    },
+                    "status_notes": {
+                        "type": "string",
+                        "description": "A statement MAY convey information about how status was determined and MAY reference other VEX information."
+                    },
+                    "justification": {
+                        "type": "string",
+                        "enum": [
+                            "component_not_present",
+                            "vulnerable_code_not_present",
+                            "vulnerable_code_not_in_execute_path",
+                            "vulnerable_code_cannot_be_controlled_by_adversary",
+                            "inline_mitigations_already_exist"
+                        ],
+                        "description": "For statements conveying a not_affected status, a VEX statement MUST include either a status justification or an impact_statement informing why the product is not affected by the vulnerability."
+                    },
+                    "impact_statement": {
+                        "type": "string",
+                        "description": "For statements conveying a not_affected status, a VEX statement MUST include either a status justification or an impact_statement informing why the product is not affected by the vulnerability."
+                    },
+                    "action_statement": {
+                        "type": "string",
+                        "description": "For a statement with affected status, a VEX statement MUST include a statement that SHOULD describe actions to remediate or mitigate the vulnerability."
+                    },
+                    "action_statement_timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The timestamp when the action statement was issued."
+                    }
+                },
+                "required": [
+                    "vulnerability",
+                    "status"
+                ],
+                "additionalProperties": false,
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": { "status": { "const": "not_affected" }}
+                        },
+                        "then": {
+                            "anyOf": [
+                                { "required": ["justification"]},
+                                { "required": ["impact_statement"]}
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": { "status": { "const": "affected" }}
+                        },
+                        "then": {
+                            "required": ["action_statement"]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "required": [
+        "@context",
+        "@id",
+        "author",
+        "timestamp",
+        "version",
+        "statements"
+    ],
+    "additionalProperties": false
+}

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -320,3 +320,154 @@ def test_cli_diff_command(tmp_path):
     assert result.exit_code == 1
     assert "FAILURE" in result.stdout
     assert "mock_malware.pt" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# #113 — VEX output alongside the SBOM.
+# ---------------------------------------------------------------------------
+
+
+def _scan_with_vex(tmp_path, *extra_args, expect_exit=2):
+    """Scan a tree holding one malicious .pt and one GGUF, emitting VEX."""
+    _write_malicious_pt(tmp_path / "mock_malware.pt")
+    create_mock_gguf(tmp_path)
+    output_path = tmp_path / "sbom.json"
+    result = runner.invoke(
+        app,
+        ["scan", str(tmp_path), "--output", str(output_path), "--vex", *extra_args],
+    )
+    assert result.exit_code == expect_exit, result.output
+    return output_path, result
+
+
+def test_vex_writes_both_flavors_beside_the_sbom(tmp_path):
+    _scan_with_vex(tmp_path)
+    assert (tmp_path / "sbom.openvex.json").exists()
+    assert (tmp_path / "sbom.vex.cdx.json").exists()
+
+
+def test_vex_products_resolve_into_the_sbom_the_same_run_wrote(tmp_path):
+    """AC #3: the cross-reference must actually join the two documents."""
+    output_path, _ = _scan_with_vex(tmp_path)
+    sbom = json.loads(output_path.read_text())
+    openvex = json.loads((tmp_path / "sbom.openvex.json").read_text())
+
+    serial = sbom["serialNumber"]
+    sbom_refs = {c["bom-ref"] for c in sbom["components"]}
+
+    assert openvex["statements"], "expected at least one statement"
+    for statement in openvex["statements"]:
+        document, _, ref = statement["products"][0]["@id"].partition("#")
+        assert document == serial
+        assert ref in sbom_refs
+
+
+def test_vex_cyclonedx_affects_resolve_into_the_sbom(tmp_path):
+    output_path, _ = _scan_with_vex(tmp_path)
+    sbom = json.loads(output_path.read_text())
+    vex = json.loads((tmp_path / "sbom.vex.cdx.json").read_text())
+
+    sbom_refs = {c["bom-ref"] for c in sbom["components"]}
+    for vulnerability in vex["vulnerabilities"]:
+        for affected in vulnerability["affects"]:
+            assert affected["ref"] in sbom_refs
+
+
+def test_vex_reports_the_malicious_pickle_as_affected(tmp_path):
+    _scan_with_vex(tmp_path)
+    openvex = json.loads((tmp_path / "sbom.openvex.json").read_text())
+    affected = [
+        s for s in openvex["statements"]
+        if s["status"] == "affected"
+        and s["vulnerability"]["name"] == "AISBOM-PICKLE-RCE"
+    ]
+    assert len(affected) == 1
+    assert "mock_malware.pt" in affected[0]["products"][0]["@id"]
+
+
+def test_vex_format_openvex_writes_only_that_flavor(tmp_path):
+    _scan_with_vex(tmp_path, "--vex-format", "openvex")
+    assert (tmp_path / "sbom.openvex.json").exists()
+    assert not (tmp_path / "sbom.vex.cdx.json").exists()
+
+
+def test_vex_format_cyclonedx_writes_only_that_flavor(tmp_path):
+    _scan_with_vex(tmp_path, "--vex-format", "cyclonedx")
+    assert (tmp_path / "sbom.vex.cdx.json").exists()
+    assert not (tmp_path / "sbom.openvex.json").exists()
+
+
+def test_no_vex_flag_writes_no_vex_files(tmp_path):
+    _write_malicious_pt(tmp_path / "mock_malware.pt")
+    output_path = tmp_path / "sbom.json"
+    runner.invoke(app, ["scan", str(tmp_path), "--output", str(output_path)])
+    assert output_path.exists()
+    assert not (tmp_path / "sbom.openvex.json").exists()
+    assert not (tmp_path / "sbom.vex.cdx.json").exists()
+
+
+def test_vex_is_refused_for_non_cyclonedx_output(tmp_path):
+    """A VEX file next to an SPDX document would dangle."""
+    _write_malicious_pt(tmp_path / "mock_malware.pt")
+    result = runner.invoke(
+        app,
+        [
+            "scan", str(tmp_path),
+            "--format", "spdx",
+            "--output", str(tmp_path / "sbom.spdx.json"),
+            "--vex",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "--vex requires --format json" in result.output
+    assert not list(tmp_path.glob("*openvex*"))
+
+
+def test_vex_missing_baseline_fails_before_scanning(tmp_path):
+    _write_malicious_pt(tmp_path / "mock_malware.pt")
+    result = runner.invoke(
+        app,
+        [
+            "scan", str(tmp_path),
+            "--output", str(tmp_path / "sbom.json"),
+            "--vex",
+            "--vex-baseline", str(tmp_path / "nope.json"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "VEX baseline not found" in result.output
+
+
+def test_vex_baseline_turns_a_removed_finding_into_fixed(tmp_path):
+    """Remediation evidence: scan a dirty tree, clean it, re-scan with baseline."""
+    import pickle
+    import zipfile
+
+    _write_malicious_pt(tmp_path / "mock_malware.pt")
+    baseline_path = tmp_path / "baseline.json"
+    runner.invoke(app, ["scan", str(tmp_path), "--output", str(baseline_path)])
+    assert baseline_path.exists()
+
+    # Replace the malicious payload with a benign pickle at the same path, so
+    # the artifact index (and therefore the bom-ref) is unchanged.
+    with zipfile.ZipFile(tmp_path / "mock_malware.pt", "w") as zf:
+        zf.writestr("archive/data.pkl", pickle.dumps({"weights": [1, 2, 3]}))
+        zf.writestr("archive/version", "3")
+
+    result = runner.invoke(
+        app,
+        [
+            "scan", str(tmp_path),
+            "--output", str(tmp_path / "after.json"),
+            "--vex",
+            "--vex-format", "openvex",
+            "--vex-baseline", str(baseline_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    openvex = json.loads((tmp_path / "after.openvex.json").read_text())
+    fixed = [s for s in openvex["statements"] if s["status"] == "fixed"]
+    assert len(fixed) == 1
+    assert fixed[0]["vulnerability"]["name"] == "AISBOM-PICKLE-RCE"
+    assert "fixed since baseline" in result.output

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -418,6 +418,40 @@ def test_config_larger_than_the_read_budget_is_not_called_clean(tmp_path, monkey
     assert "CRITICAL" not in art["risk_level"]
 
 
+def test_truncated_config_is_not_cleared_in_vex_either(tmp_path, monkeypatch):
+    """The same "not called clean" rule, end to end through VEX (#113).
+
+    Found on a live target rather than a fixture: `hf://google-bert/
+    bert-base-uncased` ships a `tf_model.h5` whose config exceeds the read
+    budget over a range request, and the first VEX implementation answered
+    `not_affected` — "declares no Lambda layer" — for it. Over a range request
+    that is the common case for a `.h5`, so this asserts the scanner's
+    truncation flag actually reaches the compliance artifact.
+    """
+    import aisbom.scanner as scanner_mod
+    from aisbom.vex import derive_statements
+
+    cfg = _keras2_config(with_lambda=False)
+    cfg["config"]["layers"].extend(
+        {"class_name": "Dense", "config": {"name": f"pad_{i}", "units": 64}}
+        for i in range(2000)
+    )
+    with zipfile.ZipFile(tmp_path / "big.keras", "w") as z:
+        z.writestr("config.json", json.dumps(cfg))
+        z.writestr("metadata.json", json.dumps({"keras_version": "3.5.0"}))
+
+    monkeypatch.setattr(scanner_mod, "KERAS_MAX_SCAN_BYTES", 4096)
+    artifacts = DeepScanner(str(tmp_path)).scan()["artifacts"]
+
+    statements = derive_statements(artifacts)
+    keras_statements = [
+        s for s in statements
+        if s.finding_class.id == "AISBOM-KERAS-LAMBDA-RCE"
+    ]
+    assert [s.status for s in keras_statements] == ["under_investigation"]
+    assert keras_statements[0].justification is None
+
+
 # --- Hugging Face resolution ----------------------------------------------
 
 @pytest.mark.parametrize("filename", [

--- a/tests/test_pickle_variants.py
+++ b/tests/test_pickle_variants.py
@@ -208,6 +208,29 @@ def test_unreadable_codec_is_named_not_called_clean(tmp_path, magic, label):
     assert artifact["risk_level"] == f"MEDIUM (Unscanned Container: {label})"
     assert artifact["details"]["compression"] == label
     assert "CRITICAL" not in artifact["risk_level"]
+    # Nothing inside was inspected, so the structured marker must say so too —
+    # the prose label alone is invisible to a consumer reading properties.
+    assert artifact["details"]["scan_incomplete"] is True
+
+
+@pytest.mark.parametrize("magic,label", [(b"\x04\x22\x4d\x18", "lz4"), (b"\x28\xb5\x2f\xfd", "zstd")])
+def test_unreadable_codec_is_not_cleared_in_vex_either(tmp_path, magic, label):
+    """The "different answer from clean" rule, end to end through VEX (#113).
+
+    Raised by review on PR #99: the container is named and reported unscanned,
+    but the marker `_classify` reads was only set for a *truncated* stream, so
+    every pickle class came out `not_affected` with justification
+    `vulnerable_code_not_present` for a payload that was never opened.
+    """
+    from aisbom.vex import derive_statements
+
+    artifact = scan_one(tmp_path, "model.joblib", magic + b"\x00" * 256)
+    statuses = {
+        s.finding_class.id: s.status for s in derive_statements([artifact])
+    }
+    assert statuses["AISBOM-PICKLE-RCE"] == "under_investigation"
+    assert statuses["AISBOM-PICKLE-UNSCANNED"] == "under_investigation"
+    assert all(s.justification is None for s in derive_statements([artifact]))
 
 
 # --- numpy -------------------------------------------------------------

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -20,6 +20,7 @@ from cyclonedx.validation.json import JsonStrictValidator
 from jsonschema import Draft202012Validator
 
 from aisbom.vex import (
+    BaselineIndex,
     FINDING_CLASSES_BY_ID,
     JUSTIFICATION_CODE_NOT_PRESENT,
     PUBLISHED_FINDING_CLASS_IDS,
@@ -318,9 +319,9 @@ def test_under_investigation_when_the_stream_was_not_fully_read(openvex_validato
 
 def test_fixed_requires_a_baseline_that_saw_the_finding(openvex_validator):
     """`fixed` is the one status a single scan cannot honestly assert."""
-    baseline = {
-        "artifact-0-model.pt": {"AISBOM-PICKLE-RCE": "affected"},
-    }
+    baseline = BaselineIndex(
+        by_name={"model.pt": {"AISBOM-PICKLE-RCE": "affected"}}
+    )
     doc = _openvex([_artifact()], baseline=baseline)
     openvex_validator.validate(doc)
 
@@ -339,9 +340,103 @@ def test_no_baseline_means_no_fixed_statement(openvex_validator):
 
 def test_a_still_affected_finding_is_not_reported_fixed():
     """A baseline finding that is still present stays `affected`."""
-    baseline = {"artifact-0-model.pt": {"AISBOM-PICKLE-RCE": "affected"}}
+    baseline = BaselineIndex(
+        by_name={"model.pt": {"AISBOM-PICKLE-RCE": "affected"}}
+    )
     doc = _openvex([_artifact(threats=["os.system"])], baseline=baseline)
     assert _statuses(doc, "AISBOM-PICKLE-RCE") == ["affected"]
+
+
+# --------------------------------------------------------------------------
+# Baseline identity must survive a change in scan order.
+#
+# `bom-ref` embeds the enumeration index, which is stable within one scan and
+# not across two. Matching on it misses remediated findings when a file is
+# added earlier in the tree, and — because artifact names are basenames — can
+# apply an affected baseline entry to a different, always-clean artifact and
+# fabricate a remediation.
+# --------------------------------------------------------------------------
+
+def test_a_fix_is_still_recognised_when_an_earlier_file_shifts_the_index():
+    """Adding a file ahead of the fixed one must not hide the `fixed`."""
+    baseline = baseline_findings({
+        "components": [{
+            "bom-ref": "artifact-0-model.pt",
+            "name": "model.pt",
+            "properties": [
+                {"name": "aisbom:format", "value": "pickle"},
+                {"name": "aisbom:pickle:opcode", "value": "os.system"},
+            ],
+        }]
+    })
+    # `model.pt` is now index 1 — its bom-ref changed, the artifact did not.
+    doc = _openvex(
+        [_artifact(name="added.safetensors", framework="SafeTensors"),
+         _artifact(name="model.pt", artifact_hash=SHA_B)],
+        baseline=baseline,
+    )
+    assert "fixed" in _statuses(doc, "AISBOM-PICKLE-RCE")
+
+
+def test_duplicate_basenames_never_fabricate_a_fix():
+    """The serious case: an affected entry landing on the wrong artifact.
+
+    Two directories holding `model.pt` yield two components differing only by
+    index. If their order swaps between scans, index-based matching applies the
+    affected baseline entry to the other, always-clean file and claims it was
+    fixed — a remediation that never happened, in the document whose purpose is
+    evidencing remediation. An ambiguous name must yield no prior at all.
+    """
+    baseline = baseline_findings({
+        "components": [
+            {
+                "bom-ref": "artifact-0-model.pt",
+                "name": "model.pt",
+                "properties": [
+                    {"name": "aisbom:format", "value": "pickle"},
+                    {"name": "aisbom:pickle:opcode", "value": "os.system"},
+                ],
+            },
+            {
+                "bom-ref": "artifact-1-model.pt",
+                "name": "model.pt",
+                "properties": [{"name": "aisbom:format", "value": "pickle"}],
+            },
+        ]
+    })
+    assert "model.pt" not in baseline.by_name
+
+    doc = _openvex(
+        [_artifact(name="model.pt", artifact_hash=SHA_A),
+         _artifact(name="model.pt", artifact_hash=SHA_B)],
+        baseline=baseline,
+    )
+    assert "fixed" not in _statuses(doc, "AISBOM-PICKLE-RCE")
+
+
+def test_a_matching_content_hash_resolves_an_ambiguous_name():
+    """SHA-256 identifies the file even when the basename cannot."""
+    baseline = baseline_findings({
+        "components": [
+            {
+                "bom-ref": "artifact-0-model.pt",
+                "name": "model.pt",
+                "hashes": [{"alg": "SHA-256", "content": SHA_A}],
+                "properties": [
+                    {"name": "aisbom:format", "value": "pickle"},
+                    {"name": "aisbom:pickle:opcode", "value": "os.system"},
+                ],
+            },
+            {
+                "bom-ref": "artifact-1-model.pt",
+                "name": "model.pt",
+                "hashes": [{"alg": "SHA-256", "content": SHA_B}],
+                "properties": [{"name": "aisbom:format", "value": "pickle"}],
+            },
+        ]
+    })
+    assert baseline.by_hash[SHA_A]["AISBOM-PICKLE-RCE"] == "affected"
+    assert baseline.by_hash[SHA_B]["AISBOM-PICKLE-RCE"] == "not_affected"
 
 
 # --------------------------------------------------------------------------
@@ -558,6 +653,25 @@ def test_a_truncated_keras_read_still_reports_a_payload_it_did_see():
     assert _statuses(doc, "AISBOM-KERAS-LAMBDA-RCE") == ["affected"]
 
 
+def test_an_artifact_whose_inspection_raised_is_under_investigation():
+    """A sparse detail dict from an exception is not "looked and found nothing".
+
+    Most inspectors record the failure as `error` on the artifact; the GGUF one
+    puts it under `details`. Both leave a detail dict indistinguishable from a
+    clean scan unless the error is treated as incompleteness.
+    """
+    art = _artifact()
+    art["error"] = "unexpected EOF while reading archive"
+    assert _statuses(_openvex([art]), "AISBOM-PICKLE-RCE") == [
+        "under_investigation"
+    ]
+
+    gguf = _artifact(name="m.gguf", framework="GGUF", error="bad header")
+    assert _statuses(_openvex([gguf]), "AISBOM-GGUF-TEMPLATE-INJECTION") == [
+        "under_investigation"
+    ]
+
+
 def test_truncated_onnx_graph_is_under_investigation():
     doc = _openvex([
         _artifact(name="m.onnx", framework="ONNX", parsed=True, truncated=True)
@@ -652,7 +766,9 @@ def test_cyclonedx_vex_validates_against_the_strict_1_7_schema():
 
 def test_cyclonedx_vex_maps_every_openvex_status():
     """The two vocabularies differ; the mapping must be total."""
-    baseline = {"artifact-3-fixed.pt": {"AISBOM-PICKLE-RCE": "affected"}}
+    baseline = BaselineIndex(
+        by_name={"fixed.pt": {"AISBOM-PICKLE-RCE": "affected"}}
+    )
     statements = derive_statements(
         [
             _artifact(name="bad.pt", threats=["os.system"]),
@@ -749,7 +865,7 @@ def test_baseline_findings_reads_structured_properties():
         ]
     }
     findings = baseline_findings(sbom)
-    assert findings["artifact-0-model.pt"]["AISBOM-PICKLE-RCE"] == "affected"
+    assert findings.by_name["model.pt"]["AISBOM-PICKLE-RCE"] == "affected"
 
 
 def test_baseline_findings_degrades_to_the_description_for_pre_54_sboms():
@@ -772,7 +888,7 @@ def test_baseline_findings_degrades_to_the_description_for_pre_54_sboms():
         ]
     }
     findings = baseline_findings(sbom)
-    assert findings["artifact-0-model.pt"]["AISBOM-PICKLE-RCE"] == "affected"
+    assert findings.by_name["model.pt"]["AISBOM-PICKLE-RCE"] == "affected"
 
 
 def test_pre_54_baseline_does_not_manufacture_a_fixed_statement():
@@ -781,6 +897,7 @@ def test_pre_54_baseline_does_not_manufacture_a_fixed_statement():
         "components": [
             {
                 "bom-ref": "artifact-0-model.pt",
+                "name": "model.pt",
                 "description": (
                     "Risk: CRITICAL (RCE Detected: os.system) | "
                     "Framework: PyTorch | Legal: PASS | License: MIT"
@@ -798,6 +915,7 @@ def test_baseline_findings_accepts_a_path(tmp_path):
         "components": [
             {
                 "bom-ref": "artifact-0-model.pt",
+                "name": "model.pt",
                 "properties": [
                     {"name": "aisbom:format", "value": "pickle"},
                     {"name": "aisbom:pickle:opcode", "value": "os.system"},
@@ -806,17 +924,20 @@ def test_baseline_findings_accepts_a_path(tmp_path):
         ]
     }))
     findings = baseline_findings(str(path))
-    assert findings["artifact-0-model.pt"]["AISBOM-PICKLE-RCE"] == "affected"
+    assert findings.by_name["model.pt"]["AISBOM-PICKLE-RCE"] == "affected"
 
 
-def test_baseline_findings_skips_components_without_a_ref_or_format():
+def test_baseline_findings_skips_components_with_no_recognised_format():
+    """Library components carry no `aisbom:format` and are not artifacts."""
     sbom = {
         "components": [
-            {"name": "no-ref", "properties": [{"name": "aisbom:format", "value": "pickle"}]},
             {"bom-ref": "lib-1", "name": "torch", "version": "2.0.1"},
+            {"bom-ref": "lib-2", "name": "requests", "version": "2.31.0"},
         ]
     }
-    assert baseline_findings(sbom) == {}
+    findings = baseline_findings(sbom)
+    assert findings.by_name == {}
+    assert findings.by_hash == {}
 
 
 def test_signals_from_component_reads_onnx_counts():

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -1,0 +1,865 @@
+"""VEX output — OpenVEX + CycloneDX VEX (#113).
+
+Every generated OpenVEX document is validated against the *official* OpenVEX
+0.2.0 JSON schema bundled at ``tests/schemas/openvex-0.2.0.schema.json``, and
+every CycloneDX VEX document against the library's own strict 1.7 schema. Both
+set ``additionalProperties: false``, so a misspelled key fails the suite rather
+than shipping into a compliance artifact.
+
+The schema check matters here for the same reason it did for SPDX 3.0 (#112):
+the mapping from AIsbom's scan output to the VEX vocabulary is hand-built, and
+a document that does not validate is one a consumer will reject.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from cyclonedx.schema import SchemaVersion
+from cyclonedx.validation.json import JsonStrictValidator
+from jsonschema import Draft202012Validator
+
+from aisbom.vex import (
+    FINDING_CLASSES_BY_ID,
+    JUSTIFICATION_CODE_NOT_PRESENT,
+    PUBLISHED_FINDING_CLASS_IDS,
+    VEX_FINDING_CLASSES,
+    VEX_NAMESPACE,
+    baseline_findings,
+    derive_statements,
+    finding_classes_markdown,
+    generate_cyclonedx_vex,
+    generate_openvex,
+    signals_from_component,
+)
+
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+SERIAL = "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+
+_OPENVEX_SCHEMA = Path(__file__).parent / "schemas" / "openvex-0.2.0.schema.json"
+_DOCS_REGISTRY = (
+    Path(__file__).parent.parent / "docs" / "vex-finding-classes.md"
+)
+
+
+@pytest.fixture(scope="module")
+def openvex_validator():
+    with _OPENVEX_SCHEMA.open() as fh:
+        return Draft202012Validator(json.load(fh))
+
+
+def _artifact(name="model.pt", framework="PyTorch", artifact_hash=SHA_A, **details):
+    """An artifact dict shaped like the one ``DeepScanner`` emits."""
+    return {
+        "name": name,
+        "type": "machine-learning-model",
+        "framework": framework,
+        "risk_level": "LOW",
+        "license": "Unknown",
+        "legal_status": "UNKNOWN",
+        "hash": artifact_hash,
+        "details": dict(details),
+    }
+
+
+def _openvex(artifacts, baseline=None):
+    return json.loads(
+        generate_openvex(
+            derive_statements(artifacts, baseline), sbom_serial=SERIAL
+        )
+    )
+
+
+def _statuses(doc, class_id):
+    """Every status asserted for one finding class in an OpenVEX document."""
+    return [
+        s["status"]
+        for s in doc["statements"]
+        if s["vulnerability"]["name"] == class_id
+    ]
+
+
+def _assert_cdx_valid(doc_json):
+    """Validate against the library's own strict CycloneDX 1.7 schema."""
+    errors = JsonStrictValidator(SchemaVersion.V1_7).validate_str(doc_json)
+    assert errors is None, f"CycloneDX 1.7 validation failed: {errors}"
+
+
+# --------------------------------------------------------------------------
+# The vocabulary is an API
+# --------------------------------------------------------------------------
+
+def test_finding_class_ids_are_pinned():
+    """The public ID set is an API. Changing it must be deliberate.
+
+    These strings ship inside customers' compliance artifacts and are used to
+    diff one scan against the next, so a rename is a breaking change for a
+    consumer. Editing this list is the deliberate act that makes one.
+    """
+    assert [c.id for c in VEX_FINDING_CLASSES] == [
+        "AISBOM-PICKLE-RCE",
+        "AISBOM-PICKLE-CODE-OBJECT",
+        "AISBOM-PICKLE-UNSCANNED",
+        "AISBOM-KERAS-LAMBDA-RCE",
+        "AISBOM-GGUF-TEMPLATE-INJECTION",
+        "AISBOM-ONNX-CUSTOM-OP",
+        "AISBOM-ONNX-EXTERNAL-DATA",
+    ]
+
+
+def test_every_published_identifier_is_still_resolvable():
+    """The compatibility promise, mechanically enforced.
+
+    These strings live in documents on other people's disks long after the
+    scan — build gates match them, and year-on-year comparisons key on them.
+    Dropping one breaks those *silently*, so the guarantee is not "never
+    rename" but "never break a consumer": a retired identifier must still
+    resolve, either because it is still emitted or because its successor
+    carries it in `aliases`.
+
+    If this fails, do not edit the published list — add the missing identifier
+    to the successor class's `aliases` instead.
+    """
+    live = {c.id for c in VEX_FINDING_CLASSES}
+    aliased = {alias for c in VEX_FINDING_CLASSES for alias in c.aliases}
+    for published in PUBLISHED_FINDING_CLASS_IDS:
+        assert published in live or published in aliased, (
+            f"{published} was published and is no longer resolvable — alias it "
+            "from whichever class replaced it."
+        )
+
+
+def test_published_list_covers_every_live_class():
+    """A new class must be recorded as published, or the promise has a hole."""
+    assert {c.id for c in VEX_FINDING_CLASSES} <= set(PUBLISHED_FINDING_CLASS_IDS)
+
+
+def test_published_identifiers_are_unique():
+    """An identifier is never reused for a different meaning."""
+    assert len(set(PUBLISHED_FINDING_CLASS_IDS)) == len(PUBLISHED_FINDING_CLASS_IDS)
+
+
+def test_a_renamed_class_still_reaches_the_documents_by_its_old_name(
+    openvex_validator,
+):
+    """The escape hatch must work on the day it is needed, not in principle.
+
+    `aliases` is empty for every class today, so without this test both
+    emitters' alias branches would ship having never produced a document — and
+    the migration path would be discovered broken at exactly the moment it was
+    needed. Simulates the supported rename: the successor carries the retired
+    identifier, and a consumer matching the old string still finds it in both
+    flavors.
+    """
+    import dataclasses
+
+    renamed = dataclasses.replace(
+        FINDING_CLASSES_BY_ID["AISBOM-PICKLE-RCE"],
+        id="AISBOM-PICKLE-EXEC",
+        aliases=("AISBOM-PICKLE-RCE", "CVE-9999-0001"),
+    )
+    statements = [
+        dataclasses.replace(s, finding_class=renamed)
+        for s in derive_statements([_artifact(threats=["os.system"])])
+        if s.finding_class.id == "AISBOM-PICKLE-RCE"
+    ]
+
+    ovex = json.loads(generate_openvex(statements, sbom_serial=SERIAL))
+    openvex_validator.validate(ovex)
+    assert ovex["statements"][0]["vulnerability"]["aliases"] == [
+        "AISBOM-PICKLE-RCE", "CVE-9999-0001"
+    ]
+
+    cdx_json = generate_cyclonedx_vex(statements, sbom_serial=SERIAL)
+    _assert_cdx_valid(cdx_json)
+    cdx = json.loads(cdx_json)
+    referenced = {r["id"] for r in cdx["vulnerabilities"][0]["references"]}
+    assert "AISBOM-PICKLE-RCE" in referenced
+
+
+def test_emitters_accept_a_statement_whose_class_is_not_in_the_registry(
+    openvex_validator,
+):
+    """Both emitters must serialize a statement AIsbom did not define.
+
+    This is the shape an OSV-sourced dependency CVE will arrive in: a real
+    CVE identifier that is deliberately *not* a member of
+    `VEX_FINDING_CLASSES`. The module's premise is that the emitters take
+    statements and do not care where one came from, so this must work before
+    that integration is written, not after.
+    """
+    from aisbom.vex import FindingClass, VexStatement
+
+    cve = FindingClass(
+        id="CVE-2024-3568",
+        title="Arbitrary code execution in a pinned dependency",
+        description="A published vulnerability in a requirements.txt pin.",
+        action="Upgrade to the fixed version.",
+        formats=frozenset({"pickle"}),
+    )
+    statements = [
+        VexStatement(
+            finding_class=cve,
+            product_ref="artifact-0-model.pt",
+            product_id="",
+            product_hash=SHA_A,
+            status="affected",
+            status_notes="Reported by the dependency scanner.",
+            action_statement=cve.action,
+        )
+    ]
+
+    ovex = json.loads(generate_openvex(statements, sbom_serial=SERIAL))
+    openvex_validator.validate(ovex)
+    assert ovex["statements"][0]["vulnerability"]["name"] == "CVE-2024-3568"
+
+    cdx_json = generate_cyclonedx_vex(statements, sbom_serial=SERIAL)
+    _assert_cdx_valid(cdx_json)
+    assert json.loads(cdx_json)["vulnerabilities"][0]["id"] == "CVE-2024-3568"
+
+
+def test_registry_publishes_the_compatibility_policy():
+    text = _DOCS_REGISTRY.read_text()
+    assert "Compatibility policy" in text
+    assert "never deleted" in text
+    assert "never reused" in text
+    assert "`aliases`" in text
+
+
+def test_no_finding_class_is_shaped_like_a_cve():
+    """A finding class must never be mistakable for a CVE identifier."""
+    for cls in VEX_FINDING_CLASSES:
+        assert cls.id.startswith("AISBOM-")
+        assert not cls.id.startswith("CVE-")
+        assert cls.iri == f"{VEX_NAMESPACE}{cls.id}"
+
+
+def test_no_class_aliases_a_picklescan_cve():
+    """The corpus CVEs are picklescan bugs, not model vulnerabilities.
+
+    CVE-2025-1889/1944/1945, CVE-2025-10155/10156/10157 and CVE-2025-1716 all
+    describe *another scanner* failing to detect something. Aliasing an AIsbom
+    finding to one would assert a relationship that does not exist, in a
+    document a regulator may read.
+    """
+    picklescan_cves = {
+        "CVE-2025-1716", "CVE-2025-1889", "CVE-2025-1944", "CVE-2025-1945",
+        "CVE-2025-10155", "CVE-2025-10156", "CVE-2025-10157",
+    }
+    for cls in VEX_FINDING_CLASSES:
+        assert not (set(cls.aliases) & picklescan_cves)
+
+
+def test_published_registry_matches_the_table():
+    """`docs/vex-finding-classes.md` is generated; drift fails the suite."""
+    assert _DOCS_REGISTRY.read_text() == finding_classes_markdown()
+
+
+def test_registry_states_these_are_not_cves():
+    text = _DOCS_REGISTRY.read_text()
+    assert "not CVE identifiers" in text
+    for cls in VEX_FINDING_CLASSES:
+        assert f"`{cls.id}`" in text
+
+
+# --------------------------------------------------------------------------
+# Status paths — all four, both directions
+# --------------------------------------------------------------------------
+
+def test_affected_pickle_rce(openvex_validator):
+    doc = _openvex([_artifact(threats=["os.system"])])
+    openvex_validator.validate(doc)
+
+    affected = [s for s in doc["statements"] if s["status"] == "affected"]
+    assert len(affected) == 1
+    stmt = affected[0]
+    assert stmt["vulnerability"]["name"] == "AISBOM-PICKLE-RCE"
+    assert stmt["vulnerability"]["@id"] == f"{VEX_NAMESPACE}AISBOM-PICKLE-RCE"
+    assert "os.system" in stmt["status_notes"]
+    # The spec says an `affected` statement SHOULD describe remediation.
+    assert stmt["action_statement"]
+    assert stmt["action_statement_timestamp"]
+    # ...and MUST NOT carry a justification, which is a `not_affected` field.
+    assert "justification" not in stmt
+
+
+def test_not_affected_carries_a_justification(openvex_validator):
+    doc = _openvex([_artifact(name="model.safetensors", framework="SafeTensors")])
+    openvex_validator.validate(doc)
+
+    pickle_rce = [
+        s for s in doc["statements"]
+        if s["vulnerability"]["name"] == "AISBOM-PICKLE-RCE"
+    ]
+    assert len(pickle_rce) == 1
+    assert pickle_rce[0]["status"] == "not_affected"
+    assert pickle_rce[0]["justification"] == JUSTIFICATION_CODE_NOT_PRESENT
+    assert "no Python pickle stream" in pickle_rce[0]["status_notes"]
+    assert "action_statement" not in pickle_rce[0]
+
+
+def test_under_investigation_when_the_stream_was_not_fully_read(openvex_validator):
+    """An incomplete scan must not be reported as a clean one.
+
+    This is the nullifAI class (#107): a deliberately broken stream ends the
+    disassembly early. Reporting `not_affected` there would turn an evasion
+    into a clean bill of health.
+    """
+    doc = _openvex([_artifact(scan_incomplete=True)])
+    openvex_validator.validate(doc)
+
+    assert _statuses(doc, "AISBOM-PICKLE-RCE") == ["under_investigation"]
+    assert _statuses(doc, "AISBOM-PICKLE-UNSCANNED") == ["under_investigation"]
+    for stmt in doc["statements"]:
+        if stmt["status"] == "under_investigation":
+            assert "justification" not in stmt
+
+
+def test_fixed_requires_a_baseline_that_saw_the_finding(openvex_validator):
+    """`fixed` is the one status a single scan cannot honestly assert."""
+    baseline = {
+        "artifact-0-model.pt": {"AISBOM-PICKLE-RCE": "affected"},
+    }
+    doc = _openvex([_artifact()], baseline=baseline)
+    openvex_validator.validate(doc)
+
+    assert _statuses(doc, "AISBOM-PICKLE-RCE") == ["fixed"]
+    fixed = [s for s in doc["statements"] if s["status"] == "fixed"][0]
+    assert "Present in the baseline SBOM" in fixed["status_notes"]
+    # `fixed` is not a `not_affected`, so it carries no justification.
+    assert "justification" not in fixed
+
+
+def test_no_baseline_means_no_fixed_statement(openvex_validator):
+    doc = _openvex([_artifact()])
+    openvex_validator.validate(doc)
+    assert "fixed" not in {s["status"] for s in doc["statements"]}
+
+
+def test_a_still_affected_finding_is_not_reported_fixed():
+    """A baseline finding that is still present stays `affected`."""
+    baseline = {"artifact-0-model.pt": {"AISBOM-PICKLE-RCE": "affected"}}
+    doc = _openvex([_artifact(threats=["os.system"])], baseline=baseline)
+    assert _statuses(doc, "AISBOM-PICKLE-RCE") == ["affected"]
+
+
+# --------------------------------------------------------------------------
+# Scoped negatives — the claim must match what AIsbom actually checked
+# --------------------------------------------------------------------------
+
+def test_negatives_are_scoped_to_formats_the_class_applies_to():
+    """No vacuous statements: an ONNX class says nothing about SafeTensors."""
+    doc = _openvex([_artifact(name="model.safetensors", framework="SafeTensors")])
+    named = {s["vulnerability"]["name"] for s in doc["statements"]}
+    assert named == {"AISBOM-PICKLE-RCE"}
+
+
+def test_keras_never_receives_a_pickle_rce_claim():
+    """`_inspect_keras` does not disassemble pickles, so it cannot clear one.
+
+    The Keras path reads the model config with `scan_keras_config`, never
+    `scan_pickle_stream`. A `not_affected` pickle-RCE claim on a `.keras`
+    container would assert a check that never ran.
+    """
+    doc = _openvex([_artifact(name="m.keras", framework="Keras")])
+    named = {s["vulnerability"]["name"] for s in doc["statements"]}
+    assert "AISBOM-PICKLE-RCE" not in named
+    assert named == {"AISBOM-KERAS-LAMBDA-RCE"}
+
+
+def test_a_clean_scanned_pickle_gets_a_negative_on_its_own_terms():
+    """`not_affected` for a real pickle reads as "disassembled, found nothing"."""
+    doc = _openvex([_artifact()])
+    pickle_rce = [
+        s for s in doc["statements"]
+        if s["vulnerability"]["name"] == "AISBOM-PICKLE-RCE"
+    ][0]
+    assert pickle_rce["status"] == "not_affected"
+    assert "disassembled in full" in pickle_rce["status_notes"]
+
+
+def test_an_unrecognised_format_produces_no_statements():
+    doc = _openvex([_artifact(name="notes.txt", framework="Text")])
+    assert doc["statements"] == []
+
+
+@pytest.mark.parametrize(
+    "framework,name,expected",
+    [
+        ("SafeTensors", "m.safetensors", {"AISBOM-PICKLE-RCE"}),
+        ("GGUF", "m.gguf", {"AISBOM-PICKLE-RCE", "AISBOM-GGUF-TEMPLATE-INJECTION"}),
+        (
+            "ONNX",
+            "m.onnx",
+            {
+                "AISBOM-PICKLE-RCE",
+                "AISBOM-ONNX-CUSTOM-OP",
+                "AISBOM-ONNX-EXTERNAL-DATA",
+            },
+        ),
+        ("Keras", "m.keras", {"AISBOM-KERAS-LAMBDA-RCE"}),
+        (
+            "PyTorch",
+            "m.pt",
+            {
+                "AISBOM-PICKLE-RCE",
+                "AISBOM-PICKLE-CODE-OBJECT",
+                "AISBOM-PICKLE-UNSCANNED",
+            },
+        ),
+        (
+            "Joblib",
+            "m.joblib",
+            {
+                "AISBOM-PICKLE-RCE",
+                "AISBOM-PICKLE-CODE-OBJECT",
+                "AISBOM-PICKLE-UNSCANNED",
+            },
+        ),
+    ],
+)
+def test_each_format_gets_exactly_its_own_classes(framework, name, expected):
+    doc = _openvex([_artifact(name=name, framework=framework)])
+    assert {s["vulnerability"]["name"] for s in doc["statements"]} == expected
+
+
+# --------------------------------------------------------------------------
+# Per-format detections
+# --------------------------------------------------------------------------
+
+def test_dill_code_objects_are_their_own_class():
+    doc = _openvex([_artifact(dill_code_objects=True)])
+    assert _statuses(doc, "AISBOM-PICKLE-CODE-OBJECT") == ["affected"]
+    # No dangerous global was found, so the RCE class stays negative.
+    assert _statuses(doc, "AISBOM-PICKLE-RCE") == ["not_affected"]
+
+
+def test_keras_lambda_layer_is_affected_and_names_the_layer():
+    doc = _openvex([
+        _artifact(
+            name="m.keras",
+            framework="Keras",
+            threats=["KERAS_LAMBDA: scrub"],
+            lambda_layers=["scrub"],
+        )
+    ])
+    stmt = [
+        s for s in doc["statements"]
+        if s["vulnerability"]["name"] == "AISBOM-KERAS-LAMBDA-RCE"
+    ][0]
+    assert stmt["status"] == "affected"
+    assert "scrub" in stmt["status_notes"]
+    assert "safe_mode=True" in stmt["action_statement"]
+
+
+def test_gguf_template_threat_is_affected():
+    doc = _openvex([
+        _artifact(
+            name="m.gguf",
+            framework="GGUF",
+            chat_template_present=True,
+            chat_template_threats=["JINJA_SANDBOX_ESCAPE: __class__"],
+        )
+    ])
+    assert _statuses(doc, "AISBOM-GGUF-TEMPLATE-INJECTION") == ["affected"]
+
+
+def test_gguf_clean_template_is_distinguished_from_no_template():
+    inspected = _openvex([
+        _artifact(name="m.gguf", framework="GGUF", chat_template_present=True)
+    ])
+    absent = _openvex([_artifact(name="m.gguf", framework="GGUF")])
+
+    inspected_note = [
+        s for s in inspected["statements"]
+        if s["vulnerability"]["name"] == "AISBOM-GGUF-TEMPLATE-INJECTION"
+    ][0]["status_notes"]
+    absent_note = [
+        s for s in absent["statements"]
+        if s["vulnerability"]["name"] == "AISBOM-GGUF-TEMPLATE-INJECTION"
+    ][0]["status_notes"]
+
+    assert "was inspected" in inspected_note
+    assert "no chat template" in absent_note
+
+
+def test_truncated_gguf_metadata_is_under_investigation():
+    """"We did not finish looking" is not "nothing is there"."""
+    doc = _openvex([
+        _artifact(name="m.gguf", framework="GGUF", metadata_truncated=True)
+    ])
+    assert _statuses(doc, "AISBOM-GGUF-TEMPLATE-INJECTION") == [
+        "under_investigation"
+    ]
+
+
+# --------------------------------------------------------------------------
+# Incomplete reads must never be reported as clean.
+#
+# Found by scanning a live target, not by a fixture: `hf://google-bert/
+# bert-base-uncased` ships a `tf_model.h5` whose Keras config exceeds the read
+# budget over a range request, and the first version of this module answered
+# "declares no Lambda layer" for it. For a remote `.h5` that is the *common*
+# case, not an edge case.
+# --------------------------------------------------------------------------
+
+def test_truncated_keras_config_is_under_investigation():
+    doc = _openvex([
+        _artifact(
+            name="tf_model.h5",
+            framework="Keras",
+            container="hdf5",
+            config_found=True,
+            truncated=True,
+            threats=[],
+        )
+    ])
+    assert _statuses(doc, "AISBOM-KERAS-LAMBDA-RCE") == ["under_investigation"]
+    stmt = doc["statements"][0]
+    assert "not read in full" in stmt["status_notes"]
+    assert "justification" not in stmt
+
+
+def test_keras_config_never_located_is_under_investigation():
+    """No config was inspected, so there is nothing to clear."""
+    doc = _openvex([
+        _artifact(name="m.keras", framework="Keras", config_found=False)
+    ])
+    assert _statuses(doc, "AISBOM-KERAS-LAMBDA-RCE") == ["under_investigation"]
+
+
+def test_fully_read_keras_config_is_still_cleared():
+    """The guard must not swallow the negative it is scoping."""
+    doc = _openvex([
+        _artifact(
+            name="m.keras",
+            framework="Keras",
+            config_found=True,
+            truncated=False,
+            threats=[],
+        )
+    ])
+    assert _statuses(doc, "AISBOM-KERAS-LAMBDA-RCE") == ["not_affected"]
+
+
+def test_a_truncated_keras_read_still_reports_a_payload_it_did_see():
+    """Truncation downgrades a negative, never a positive."""
+    doc = _openvex([
+        _artifact(
+            name="m.keras",
+            framework="Keras",
+            config_found=True,
+            truncated=True,
+            threats=["KERAS_LAMBDA: scrub"],
+            lambda_layers=["scrub"],
+        )
+    ])
+    assert _statuses(doc, "AISBOM-KERAS-LAMBDA-RCE") == ["affected"]
+
+
+def test_truncated_onnx_graph_is_under_investigation():
+    doc = _openvex([
+        _artifact(name="m.onnx", framework="ONNX", parsed=True, truncated=True)
+    ])
+    assert _statuses(doc, "AISBOM-ONNX-CUSTOM-OP") == ["under_investigation"]
+    assert _statuses(doc, "AISBOM-ONNX-EXTERNAL-DATA") == ["under_investigation"]
+
+
+def test_unparsable_onnx_is_under_investigation():
+    doc = _openvex([
+        _artifact(name="m.onnx", framework="ONNX", parsed=False, truncated=False)
+    ])
+    assert _statuses(doc, "AISBOM-ONNX-CUSTOM-OP") == ["under_investigation"]
+
+
+def test_fully_walked_onnx_graph_is_still_cleared():
+    doc = _openvex([
+        _artifact(name="m.onnx", framework="ONNX", parsed=True, truncated=False)
+    ])
+    assert _statuses(doc, "AISBOM-ONNX-CUSTOM-OP") == ["not_affected"]
+    assert _statuses(doc, "AISBOM-ONNX-EXTERNAL-DATA") == ["not_affected"]
+
+
+def test_onnx_custom_ops_and_external_data_are_separate_classes():
+    doc = _openvex([
+        _artifact(
+            name="m.onnx",
+            framework="ONNX",
+            custom_ops=[{"domain": "com.evil", "op_type": "Run"}],
+            external_data=[{"location": "../../etc/passwd"}],
+            threats=["ONNX_EXTERNAL_DATA_ESCAPE: ../../etc/passwd"],
+        )
+    ])
+    assert _statuses(doc, "AISBOM-ONNX-CUSTOM-OP") == ["affected"]
+    escape = [
+        s for s in doc["statements"]
+        if s["vulnerability"]["name"] == "AISBOM-ONNX-EXTERNAL-DATA"
+    ][0]
+    assert escape["status"] == "affected"
+    assert "outside the model directory" in escape["status_notes"]
+
+
+# --------------------------------------------------------------------------
+# Cross-reference to the SBOM (AC #3)
+# --------------------------------------------------------------------------
+
+def test_products_address_the_sbom_component_by_serial_and_bom_ref():
+    doc = _openvex([_artifact(), _artifact(name="other.pt", artifact_hash=SHA_B)])
+    ids = {s["products"][0]["@id"] for s in doc["statements"]}
+    assert ids == {
+        f"{SERIAL}#artifact-0-model.pt",
+        f"{SERIAL}#artifact-1-other.pt",
+    }
+
+
+def test_same_named_artifacts_stay_distinct():
+    """Artifact names are basenames, so two trees can hold the same one."""
+    doc = _openvex([
+        _artifact(name="model.pt", artifact_hash=SHA_A),
+        _artifact(name="model.pt", artifact_hash=SHA_B),
+    ])
+    ids = {s["products"][0]["@id"] for s in doc["statements"]}
+    assert ids == {
+        f"{SERIAL}#artifact-0-model.pt",
+        f"{SERIAL}#artifact-1-model.pt",
+    }
+
+
+def test_sentinel_hashes_are_never_emitted():
+    """Remote scans store `remote_unhashed`; it is not a SHA-256."""
+    doc = _openvex([_artifact(artifact_hash="remote_unhashed")])
+    for stmt in doc["statements"]:
+        assert "hashes" not in stmt["products"][0]
+
+
+def test_real_hashes_are_emitted_under_the_spec_key():
+    doc = _openvex([_artifact()])
+    assert doc["statements"][0]["products"][0]["hashes"] == {"sha-256": SHA_A}
+
+
+# --------------------------------------------------------------------------
+# CycloneDX VEX
+# --------------------------------------------------------------------------
+
+def test_cyclonedx_vex_validates_against_the_strict_1_7_schema():
+    statements = derive_statements([
+        _artifact(threats=["os.system"]),
+        _artifact(name="m.safetensors", framework="SafeTensors", artifact_hash=SHA_B),
+    ])
+    _assert_cdx_valid(generate_cyclonedx_vex(statements, sbom_serial=SERIAL))
+
+
+def test_cyclonedx_vex_maps_every_openvex_status():
+    """The two vocabularies differ; the mapping must be total."""
+    baseline = {"artifact-3-fixed.pt": {"AISBOM-PICKLE-RCE": "affected"}}
+    statements = derive_statements(
+        [
+            _artifact(name="bad.pt", threats=["os.system"]),
+            _artifact(name="clean.safetensors", framework="SafeTensors"),
+            _artifact(name="partial.pt", scan_incomplete=True),
+            _artifact(name="fixed.pt"),
+        ],
+        baseline,
+    )
+    doc = json.loads(generate_cyclonedx_vex(statements, sbom_serial=SERIAL))
+    states = {v["analysis"]["state"] for v in doc["vulnerabilities"]}
+    assert states == {"exploitable", "not_affected", "in_triage", "resolved"}
+    _assert_cdx_valid(generate_cyclonedx_vex(statements, sbom_serial=SERIAL))
+
+
+def test_cyclonedx_vex_does_not_claim_one_state_for_conflicting_components():
+    """A repo can hold a malicious .pt and a clean .safetensors at once.
+
+    CycloneDX scopes one `analysis` per vulnerability entry, so the same class
+    reaching different conclusions must split into separate entries — otherwise
+    one of the two components is described wrongly.
+    """
+    statements = derive_statements([
+        _artifact(name="bad.pt", threats=["os.system"]),
+        _artifact(name="clean.safetensors", framework="SafeTensors", artifact_hash=SHA_B),
+    ])
+    doc = json.loads(generate_cyclonedx_vex(statements, sbom_serial=SERIAL))
+
+    rce = [v for v in doc["vulnerabilities"] if v["id"] == "AISBOM-PICKLE-RCE"]
+    assert len(rce) == 2
+    by_state = {v["analysis"]["state"]: v for v in rce}
+    assert by_state["exploitable"]["affects"] == [{"ref": "artifact-0-bad.pt"}]
+    assert by_state["not_affected"]["affects"] == [
+        {"ref": "artifact-1-clean.safetensors"}
+    ]
+
+
+def test_cyclonedx_vex_names_aisbom_as_the_source():
+    """An unfamiliar ID must not read as an orphan."""
+    statements = derive_statements([_artifact(threats=["os.system"])])
+    doc = json.loads(generate_cyclonedx_vex(statements, sbom_serial=SERIAL))
+    entry = doc["vulnerabilities"][0]
+    assert entry["source"]["name"] == "AIsbom"
+    assert entry["source"]["url"].startswith(VEX_NAMESPACE)
+    assert entry["recommendation"]
+
+
+def test_cyclonedx_vex_links_back_to_the_sbom():
+    statements = derive_statements([_artifact()])
+    doc = json.loads(generate_cyclonedx_vex(statements, sbom_serial=SERIAL))
+    assert doc["serialNumber"] == SERIAL
+    assert doc["externalReferences"][0]["type"] == "bom"
+    assert doc["externalReferences"][0]["url"] == SERIAL
+
+
+def test_cyclonedx_affects_refs_match_the_openvex_products():
+    """Both flavors must address the same components (AC #3)."""
+    artifacts = [
+        _artifact(threats=["os.system"]),
+        _artifact(name="m.gguf", framework="GGUF", artifact_hash=SHA_B),
+    ]
+    statements = derive_statements(artifacts)
+    cdx = json.loads(generate_cyclonedx_vex(statements, sbom_serial=SERIAL))
+    ovex = json.loads(generate_openvex(statements, sbom_serial=SERIAL))
+
+    cdx_refs = {a["ref"] for v in cdx["vulnerabilities"] for a in v["affects"]}
+    ovex_refs = {
+        s["products"][0]["@id"].split("#", 1)[1] for s in ovex["statements"]
+    }
+    assert cdx_refs == ovex_refs
+
+
+def test_cyclonedx_vex_is_empty_but_valid_when_nothing_was_scanned():
+    doc_json = generate_cyclonedx_vex([], sbom_serial=SERIAL)
+    _assert_cdx_valid(doc_json)
+    assert json.loads(doc_json)["vulnerabilities"] == []
+
+
+# --------------------------------------------------------------------------
+# Baseline reading
+# --------------------------------------------------------------------------
+
+def test_baseline_findings_reads_structured_properties():
+    sbom = {
+        "components": [
+            {
+                "bom-ref": "artifact-0-model.pt",
+                "name": "model.pt",
+                "properties": [
+                    {"name": "aisbom:format", "value": "pickle"},
+                    {"name": "aisbom:pickle:opcode", "value": "os.system"},
+                ],
+            }
+        ]
+    }
+    findings = baseline_findings(sbom)
+    assert findings["artifact-0-model.pt"]["AISBOM-PICKLE-RCE"] == "affected"
+
+
+def test_baseline_findings_degrades_to_the_description_for_pre_54_sboms():
+    """A baseline older than #53/#54 carries no `aisbom:*` properties.
+
+    Reading nothing there would report a clean baseline and turn every
+    pre-existing finding into a spurious `fixed` — the worst possible failure
+    mode for a remediation-evidence artifact.
+    """
+    sbom = {
+        "components": [
+            {
+                "bom-ref": "artifact-0-model.pt",
+                "name": "model.pt",
+                "description": (
+                    "Risk: CRITICAL (RCE Detected: os.system, builtins.eval) | "
+                    "Framework: PyTorch | Legal: PASS | License: MIT"
+                ),
+            }
+        ]
+    }
+    findings = baseline_findings(sbom)
+    assert findings["artifact-0-model.pt"]["AISBOM-PICKLE-RCE"] == "affected"
+
+
+def test_pre_54_baseline_does_not_manufacture_a_fixed_statement():
+    """End to end: an old baseline still suppresses a false `fixed`."""
+    sbom = {
+        "components": [
+            {
+                "bom-ref": "artifact-0-model.pt",
+                "description": (
+                    "Risk: CRITICAL (RCE Detected: os.system) | "
+                    "Framework: PyTorch | Legal: PASS | License: MIT"
+                ),
+            }
+        ]
+    }
+    doc = _openvex([_artifact(threats=["os.system"])], baseline=baseline_findings(sbom))
+    assert _statuses(doc, "AISBOM-PICKLE-RCE") == ["affected"]
+
+
+def test_baseline_findings_accepts_a_path(tmp_path):
+    path = tmp_path / "baseline.json"
+    path.write_text(json.dumps({
+        "components": [
+            {
+                "bom-ref": "artifact-0-model.pt",
+                "properties": [
+                    {"name": "aisbom:format", "value": "pickle"},
+                    {"name": "aisbom:pickle:opcode", "value": "os.system"},
+                ],
+            }
+        ]
+    }))
+    findings = baseline_findings(str(path))
+    assert findings["artifact-0-model.pt"]["AISBOM-PICKLE-RCE"] == "affected"
+
+
+def test_baseline_findings_skips_components_without_a_ref_or_format():
+    sbom = {
+        "components": [
+            {"name": "no-ref", "properties": [{"name": "aisbom:format", "value": "pickle"}]},
+            {"bom-ref": "lib-1", "name": "torch", "version": "2.0.1"},
+        ]
+    }
+    assert baseline_findings(sbom) == {}
+
+
+def test_signals_from_component_reads_onnx_counts():
+    sig = signals_from_component({
+        "properties": [
+            {"name": "aisbom:format", "value": "onnx"},
+            {"name": "aisbom:onnx:custom_op_count", "value": "2"},
+            {"name": "aisbom:onnx:external_data_count", "value": "1"},
+            {"name": "aisbom:onnx:threat", "value": "ONNX_EXTERNAL_DATA_ESCAPE: ../x"},
+        ]
+    })
+    assert sig["onnx_custom_ops"] == 2
+    assert sig["onnx_external_data"] == 1
+    assert sig["onnx_external_escape"] is True
+
+
+def test_signals_from_component_splits_keras_lambda_csv():
+    sig = signals_from_component({
+        "properties": [
+            {"name": "aisbom:format", "value": "keras"},
+            {"name": "aisbom:keras:lambda_layers", "value": "scrub,decode"},
+        ]
+    })
+    assert sig["keras_lambda_layers"] == ["scrub", "decode"]
+
+
+# --------------------------------------------------------------------------
+# Document shape
+# --------------------------------------------------------------------------
+
+def test_openvex_document_carries_the_required_metadata(openvex_validator):
+    doc = _openvex([_artifact()])
+    openvex_validator.validate(doc)
+    assert doc["@context"] == "https://openvex.dev/ns/v0.2.0"
+    assert doc["@id"] == f"{SERIAL}#openvex"
+    assert doc["author"] == "AIsbom"
+    assert doc["version"] == 1
+    assert doc["tooling"].startswith("aisbom-cli/")
+
+
+def test_every_class_description_is_prose_a_reader_can_act_on():
+    for cls in VEX_FINDING_CLASSES:
+        assert cls.description.endswith(".")
+        assert cls.action.endswith(".")
+        assert len(cls.description) > 80
+        assert FINDING_CLASSES_BY_ID[cls.id] is cls


### PR DESCRIPTION
Closes Lab700xOrg/aisbom-ops#113.

`aisbom scan --vex` writes VEX documents alongside the CycloneDX SBOM, stating per finding whether each scanned artifact is actually affected. FDA §524B has required VEX beside the SBOM since March 2026.

```bash
aisbom scan . --vex --output sbom.json
# -> sbom.json, sbom.openvex.json, sbom.vex.cdx.json
```

`--vex-format openvex|cyclonedx|both` (default `both`), `--vex-baseline <old-sbom.json>` for `fixed`.

## Design decisions

**Statements are keyed on AIsbom finding classes, not CVEs.** What AIsbom detects lives inside a model file — a pickle stream importing `os.system`, a Keras Lambda layer, a Jinja chat template with a sandbox escape. None of that has a CVE, because the file *is* the payload rather than a component with a patchable defect. Seven coarse, class-level identifiers, documented in [`docs/vex-finding-classes.md`](docs/vex-finding-classes.md), resolving under `https://aisbom.io/vex/`, never presented as CVE identifiers.

**`aliases` is deliberately empty.** The CVEs the bypass corpus knows — CVE-2025-1889/1944/1945, CVE-2025-10155/10156/10157, CVE-2025-1716 — are vulnerabilities in *picklescan*, another scanner failing to detect something. One entry literally reads "Fixed in picklescan 0.0.23." Aliasing an AIsbom finding to those would assert a relationship that does not exist, in a document a regulator may read. A test enforces it.

**Negatives are scoped to what was actually checked.** A class is asserted only for formats it can arise in, and only when the scan that would have found it ran to completion. Keras never receives a pickle-RCE claim at all: `_inspect_keras` reads the config with `scan_keras_config`, never `scan_pickle_stream`, so clearing one would assert a check that never ran.

**`fixed` requires `--vex-baseline`.** A single scan observes one point in time. The baseline is read from the SBOM's structured `aisbom:*` properties (#53/#54), falling back to the description string for older baselines — reading nothing there would report a clean baseline and turn every pre-existing finding into a spurious `fixed`.

**Justification is restricted to `vulnerable_code_not_present`.** OpenVEX offers five and CycloneDX nine, and they do not line up; mapping more would mean picking an inexact analogue for at least one. It is also the only justification a static read can support.

**CycloneDX VEX splits one entry per (class, status).** The library scopes one `analysis` block per vulnerability, but a repo routinely holds a malicious `.pt` and a clean `.safetensors` at once. Splitting keeps each component's status truthful.

**Compatibility policy, enforced.** A class is never deleted and an identifier never reused; a renamed class is aliased from its successor; `PUBLISHED_FINDING_CLASS_IDS` is append-only and a test fails if any published identifier stops resolving.

## Two defects found by leaving the fixtures

1. **Keras and ONNX over-claims.** A live `hf://google-bert/bert-base-uncased` scan showed `tf_model.h5` reported `not_affected` for Lambda execution when the config had hit the read budget — over a range request that is the *common* case for a `.h5`, not an edge case. Same for a truncated ONNX graph. Both now report `under_investigation`; regression test drives the real scanner.
2. **`KeyError` in the CycloneDX emitter.** Exercising the (currently empty) alias path revealed `generate_cyclonedx_vex` re-looking-up each class in the module-level registry instead of using the class the statement carries. It would have crashed on any statement AIsbom did not define — including the OSV-sourced CVE statements this module exists to accommodate. Fixed, with a test that serializes a `CVE-*` statement through both flavors.

## Verification

- `poetry run pytest --cov=aisbom --cov-fail-under=85` — **984 passed**, coverage **92.44%**, `aisbom/vex.py` at **100%**. 69 new tests.
- `aisbom bypass-scorecard --check` — gate passed, no case below the floor.
- **Live probe** `hf://google-bert/bert-base-uncased`: OpenVEX 0.2.0 strict validation PASS (official bundled schema, `additionalProperties: false`), CycloneDX 1.7 strict validation PASS, zero dangling product refs, all 4 model components covered.
- **Local probe** over `generate-test-artifacts`: `mock_malware.pt` `affected` with an action statement; SafeTensors and GGUF correctly `not_affected` with justification; real SHA-256 hashes emitted, sentinels never.
- **No regression:** insertion-only diff (0 deletions in every file). `aisbom scan .` against `origin/main` on the same tree — SBOM byte-identical (3095/3095), components identical, `bom-ref` set identical, terminal output identical, exit code identical.
- No dependency changes; `pyproject.toml` and `poetry.lock` untouched. +1.12 ms marginal import cost.
- CI gains smoke test #11 exercising both flavors and the baseline path.

## Follow-ups (not blockers)

- OSV/CVE mapping for `requirements.txt` pins — the CVE-keyed statements that join the same document. This is what actually closes the FDA §524B expectation of CVE-keyed VEX; the finding classes are additive to a submission, never a substitute.
- `https://aisbom.io/vex/*` pages the `@id` IRIs point at do not exist yet — fits the #115 compliance hub.
- `details["truncated"]` for ONNX is computed from the buffered read and stays `True` even when the streamed re-walk covered the file, so large *local* ONNX files report `under_investigation` conservatively. Making that field reflect the re-walk is a change to #105's output and deserves its own slice.
- GGUF `metadata_truncated` is not exposed as an `aisbom:*` property, so the baseline reader cannot see it. Harmless today (`fixed` only transitions from `affected`), but it is a gap in the structured surface.
