### PR TITLE
feat(score): grade AIBOM completeness with `aisbom score` (#114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,16 @@ jobs:
           test -s vex-sbom.openvex.json
           test -s vex-sbom.vex.cdx.json
           poetry run aisbom scan . --vex --vex-baseline vex-sbom.json --output vex-rescan.json --no-fail-on-risk
+
+      # Exercises all three input routes and both gate outcomes. `--fail-under 0`
+      # must pass and `--fail-under 101` must exit 2, so a gate that silently
+      # stopped gating would fail the build rather than going unnoticed.
+      - name: Smoke Test #12 - Completeness Score
+        run: |
+          poetry run aisbom score sbom.json
+          poetry run aisbom score sbom.json --json
+          poetry run aisbom score . --json
+          poetry run aisbom score vex-sbom.json --fail-under 0
+          if poetry run aisbom score sbom.json --fail-under 101; then
+            echo "::error::--fail-under did not gate on a failing score"; exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -368,7 +368,12 @@ aisbom score hf://google-bert/bert-base-uncased
 ```
 
 VEX documents written by `scan --vex` are found automatically next to the SBOM;
-`--vex <path>` points elsewhere.
+`--vex <path>` points elsewhere. A VEX document only counts if it actually
+describes *this* SBOM — both formats bind to the document's serial number — so
+files left behind by an earlier scan are not credited. Scoring a target whose
+scan hit a fetch or parse error exits `1` rather than grading the partial
+result, since a completeness score computed from only the artifacts that
+scanned would overstate the document.
 
 **As a CI gate:**
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,87 @@ aisbom scan . --vex --vex-baseline last-release-sbom.json --output sbom.json
 Baselines predating structured findings still work: the finding is recovered
 from the component description rather than reported as a spurious `fixed`.
 
+### Completeness score (`aisbom score`)
+
+A scan can come back perfectly clean and still produce an SBOM that names no
+licenses, carries no checksums and describes none of the models. `aisbom score`
+grades the document you are about to hand an auditor:
+
+```bash
+aisbom score sbom.json
+```
+
+```
+╭─ AIBOM completeness ─╮
+│ C  63.6/100          │
+│ 7 component(s), 4 model(s), CycloneDX 1.7 │
+╰──────────────────────╯
+```
+
+Seven dimensions, weighted to 100 — 65 points of NTIA-style minimum elements,
+25 of AI-specific description, 10 of VEX:
+
+| Dimension | Weight | Earned by |
+|---|---|---|
+| Component identity | 20 | name, stable `bom-ref`, real version |
+| Checksums | 20 | SHA-256 on every model component |
+| Licenses | 15 | a declared license per component |
+| Model-card coverage | 15 | task / architecture per model |
+| Dataset provenance | 10 | named training datasets |
+| VEX presence | 10 | exploitability statements alongside the inventory |
+| Document provenance | 10 | `metadata.tools`, timestamp, serial number, spec version |
+
+Grades: **A** ≥85, **B** ≥70, **C** ≥55, **D** ≥40, **F** below 40.
+
+The output is a worklist, not a verdict. Gaps are grouped by dimension and
+ranked by how many points closing them is worth, so the cheapest large win
+comes first:
+
+```
+How to improve (53.6 → 100.0 possible)
+   +15.0  Model-card coverage — 4 of 4 model(s) declare no task or architecture
+          → aisbom scan hf://<org>/<model>
+   +10.7  Licenses — 5 of 7 component(s) declare no license
+   +10.0  Dataset provenance — 4 of 4 model(s) name no training data
+   +10.0  VEX presence — no exploitability statements
+          → aisbom scan . --vex --output sbom.json
+    +0.7  Component identity — 1 component(s) incompletely identified
+```
+
+`--verbose` lists every affected component under each entry; `--json` always
+carries the full per-component detail.
+
+Score a target directly and it is scanned first — the document graded is the
+one `aisbom scan` would have written:
+
+```bash
+aisbom score ./models
+aisbom score hf://google-bert/bert-base-uncased
+```
+
+VEX documents written by `scan --vex` are found automatically next to the SBOM;
+`--vex <path>` points elsewhere.
+
+**As a CI gate:**
+
+```bash
+aisbom score sbom.json --fail-under 70
+```
+
+Exit `2` if the score is below the threshold, `1` on an unreadable or
+non-CycloneDX input, `0` otherwise. `--json` emits the full breakdown for
+programmatic use, and still honours `--fail-under`.
+
+A note on what is reachable: `hf://` scans stream byte ranges and never read a
+whole file, so they cannot produce checksums and top out at 80. That is
+reported as a gap with its cause named, not silently excused — scan a local
+copy to fill it in. Scoring is deliberately fixed-denominator: every document
+is graded against all seven dimensions, because a grade computed on a
+per-document denominator is not comparable with anyone else's.
+
+`aisbom score` grades CycloneDX. SPDX input is rejected rather than partially
+scored.
+
 ---
 
 ## Use as a GitHub Action

--- a/aisbom/cli.py
+++ b/aisbom/cli.py
@@ -8,26 +8,20 @@ from enum import Enum
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
-from cyclonedx.model.bom import Bom
-from cyclonedx.model.component import Component, ComponentType
-from cyclonedx.model import HashAlgorithm, HashType, Property
-from cyclonedx.output.json import JsonV1Dot5, JsonV1Dot6, JsonV1Dot7
-from cyclonedx.factory.license import LicenseFactory
 from .mock_generator import create_mock_malware_file, create_mock_restricted_file, create_mock_gguf, create_demo_diff_sboms, create_mock_broken_file
 from pathlib import Path
 from urllib.parse import urlparse
 import importlib.metadata
 from .scanner import DeepScanner
 from .diff import SBOMDiff
-from .properties import build_component_properties
-from .modelcard import bom_ref_for, inject_model_cards
+from .cyclonedx_gen import build_cyclonedx_json
+from . import score as score_mod
 from .vex import (
     baseline_findings,
     derive_statements,
     generate_cyclonedx_vex,
     generate_openvex,
 )
-from .spdx_gen import _sha256_or_none
 
 import threading
 import time
@@ -796,61 +790,7 @@ def scan(
         for err in parse_errors:
             console.print(f"  - Could not parse [yellow]{err['file']}[/yellow]: {err['error']}")
     
-    # 3. Generate CycloneDX SBOM (Standard Compliance)
-    bom = Bom()
-    lf = LicenseFactory()
-    
-    # Add Models
-    for art_index, art in enumerate(results['artifacts']):
-        c = Component(
-            name=art['name'],
-            type=ComponentType.MACHINE_LEARNING_MODEL,
-            # An explicit, stable bom-ref. Left to the library this is a fresh
-            # random string on every run, which nothing downstream can rely on
-            # and which cannot be computed ahead of serialization — so the
-            # modelCard splice would have no identifier to join on and would
-            # fall back to matching by basename, which collides (#111).
-            bom_ref=bom_ref_for(art_index, art),
-            description=f"Risk: {art['risk_level']} | Framework: {art['framework']} | Legal: {art['legal_status']} | License: {art.get('license')}"
-        )
-        # Add SHA256 Hash only when the field actually holds one. The scanner
-        # stores the sentinels `remote_unhashed` (range-request scans never
-        # read the whole file) and `hash_error` in the same field, and the old
-        # `!= 'hash_error'` guard let `remote_unhashed` through as a SHA-256
-        # digest — which made every hf:// SBOM fail CycloneDX validation, at
-        # 1.6 as well as 1.7. Reuses spdx_gen's predicate, which already had to
-        # solve this for SPDX (#101), rather than blacklisting sentinel names:
-        # a sentinel added later would silently reintroduce the bug.
-        digest = _sha256_or_none(art.get('hash'))
-        if digest:
-            c.hashes.add(HashType(
-                alg=HashAlgorithm.SHA_256,
-                content=digest
-            ))
-        # Add License info to SBOM if known
-        if art.get('license') and art['license'] != 'Unknown':
-            # Create a License object (using name since we don't have SPDX ID validation yet)
-            lic = lf.make_from_string(art['license'])
-            c.licenses.add(lic)
-
-        # Attach structured, namespaced per-format findings as CycloneDX
-        # properties so consumers can render them directly (the description
-        # string above is kept unchanged for backwards compatibility).
-        for prop_name, prop_value in build_component_properties(art):
-            c.properties.add(Property(name=prop_name, value=prop_value))
-
-        bom.components.add(c)
-
-    # Add Libraries
-    for dep in results['dependencies']:
-        c = Component(
-            name=dep['name'],
-            version=dep['version'],
-            type=ComponentType.LIBRARY
-        )
-        bom.components.add(c)
-
-    # 4. Save to Disk
+    # 3. Save to Disk
     if output is None:
         if format == OutputFormat.JSON:
              output = "sbom.json"
@@ -860,25 +800,7 @@ def scan(
              output = "aisbom-report.md"
 
     if format == OutputFormat.JSON:
-        if schema_version == "1.5":
-            outputter = JsonV1Dot5(bom)
-        elif schema_version == "1.6":
-            outputter = JsonV1Dot6(bom)
-        else:
-            outputter = JsonV1Dot7(bom)
-
-        sbom_json = outputter.output_as_string()
-
-        # ML-BOM enrichment (#111). `modelCard` only exists from CycloneDX 1.5
-        # on, but 1.5/1.6 output is what older platform receivers and third
-        # party tools were pinned against, so the block is added to 1.7 only —
-        # asking for an older schema version keeps giving byte-identical
-        # output to before this change. cyclonedx-python-lib cannot model the
-        # field, hence the post-serialization splice.
-        if schema_version == "1.7":
-            sbom_json = inject_model_cards(
-                sbom_json, results['artifacts'], results.get('hf_model_card')
-            )
+        sbom_json = build_cyclonedx_json(results, schema_version)
 
         with open(output, "w") as f:
             f.write(sbom_json)
@@ -1169,6 +1091,219 @@ def bypass_scorecard(
             )
             raise typer.Exit(code=2)
         console.print("\n[green]Scorecard gate passed[/green] — no case below the floor.")
+
+
+def _render_score_footer() -> None:
+    """Print the post-score footer, mirroring `scan`'s "Next steps" panel.
+
+    Deliberately does *not* sell the gaps back to the user. Almost everything
+    the plan asks for — `--vex`, a local re-scan, `hf://` metadata — is a free
+    CLI action, so framing the gap list as a reason to buy would be both a dark
+    pattern and inaccurate. What the platform genuinely adds over a one-shot
+    grade is the trend across scans, which is what this points at.
+    """
+    console.print(Panel(
+        "📈 [bold]Track this score across scans:[/bold]\n"
+        f"   [underline cyan]{_attribution_ref('https://app.aisbom.io')}[/underline cyan]\n"
+        f"📰 [bold]Latest model advisories:[/bold] "
+        f"[underline cyan]{_attribution_ref('https://aisbom.io/advisories')}[/underline cyan]",
+        title=" Next steps ",
+        border_style="blue",
+        expand=False,
+    ))
+
+
+def _grade_style(grade: str) -> str:
+    return {
+        "A": "bold green", "B": "green", "C": "yellow",
+        "D": "bold yellow", "F": "bold red",
+    }.get(grade, "white")
+
+
+def _score_style(value: float) -> str:
+    if value >= 85:
+        return "green"
+    if value >= 55:
+        return "yellow"
+    return "red"
+
+
+@app.command()
+def score(
+    target: str = typer.Argument(
+        "sbom.json",
+        help=(
+            "A CycloneDX SBOM to grade, or a scan target to scan and then grade "
+            "(directory, hf:// slug, or HTTP(S) URL)."
+        ),
+    ),
+    fail_under: float = typer.Option(
+        None,
+        "--fail-under",
+        help="Exit with code 2 if the overall score is below this threshold (CI gate).",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Print the machine-readable result only."
+    ),
+    vex_file: str = typer.Option(
+        None,
+        "--vex",
+        help=(
+            "A VEX document to credit for the VEX dimension. Defaults to the "
+            "files `scan --vex` writes next to the SBOM."
+        ),
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        help="List every affected component under each improvement, not just a count.",
+    ),
+    strict: bool = typer.Option(
+        False, help="Use strict allowlisting mode when TARGET is a scan target."
+    ),
+):
+    """
+    Grade an AIBOM for completeness and quality.
+
+    Scores a CycloneDX document across seven dimensions — component identity,
+    checksums, licenses, model-card coverage, dataset provenance, VEX presence
+    and document provenance — and names the specific gaps behind each one.
+    Use --fail-under to gate CI on the result.
+    """
+    t = threading.Thread(target=run_version_check_wrapper, daemon=True)
+    t.start()
+
+    scan_id = uuid.uuid4().hex
+    telemetry_threads: list[threading.Thread | None] = [_maybe_emit_install_event()]
+
+    path = Path(target)
+    sbom_path: Path | None = None
+
+    if path.is_file():
+        # An existing file is graded as-is. Its siblings are where `scan --vex`
+        # would have put the VEX documents, so they are discoverable from here.
+        try:
+            doc = score_mod.load_sbom(path)
+        except score_mod.ScoreInputError as exc:
+            console.print(f"[bold red]✖ {exc}[/bold red]")
+            _flush_telemetry_threads(telemetry_threads)
+            raise typer.Exit(code=1)
+        sbom_path = path
+    elif path.is_dir() or _classify_target(target) in ("huggingface", "https", "http"):
+        # A scan target: produce the document, then grade what was produced.
+        # Built through the same `build_cyclonedx_json` that `scan` writes, so
+        # the grade describes exactly the file a scan would have handed over.
+        #
+        # Under --json the scan chrome goes to stderr: the flag promises the
+        # machine-readable result *only*, so a progress panel on stdout would
+        # make `aisbom score <dir> --json | jq` fail on the first line.
+        progress = err_console if json_output else console
+        progress.print(
+            Panel.fit(f"🚀 [bold cyan]AIsbom[/bold cyan] Scanning: [underline]{target}[/underline]")
+        )
+        try:
+            scanner = DeepScanner(target, strict_mode=strict, lint=False)
+            with progress.status("[cyan]Scanning...[/cyan]"):
+                results = scanner.scan()
+        except Exception as exc:
+            console.print(f"[bold red]✖ Scan failed:[/bold red] {exc}")
+            _flush_telemetry_threads(telemetry_threads)
+            raise typer.Exit(code=1)
+        doc = json.loads(build_cyclonedx_json(results, "1.7"))
+    else:
+        console.print(
+            f"[bold red]✖ Cannot score[/bold red] {target}: not an existing file, "
+            "a directory, an hf:// slug or an HTTP(S) URL."
+        )
+        _flush_telemetry_threads(telemetry_threads)
+        raise typer.Exit(code=1)
+
+    if vex_file:
+        vex_documents = [Path(vex_file)]
+        if not vex_documents[0].is_file():
+            console.print(f"[bold red]✖ VEX document not found:[/bold red] {vex_file}")
+            _flush_telemetry_threads(telemetry_threads)
+            raise typer.Exit(code=1)
+    else:
+        vex_documents = score_mod.discover_vex(sbom_path)
+
+    report = score_mod.score_sbom(doc, vex_documents=vex_documents)
+
+    telemetry_threads.append(telemetry.post_event(
+        "cli_score",
+        {"grade": report.grade, "models": str(report.model_count)},
+        scan_id=scan_id,
+    ))
+
+    if json_output:
+        console.print_json(json.dumps(report.to_dict()))
+        _flush_telemetry_threads(telemetry_threads)
+        if fail_under is not None and report.overall < fail_under:
+            raise typer.Exit(code=2)
+        return
+
+    grade_style = _grade_style(report.grade)
+    console.print(Panel.fit(
+        f"[{grade_style}]{report.grade}[/{grade_style}]  "
+        f"[bold]{report.overall:.1f}[/bold]/100\n"
+        f"[dim]{report.component_count} component(s), "
+        f"{report.model_count} model(s), CycloneDX {report.spec_version or '?'}[/dim]",
+        title="AIBOM completeness",
+    ))
+
+    table = Table(title="Score by dimension", show_lines=False)
+    table.add_column("Dimension", style="cyan", no_wrap=True)
+    table.add_column("Weight", justify="right", style="dim")
+    table.add_column("Score", justify="right")
+    for dim in report.dimensions:
+        style = _score_style(dim.score)
+        table.add_row(
+            dim.label, str(dim.weight), f"[{style}]{dim.score:.0f}[/{style}]"
+        )
+    console.print(table)
+
+    # Ranked by points recoverable rather than listed by dimension. A flat list
+    # gives a one-flag ten-point VEX fix the same weight as a sub-point missing
+    # version string, and repeats an identical remedy once per component — on a
+    # 50-model scan that is ~150 lines nobody reads. Per-component detail is
+    # still available under --verbose, and always in --json.
+    plan = report.improvement_plan()
+    if plan:
+        console.print(
+            f"\n[bold]How to improve[/bold] "
+            f"[dim]({report.overall:.1f} → {report.potential:.1f} possible)[/dim]"
+        )
+        for dim in plan:
+            console.print(
+                f"  [green]{'+' + format(dim.points_recoverable, '.1f'):>6}[/green]  "
+                f"[bold]{dim.label}[/bold]"
+                + (f" [dim]— {dim.summary}[/dim]" if dim.summary else "")
+            )
+            if dim.remediation:
+                console.print(f"         [cyan]→[/cyan] {dim.remediation}")
+            if verbose:
+                for gap in dim.gaps:
+                    console.print(f"           [dim]•[/dim] [dim]{gap}[/dim]")
+        if not verbose and any(len(d.gaps) > 1 for d in plan):
+            console.print(
+                "\n[dim]Re-run with --verbose to list every affected component, "
+                "or --json for the full breakdown.[/dim]"
+            )
+    else:
+        console.print("\n[green]No gaps found — every dimension is complete.[/green]")
+
+    _render_score_footer()
+
+    if fail_under is not None and report.overall < fail_under:
+        console.print(
+            f"\n[bold red]FAILURE: score {report.overall:.1f} is below the "
+            f"--fail-under threshold of {fail_under:.1f}.[/bold red]"
+        )
+        _flush_telemetry_threads(telemetry_threads)
+        raise typer.Exit(code=2)
+
+    _check_update_status()
+    _flush_telemetry_threads(telemetry_threads)
 
 
 @app.command()

--- a/aisbom/cli.py
+++ b/aisbom/cli.py
@@ -1209,6 +1209,29 @@ def score(
             console.print(f"[bold red]✖ Scan failed:[/bold red] {exc}")
             _flush_telemetry_threads(telemetry_threads)
             raise typer.Exit(code=1)
+
+        # A fetch or parse failure is recorded in results["errors"] and the
+        # scan returns normally, so the except above never fires. Grading what
+        # survived would hand back a completeness score for a document that is
+        # silently missing the shard that failed — precisely the claim this
+        # command exists to make trustworthy. `scan` already exits 1 on these;
+        # scoring must not be the softer path.
+        if results.get("errors"):
+            console.print(
+                "[bold red]✖ Refusing to score a partial scan[/bold red] — "
+                f"{len(results['errors'])} target(s) could not be read:"
+            )
+            for err in results["errors"]:
+                console.print(
+                    f"  [red]•[/red] {err.get('file', '?')}: {err.get('error', '?')}"
+                )
+            console.print(
+                "\n[dim]A grade computed from only the artifacts that scanned "
+                "would overstate the document's completeness.[/dim]"
+            )
+            _flush_telemetry_threads(telemetry_threads)
+            raise typer.Exit(code=1)
+
         doc = json.loads(build_cyclonedx_json(results, "1.7"))
     else:
         console.print(

--- a/aisbom/cyclonedx_gen.py
+++ b/aisbom/cyclonedx_gen.py
@@ -1,0 +1,135 @@
+"""Build the CycloneDX document from a completed scan.
+
+Extracted from ``cli.scan`` (#114) so that ``aisbom score`` can grade a scan
+target directly — scoring a directory or an ``hf://`` slug means producing a
+document to score, and duplicating the construction in two places is how the
+two drift apart. ``scan`` and ``score`` now emit byte-identical documents from
+the same results, because they run the same code.
+
+The ``modelCard`` splice lives here too, so callers get a finished document
+rather than one they must remember to enrich (see ``modelcard`` for why the
+block is spliced post-serialization rather than modelled).
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import Any, Dict
+
+from cyclonedx.factory.license import LicenseFactory
+from cyclonedx.model import HashAlgorithm, HashType, Property
+from cyclonedx.model.bom import Bom
+from cyclonedx.model.component import Component, ComponentType
+from cyclonedx.output.json import JsonV1Dot5, JsonV1Dot6, JsonV1Dot7
+
+from .modelcard import bom_ref_for, inject_model_cards
+from .properties import build_component_properties
+from .spdx_gen import _sha256_or_none
+
+_OUTPUTTERS = {
+    "1.5": JsonV1Dot5,
+    "1.6": JsonV1Dot6,
+    "1.7": JsonV1Dot7,
+}
+
+# Version reported in `metadata.tools`. Read from installed metadata so a
+# released build self-identifies accurately; the fallback covers running from
+# a source checkout that was never installed.
+try:  # pragma: no cover - trivial, and environment-dependent
+    _AISBOM_VERSION = importlib.metadata.version("aisbom-cli")
+except importlib.metadata.PackageNotFoundError:  # pragma: no cover
+    _AISBOM_VERSION = "unknown"
+
+
+def _tool_component() -> Component:
+    """AIsbom's self-identification for ``metadata.tools``.
+
+    An SBOM that does not say what produced it fails the NTIA minimum
+    elements — and, since #114, AIsbom's own completeness grade. Emitting it
+    is purely additive: no existing field changes value.
+    """
+    return Component(
+        name="aisbom-cli",
+        version=_AISBOM_VERSION,
+        type=ComponentType.APPLICATION,
+        bom_ref="aisbom-cli",
+    )
+
+
+def build_bom(results: Dict[str, Any]) -> Bom:
+    """Assemble the ``Bom`` object for a completed scan's results."""
+    bom = Bom()
+    lf = LicenseFactory()
+
+    bom.metadata.tools.components.add(_tool_component())
+
+    for art_index, art in enumerate(results.get("artifacts", [])):
+        c = Component(
+            name=art["name"],
+            type=ComponentType.MACHINE_LEARNING_MODEL,
+            # An explicit, stable bom-ref. Left to the library this is a fresh
+            # random string on every run, which nothing downstream can rely on
+            # and which cannot be computed ahead of serialization — so the
+            # modelCard splice would have no identifier to join on and would
+            # fall back to matching by basename, which collides (#111).
+            bom_ref=bom_ref_for(art_index, art),
+            description=(
+                f"Risk: {art['risk_level']} | Framework: {art['framework']} | "
+                f"Legal: {art['legal_status']} | License: {art.get('license')}"
+            ),
+        )
+        # Add SHA256 Hash only when the field actually holds one. The scanner
+        # stores the sentinels `remote_unhashed` (range-request scans never
+        # read the whole file) and `hash_error` in the same field, and the old
+        # `!= 'hash_error'` guard let `remote_unhashed` through as a SHA-256
+        # digest — which made every hf:// SBOM fail CycloneDX validation, at
+        # 1.6 as well as 1.7. Reuses spdx_gen's predicate, which already had to
+        # solve this for SPDX (#101), rather than blacklisting sentinel names:
+        # a sentinel added later would silently reintroduce the bug.
+        digest = _sha256_or_none(art.get("hash"))
+        if digest:
+            c.hashes.add(HashType(alg=HashAlgorithm.SHA_256, content=digest))
+
+        if art.get("license") and art["license"] != "Unknown":
+            c.licenses.add(lf.make_from_string(art["license"]))
+
+        # Attach structured, namespaced per-format findings as CycloneDX
+        # properties so consumers can render them directly (the description
+        # string above is kept unchanged for backwards compatibility).
+        for prop_name, prop_value in build_component_properties(art):
+            c.properties.add(Property(name=prop_name, value=prop_value))
+
+        bom.components.add(c)
+
+    for dep in results.get("dependencies", []):
+        version = dep.get("version")
+        # `version: "unknown"` was a placeholder carrying no more information
+        # than an absent field, and it cost the completeness grade real points
+        # for nothing (#114). Omitting it is safe: `diff.SBOMDiff` already
+        # reads `component.get("version", "unknown")`, so an absent field and
+        # the literal string compare equal and no drift is reported.
+        bom.components.add(Component(
+            name=dep["name"],
+            version=None if version == "unknown" else version,
+            type=ComponentType.LIBRARY,
+        ))
+
+    return bom
+
+
+def build_cyclonedx_json(results: Dict[str, Any], schema_version: str = "1.7") -> str:
+    """Serialize a scan's results as a CycloneDX JSON document.
+
+    ML-BOM enrichment (#111) applies to 1.7 only. ``modelCard`` exists from
+    CycloneDX 1.5 on, but 1.5/1.6 output is what older platform receivers and
+    third-party tools were pinned against, so asking for an older schema
+    version keeps giving the document shape those consumers expect.
+    """
+    outputter = _OUTPUTTERS.get(schema_version, JsonV1Dot7)
+    sbom_json = outputter(build_bom(results)).output_as_string()
+
+    if schema_version == "1.7":
+        sbom_json = inject_model_cards(
+            sbom_json, results.get("artifacts", []), results.get("hf_model_card")
+        )
+    return sbom_json

--- a/aisbom/score.py
+++ b/aisbom/score.py
@@ -1,0 +1,567 @@
+"""Grade a CycloneDX AIBOM for completeness and quality.
+
+`aisbom score` answers a different question from `aisbom scan`: not "is this
+model dangerous" but "is this document good enough to *be* the compliance
+artifact you are about to hand someone". A scan can come back perfectly clean
+and still produce an SBOM that names no licenses, carries no checksums and
+describes none of the models — which is worth knowing before an auditor finds
+out for you.
+
+Scoring is deliberately **fixed-denominator**: every document is graded against
+all seven dimensions, whether or not it had a realistic chance at each one. The
+alternative — marking dimensions "not applicable" and renormalizing — makes two
+grades incomparable, which is the whole value of having a grade. A remote
+`hf://` scan therefore loses the checksum dimension, and the gap message says
+why and what to do about it rather than pretending the dimension does not apply.
+
+Dimensions and weights (summing to 100):
+
+===================  ==  =====================================================
+identity             20  NTIA minimum element: every component identifiable
+checksums            20  NTIA minimum element: integrity of what was scanned
+licenses             15  NTIA minimum element: what you are allowed to do
+modelcard            15  The "AI" in AIBOM — task/architecture of each model
+datasets             10  Training-data provenance
+vex                  10  Exploitability statements alongside the inventory
+docprov              10  NTIA minimum elements: SBOM author, timestamp, id
+===================  ==  =====================================================
+
+The split is 65 points of generic SBOM minimum elements, 25 of AI-specific
+description, and 10 of VEX. A complete but generic SBOM tops out around 65, so
+an A is only reachable with the AI metadata actually filled in.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+_ML_COMPONENT_TYPE = "machine-learning-model"
+
+# The property #111 routes a Hugging Face card's declared license to. It is
+# deliberately not merged into `licenses[]` there, because that field drives a
+# compliance *judgement* (the platform's license_issue_count, the CLI's LEGAL
+# RISK verdict) and backfilling it from HF metadata would silently change one.
+# The license is nonetheless genuinely declared, so this dimension credits it
+# and names where it came from — otherwise the grade would punish users for an
+# architectural decision they cannot influence.
+_HF_LICENSE_PROPERTY = "aisbom:hf:license"
+
+# Placeholder versions that carry no more information than an absent field.
+# `aisbom scan` emitted the literal string "unknown" for requirements.txt pins
+# with no version until #114; other tools emit their own variants.
+_PLACEHOLDER_VERSIONS = frozenset({"", "unknown", "none", "n/a", "noassertion", "*"})
+
+# Grade bands, calibrated against real AIsbom output rather than the academic
+# 90/80/70/60 scale: a local scan of an unlabelled model tree measures ~50 and
+# an `hf://` scan ~53, both of which are genuinely mediocre AIBOMs but not
+# failures. On an academic scale every document AIsbom produces would be an F,
+# which reads as a miscalibrated grader rather than as actionable feedback.
+GRADE_BANDS: Tuple[Tuple[float, str], ...] = (
+    (85.0, "A"),
+    (70.0, "B"),
+    (55.0, "C"),
+    (40.0, "D"),
+    (0.0, "F"),
+)
+
+
+class ScoreInputError(Exception):
+    """The input could not be read, or is not a CycloneDX document."""
+
+
+@dataclass(frozen=True)
+class Dimension:
+    key: str
+    label: str
+    weight: int
+    description: str
+
+
+DIMENSIONS: Tuple[Dimension, ...] = (
+    Dimension("identity", "Component identity", 20,
+              "Every component carries a name, a stable bom-ref and a real version"),
+    Dimension("checksums", "Checksums", 20,
+              "Every model component carries a SHA-256 digest"),
+    Dimension("licenses", "Licenses", 15,
+              "Every component declares a license"),
+    Dimension("modelcard", "Model-card coverage", 15,
+              "Every model component describes its task and architecture"),
+    Dimension("datasets", "Dataset provenance", 10,
+              "Every model component names its training datasets"),
+    Dimension("vex", "VEX presence", 10,
+              "Exploitability statements accompany the inventory"),
+    Dimension("docprov", "Document provenance", 10,
+              "The document names its author, timestamp and identity"),
+)
+
+_BY_KEY = {d.key: d for d in DIMENSIONS}
+
+
+@dataclass
+class DimensionScore:
+    key: str
+    label: str
+    weight: int
+    score: float
+    gaps: List[str] = field(default_factory=list)
+    # One action that closes this dimension, or None when there is nothing the
+    # user can do. Kept separate from `gaps` so the per-component list stays
+    # terse: repeating the same remedy on every affected component is what
+    # turns a 50-model scan's output into 150 lines nobody reads.
+    remediation: Optional[str] = None
+    summary: Optional[str] = None
+
+    @property
+    def points_recoverable(self) -> float:
+        """Points this dimension would add if it were brought to 100."""
+        return self.weight * (100.0 - self.score) / 100.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "key": self.key,
+            "label": self.label,
+            "weight": self.weight,
+            "score": round(self.score, 1),
+            "pointsRecoverable": round(self.points_recoverable, 1),
+            "summary": self.summary,
+            "remediation": self.remediation,
+            "gaps": list(self.gaps),
+        }
+
+
+@dataclass
+class ScoreReport:
+    overall: float
+    grade: str
+    dimensions: List[DimensionScore]
+    component_count: int
+    model_count: int
+    spec_version: Optional[str] = None
+
+    @property
+    def potential(self) -> float:
+        """What this document would score with every gap closed."""
+        return min(100.0, self.overall + sum(
+            d.points_recoverable for d in self.dimensions
+        ))
+
+    def improvement_plan(self) -> List[DimensionScore]:
+        """Incomplete dimensions, richest first.
+
+        Ordering by points recoverable rather than by dimension is the whole
+        point: a one-flag VEX fix is worth ten points and a missing version
+        string is worth under one, and a list sorted by dimension gives them
+        the same weight.
+        """
+        return sorted(
+            (d for d in self.dimensions if d.points_recoverable > 0.05),
+            key=lambda d: d.points_recoverable,
+            reverse=True,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "overall": round(self.overall, 1),
+            "potential": round(self.potential, 1),
+            "grade": self.grade,
+            "specVersion": self.spec_version,
+            "components": self.component_count,
+            "models": self.model_count,
+            "dimensions": [d.to_dict() for d in self.dimensions],
+        }
+
+
+def grade_for(overall: float) -> str:
+    """Map a 0-100 score onto a letter grade."""
+    for threshold, letter in GRADE_BANDS:
+        if overall >= threshold:
+            return letter
+    return "F"
+
+
+# ---------------------------------------------------------------------------
+# Input handling
+# ---------------------------------------------------------------------------
+
+def load_sbom(path: Path) -> Dict[str, Any]:
+    """Read a CycloneDX JSON document, or explain why it cannot be scored.
+
+    SPDX is rejected rather than partially scored. Its 2.3 form has no
+    structured home for model-card or dataset metadata at all — AIsbom writes
+    that into a free-text `comment` — so scoring it would mean either parsing
+    prose or grading it on a smaller denominator, and a grade computed on a
+    different denominator is not comparable with a CycloneDX one.
+    """
+    try:
+        raw = path.read_text()
+    except OSError as exc:
+        raise ScoreInputError(f"Could not read {path}: {exc}") from exc
+
+    try:
+        doc = json.loads(raw)
+    except ValueError as exc:
+        raise ScoreInputError(f"{path} is not valid JSON: {exc}") from exc
+
+    if not isinstance(doc, dict):
+        raise ScoreInputError(f"{path} does not contain a JSON object.")
+
+    if "spdxVersion" in doc or "@graph" in doc:
+        raise ScoreInputError(
+            f"{path} is an SPDX document. `aisbom score` grades CycloneDX only — "
+            "SPDX scoring is tracked as a follow-up."
+        )
+
+    if doc.get("bomFormat") != "CycloneDX" and "specVersion" not in doc:
+        raise ScoreInputError(
+            f"{path} is not a CycloneDX document (no bomFormat/specVersion)."
+        )
+
+    return doc
+
+
+def vex_paths_for(sbom_path: Path) -> List[Path]:
+    """The VEX filenames `aisbom scan --vex` would have written next to this SBOM.
+
+    Mirrors ``cli._vex_paths`` so a plain ``scan --vex`` followed by ``score``
+    finds the documents with no extra flags. Requiring an explicit path would
+    make the happy path silently lose the dimension's ten points, which reads
+    as a bug rather than as a policy.
+    """
+    name = sbom_path.name
+    stem = name[: -len(".json")] if name.endswith(".json") else name
+    return [
+        sbom_path.with_name(f"{stem}.openvex.json"),
+        sbom_path.with_name(f"{stem}.vex.cdx.json"),
+    ]
+
+
+def discover_vex(sbom_path: Optional[Path]) -> List[Path]:
+    """Sibling VEX documents that actually exist on disk."""
+    if sbom_path is None:
+        return []
+    return [p for p in vex_paths_for(sbom_path) if p.is_file()]
+
+
+def _vex_statement_count(path: Path) -> int:
+    """How many statements a VEX document carries, or 0 if it is unreadable.
+
+    An unreadable or empty VEX file scores as absent rather than raising: the
+    dimension asks whether exploitability was stated, and a file that states
+    nothing has not stated it.
+    """
+    try:
+        doc = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return 0
+    if not isinstance(doc, dict):
+        return 0
+    for key in ("statements", "vulnerabilities"):
+        value = doc.get(key)
+        if isinstance(value, list):
+            return len(value)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Per-dimension scoring
+# ---------------------------------------------------------------------------
+
+def _pct(numerator: float, denominator: float) -> float:
+    return 0.0 if denominator == 0 else 100.0 * numerator / denominator
+
+
+def _components(doc: Dict[str, Any]) -> List[Dict[str, Any]]:
+    comps = doc.get("components")
+    if not isinstance(comps, list):
+        return []
+    return [c for c in comps if isinstance(c, dict)]
+
+
+def _is_model(component: Dict[str, Any]) -> bool:
+    return component.get("type") == _ML_COMPONENT_TYPE
+
+
+def _name_of(component: Dict[str, Any]) -> str:
+    return str(component.get("name") or "<unnamed component>")
+
+
+def _model_parameters(component: Dict[str, Any]) -> Dict[str, Any]:
+    card = component.get("modelCard")
+    if not isinstance(card, dict):
+        return {}
+    params = card.get("modelParameters")
+    return params if isinstance(params, dict) else {}
+
+
+def _card_properties(component: Dict[str, Any]) -> List[Dict[str, Any]]:
+    card = component.get("modelCard")
+    if not isinstance(card, dict):
+        return []
+    props = card.get("properties")
+    if not isinstance(props, list):
+        return []
+    return [p for p in props if isinstance(p, dict)]
+
+
+def _score_identity(doc: Dict[str, Any], comps: List[Dict[str, Any]]) -> DimensionScore:
+    gaps: List[str] = []
+    if not comps:
+        return DimensionScore(
+            "identity", _BY_KEY["identity"].label, 20, 0.0,
+            gaps=["The document declares no components at all."],
+            summary="no components",
+        )
+
+    earned = 0.0
+    for c in comps:
+        checks = [bool(c.get("name")), bool(c.get("bom-ref")), bool(c.get("type"))]
+        missing = []
+        if not c.get("name"):
+            missing.append("name")
+        if not c.get("bom-ref"):
+            missing.append("bom-ref")
+        if not c.get("type"):
+            missing.append("type")
+
+        # A version is only meaningful for things that are versioned. A model
+        # *file* has a digest, not a release number, so demanding one would
+        # deduct from every local scan for a field that has nothing to hold.
+        if not _is_model(c):
+            version = str(c.get("version") or "").strip().lower()
+            has_version = version not in _PLACEHOLDER_VERSIONS
+            checks.append(has_version)
+            if not has_version:
+                missing.append("version")
+
+        earned += sum(1 for ok in checks if ok) / len(checks)
+        if missing:
+            gaps.append(f"{_name_of(c)}: missing {', '.join(missing)}")
+
+    return DimensionScore(
+        "identity", _BY_KEY["identity"].label, 20, _pct(earned, len(comps)), gaps,
+        remediation=(
+            "Pin each component listed under --verbose to a real version "
+            "in requirements.txt"
+        ) if gaps else None,
+        summary=(f"{len(gaps)} component(s) incompletely identified"
+                 if gaps else None),
+    )
+
+
+def _score_checksums(models: List[Dict[str, Any]]) -> DimensionScore:
+    label = _BY_KEY["checksums"].label
+    if not models:
+        return DimensionScore(
+            "checksums", label, 20, 0.0,
+            gaps=["No machine-learning-model components — this is a dependency "
+                  "SBOM, not an AIBOM."],
+            summary="no model components to checksum",
+        )
+
+    gaps: List[str] = []
+    hashed = 0
+    for c in models:
+        hashes = c.get("hashes")
+        digests = [h for h in hashes if isinstance(h, dict) and h.get("content")] \
+            if isinstance(hashes, list) else []
+        if digests:
+            hashed += 1
+        else:
+            gaps.append(f"{_name_of(c)}: no checksum")
+
+    missing = len(models) - hashed
+    return DimensionScore(
+        "checksums", label, 20, _pct(hashed, len(models)), gaps,
+        # Naming the cause matters: a remote scan streams byte ranges and never
+        # reads a whole file, so there is no digest to emit. The fix is to scan
+        # a local copy, not to file a bug against the scanner.
+        remediation=(
+            "aisbom scan <local-path>  — remote scans stream byte ranges and "
+            "never read a whole file, so they cannot produce digests"
+        ) if missing else None,
+        summary=(f"{missing} of {len(models)} model(s) carry no digest"
+                 if missing else None),
+    )
+
+
+def _score_licenses(comps: List[Dict[str, Any]]) -> DimensionScore:
+    label = _BY_KEY["licenses"].label
+    if not comps:
+        return DimensionScore("licenses", label, 15, 0.0,
+                              ["The document declares no components at all."])
+
+    gaps: List[str] = []
+    licensed = 0
+    for c in comps:
+        licenses = c.get("licenses")
+        if isinstance(licenses, list) and licenses:
+            licensed += 1
+            continue
+        hf_license = next(
+            (p.get("value") for p in _card_properties(c)
+             if p.get("name") == _HF_LICENSE_PROPERTY and p.get("value")),
+            None,
+        )
+        if hf_license:
+            licensed += 1
+            gaps.append(
+                f"{_name_of(c)}: license '{hf_license}' declared via "
+                f"{_HF_LICENSE_PROPERTY} rather than licenses[] "
+                "(credited — third-party tools reading only licenses[] will miss it)"
+            )
+            continue
+        gaps.append(f"{_name_of(c)}: no license declared")
+
+    missing = len(comps) - licensed
+    return DimensionScore(
+        "licenses", label, 15, _pct(licensed, len(comps)), gaps,
+        remediation=(
+            "Declare a license on each component listed under --verbose — "
+            "dependency licenses are not yet resolved automatically"
+        ) if missing else None,
+        summary=(f"{missing} of {len(comps)} component(s) declare no license"
+                 if missing else None),
+    )
+
+
+def _score_modelcard(models: List[Dict[str, Any]]) -> DimensionScore:
+    label = _BY_KEY["modelcard"].label
+    if not models:
+        return DimensionScore(
+            "modelcard", label, 15, 0.0,
+            gaps=["No machine-learning-model components to describe."],
+            summary="no model components to describe",
+        )
+
+    gaps: List[str] = []
+    described = 0
+    for c in models:
+        params = _model_parameters(c)
+        if any(params.get(k) for k in ("task", "architectureFamily", "modelArchitecture")):
+            described += 1
+        else:
+            gaps.append(f"{_name_of(c)}: no modelCard task/architecture")
+
+    missing = len(models) - described
+    return DimensionScore(
+        "modelcard", label, 15, _pct(described, len(models)), gaps,
+        remediation=(
+            "aisbom scan hf://<org>/<model>  — task and architecture are read "
+            "from the Hugging Face model card"
+        ) if missing else None,
+        summary=(f"{missing} of {len(models)} model(s) declare no task or "
+                 f"architecture" if missing else None),
+    )
+
+
+def _score_datasets(models: List[Dict[str, Any]]) -> DimensionScore:
+    label = _BY_KEY["datasets"].label
+    if not models:
+        return DimensionScore(
+            "datasets", label, 10, 0.0,
+            gaps=["No machine-learning-model components to trace."],
+            summary="no model components to trace",
+        )
+
+    gaps: List[str] = []
+    traced = 0
+    for c in models:
+        datasets = _model_parameters(c).get("datasets")
+        if isinstance(datasets, list) and datasets:
+            traced += 1
+        else:
+            gaps.append(f"{_name_of(c)}: no training datasets named")
+
+    missing = len(models) - traced
+    return DimensionScore(
+        "datasets", label, 10, _pct(traced, len(models)), gaps,
+        remediation=(
+            "aisbom scan hf://<org>/<model>  — training datasets come from the "
+            "model card's `datasets` field"
+        ) if missing else None,
+        summary=(f"{missing} of {len(models)} model(s) name no training data"
+                 if missing else None),
+    )
+
+
+def _score_vex(doc: Dict[str, Any], vex_documents: Sequence[Path]) -> DimensionScore:
+    label = _BY_KEY["vex"].label
+
+    inline = doc.get("vulnerabilities")
+    if isinstance(inline, list) and inline:
+        return DimensionScore("vex", label, 10, 100.0, [])
+
+    for path in vex_documents:
+        if _vex_statement_count(path) > 0:
+            return DimensionScore("vex", label, 10, 100.0, [])
+
+    return DimensionScore(
+        "vex", label, 10, 0.0,
+        gaps=["No VEX statements accompany this SBOM."],
+        remediation=(
+            "aisbom scan . --vex --output sbom.json  — states whether each "
+            "finding is actually exploitable"
+        ),
+        summary="no exploitability statements",
+    )
+
+
+def _score_docprov(doc: Dict[str, Any]) -> DimensionScore:
+    label = _BY_KEY["docprov"].label
+    metadata = doc.get("metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+
+    checks = {
+        "metadata.tools (which tool produced this SBOM)": bool(metadata.get("tools")),
+        "metadata.timestamp (when it was produced)": bool(metadata.get("timestamp")),
+        "serialNumber (a stable document identity)": bool(doc.get("serialNumber")),
+        "specVersion (which CycloneDX version)": bool(doc.get("specVersion")),
+    }
+    gaps = [f"missing {name}" for name, ok in checks.items() if not ok]
+    return DimensionScore(
+        "docprov", label, 10, _pct(sum(checks.values()), len(checks)), gaps,
+        remediation=(
+            "Regenerate with a current aisbom — `metadata.tools`, timestamp and "
+            "serial number are emitted automatically"
+        ) if gaps else None,
+        summary=(f"{len(gaps)} document-level field(s) absent" if gaps else None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def score_sbom(
+    doc: Dict[str, Any],
+    *,
+    vex_documents: Optional[Sequence[Path]] = None,
+) -> ScoreReport:
+    """Grade a parsed CycloneDX document across all seven dimensions."""
+    comps = _components(doc)
+    models = [c for c in comps if _is_model(c)]
+    vex_documents = vex_documents or []
+
+    dimensions = [
+        _score_identity(doc, comps),
+        _score_checksums(models),
+        _score_licenses(comps),
+        _score_modelcard(models),
+        _score_datasets(models),
+        _score_vex(doc, vex_documents),
+        _score_docprov(doc),
+    ]
+
+    overall = sum(d.score * d.weight for d in dimensions) / 100.0
+    spec_version = doc.get("specVersion")
+    return ScoreReport(
+        overall=overall,
+        grade=grade_for(overall),
+        dimensions=dimensions,
+        component_count=len(comps),
+        model_count=len(models),
+        spec_version=spec_version if isinstance(spec_version, str) else None,
+    )

--- a/aisbom/score.py
+++ b/aisbom/score.py
@@ -38,6 +38,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+from .spdx_gen import _sha256_or_none
+
 _ML_COMPONENT_TYPE = "machine-learning-model"
 
 # The property #111 routes a Hugging Face card's declared license to. It is
@@ -214,10 +216,14 @@ def load_sbom(path: Path) -> Dict[str, Any]:
             "SPDX scoring is tracked as a follow-up."
         )
 
-    if doc.get("bomFormat") != "CycloneDX" and "specVersion" not in doc:
-        raise ScoreInputError(
-            f"{path} is not a CycloneDX document (no bomFormat/specVersion)."
-        )
+    # `bomFormat` is required by the CycloneDX spec and is the only field that
+    # actually identifies the format. Accepting a bare `specVersion` let any
+    # unrelated JSON object carrying that key be graded and exit 0, despite the
+    # command documenting exit 1 for non-CycloneDX input.
+    if doc.get("bomFormat") != "CycloneDX":
+        declared = doc.get("bomFormat")
+        detail = f"declares bomFormat {declared!r}" if declared else "has no bomFormat"
+        raise ScoreInputError(f"{path} is not a CycloneDX document — it {detail}.")
 
     return doc
 
@@ -245,24 +251,73 @@ def discover_vex(sbom_path: Optional[Path]) -> List[Path]:
     return [p for p in vex_paths_for(sbom_path) if p.is_file()]
 
 
-def _vex_statement_count(path: Path) -> int:
-    """How many statements a VEX document carries, or 0 if it is unreadable.
+def _has_analysed_vulnerabilities(doc: Dict[str, Any]) -> bool:
+    """Whether a CycloneDX document states exploitability, not merely presence.
 
-    An unreadable or empty VEX file scores as absent rather than raising: the
+    A `vulnerabilities` array is an inventory: it can carry an id, ratings and
+    affected components without ever saying whether the product is actually
+    exploitable. VEX *is* the analysis, so only entries carrying an
+    `analysis.state` satisfy the dimension — otherwise ordinary vulnerability
+    data would be mislabelled as VEX and awarded the full ten points.
+    """
+    entries = doc.get("vulnerabilities")
+    if not isinstance(entries, list):
+        return False
+    return any(
+        isinstance(e, dict)
+        and isinstance(e.get("analysis"), dict)
+        and e["analysis"].get("state")
+        for e in entries
+    )
+
+
+def _vex_describes(path: Path, serial: Optional[str]) -> bool:
+    """Whether a VEX document makes statements about *this* SBOM.
+
+    Both formats bind to the SBOM's serial number — a CycloneDX VEX carries it
+    as its own `serialNumber`, and OpenVEX embeds it in every product `@id`
+    (`<serial>#<bom-ref>`, see `vex._product_id`). Checking that binding
+    matters because the sibling filenames are stable: an SBOM regenerated
+    *without* `--vex` leaves the previous run's VEX files sitting next to it,
+    and crediting those would award ten points for statements about a document
+    that no longer exists.
+
+    An unreadable or empty document scores as absent rather than raising — the
     dimension asks whether exploitability was stated, and a file that states
     nothing has not stated it.
     """
+    # Without a serial there is nothing to bind the statements to, so the claim
+    # that they describe this document cannot be checked. `docprov` already
+    # deducts for the missing serial; this declines to compound a guess on top.
+    if not serial:
+        return False
+
     try:
         doc = json.loads(path.read_text())
     except (OSError, ValueError):
-        return 0
+        return False
     if not isinstance(doc, dict):
-        return 0
-    for key in ("statements", "vulnerabilities"):
-        value = doc.get(key)
-        if isinstance(value, list):
-            return len(value)
-    return 0
+        return False
+
+    # CycloneDX VEX: same serial number as the document it describes.
+    if doc.get("serialNumber") == serial:
+        return _has_analysed_vulnerabilities(doc)
+
+    # OpenVEX: statements whose products address components inside this SBOM.
+    statements = doc.get("statements")
+    if not isinstance(statements, list):
+        return False
+    for statement in statements:
+        if not isinstance(statement, dict) or not statement.get("status"):
+            continue
+        products = statement.get("products")
+        if not isinstance(products, list):
+            continue
+        for product in products:
+            if isinstance(product, dict) and \
+                    str(product.get("@id") or "").startswith(f"{serial}#"):
+                return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -351,6 +406,27 @@ def _score_identity(doc: Dict[str, Any], comps: List[Dict[str, Any]]) -> Dimensi
     )
 
 
+def _has_sha256(component: Dict[str, Any]) -> bool:
+    """Whether a component carries a genuine SHA-256 digest.
+
+    The dimension is defined as SHA-256, so an MD5 or SHA-1 entry does not
+    satisfy it — counting any non-empty `content` would award the full twenty
+    points for a weaker digest than the one being asked for. The digest itself
+    is shape-checked with the same predicate `spdx_gen` uses, so a sentinel or
+    a truncated value cannot pass either.
+    """
+    hashes = component.get("hashes")
+    if not isinstance(hashes, list):
+        return False
+    for entry in hashes:
+        if not isinstance(entry, dict):
+            continue
+        alg = str(entry.get("alg") or "").upper().replace("_", "-")
+        if alg in ("SHA-256", "SHA256") and _sha256_or_none(entry.get("content")):
+            return True
+    return False
+
+
 def _score_checksums(models: List[Dict[str, Any]]) -> DimensionScore:
     label = _BY_KEY["checksums"].label
     if not models:
@@ -364,10 +440,7 @@ def _score_checksums(models: List[Dict[str, Any]]) -> DimensionScore:
     gaps: List[str] = []
     hashed = 0
     for c in models:
-        hashes = c.get("hashes")
-        digests = [h for h in hashes if isinstance(h, dict) and h.get("content")] \
-            if isinstance(hashes, list) else []
-        if digests:
+        if _has_sha256(c):
             hashed += 1
         else:
             gaps.append(f"{_name_of(c)}: no checksum")
@@ -490,12 +563,12 @@ def _score_datasets(models: List[Dict[str, Any]]) -> DimensionScore:
 def _score_vex(doc: Dict[str, Any], vex_documents: Sequence[Path]) -> DimensionScore:
     label = _BY_KEY["vex"].label
 
-    inline = doc.get("vulnerabilities")
-    if isinstance(inline, list) and inline:
+    if _has_analysed_vulnerabilities(doc):
         return DimensionScore("vex", label, 10, 100.0, [])
 
+    serial = doc.get("serialNumber")
     for path in vex_documents:
-        if _vex_statement_count(path) > 0:
+        if _vex_describes(path, serial if isinstance(serial, str) else None):
             return DimensionScore("vex", label, 10, 100.0, [])
 
     return DimensionScore(

--- a/tests/test_cyclonedx_gen.py
+++ b/tests/test_cyclonedx_gen.py
@@ -1,0 +1,194 @@
+"""Tests for the extracted CycloneDX builder (#114).
+
+`build_cyclonedx_json` was lifted out of `cli.scan` so `aisbom score` can grade
+a scan target without duplicating document construction. These tests pin the
+two deliberate output changes made at the same time, and assert that nothing
+else about the document moved.
+"""
+
+import json
+
+import pytest
+
+from aisbom.cyclonedx_gen import build_cyclonedx_json
+
+
+def _results(**overrides):
+    results = {
+        "artifacts": [
+            {
+                "name": "model.safetensors",
+                "risk_level": "LOW",
+                "framework": "SafeTensors",
+                "legal_status": "OK",
+                "license": "Apache-2.0",
+                "hash": "a" * 64,
+            },
+        ],
+        "dependencies": [
+            {"name": "torch", "version": "2.10.0"},
+            {"name": "numpy", "version": "unknown"},
+        ],
+        "errors": [],
+    }
+    results.update(overrides)
+    return results
+
+
+def _doc(**overrides):
+    return json.loads(build_cyclonedx_json(_results(**overrides)))
+
+
+def _by_name(doc, name):
+    return next(c for c in doc["components"] if c["name"] == name)
+
+
+# ---------------------------------------------------------------------------
+# The two deliberate output changes.
+# ---------------------------------------------------------------------------
+
+def test_metadata_tools_identifies_aisbom():
+    """An SBOM that does not say what produced it fails the NTIA minimum
+    elements — and AIsbom's own completeness grade."""
+    tools = _doc()["metadata"]["tools"]
+    names = [c["name"] for c in tools["components"]]
+    assert "aisbom-cli" in names
+
+
+def test_placeholder_version_is_omitted_not_emitted():
+    """`version: "unknown"` carried no information and cost grade points."""
+    assert "version" not in _by_name(_doc(), "numpy")
+
+
+def test_real_dependency_versions_are_preserved():
+    assert _by_name(_doc(), "torch")["version"] == "2.10.0"
+
+
+def test_dropping_the_placeholder_causes_no_diff_drift(tmp_path):
+    """The upgrade hazard this change had to clear.
+
+    Every existing user holds baseline SBOMs carrying `version: "unknown"`. If
+    dropping the placeholder registered as a version change, the first `aisbom
+    diff` after upgrading would report phantom drift on every dependency.
+    `SBOMDiff` reads `component.get("version", "unknown")`, so absent and the
+    literal string compare equal — asserted here against the real differ rather
+    than trusted from reading the source.
+    """
+    from aisbom.diff import SBOMDiff
+
+    old_doc = _doc()
+    for component in old_doc["components"]:
+        if component["name"] == "numpy":
+            component["version"] = "unknown"      # the pre-#114 shape
+    new_doc = _doc()                              # the post-#114 shape
+
+    old_path = tmp_path / "old.json"
+    new_path = tmp_path / "new.json"
+    old_path.write_text(json.dumps(old_doc))
+    new_path.write_text(json.dumps(new_doc))
+
+    result = SBOMDiff(old_path, new_path).compare()
+    assert not result.changed
+    assert not result.added and not result.removed
+
+
+def test_a_genuine_version_change_is_still_detected(tmp_path):
+    """Guards the test above from passing vacuously: the differ must be live
+    enough to notice a version change that is real."""
+    from aisbom.diff import SBOMDiff
+
+    old_doc = _doc()
+    for component in old_doc["components"]:
+        if component["name"] == "torch":
+            component["version"] = "2.9.0"
+    new_doc = _doc()                              # torch is 2.10.0
+
+    old_path = tmp_path / "old.json"
+    new_path = tmp_path / "new.json"
+    old_path.write_text(json.dumps(old_doc))
+    new_path.write_text(json.dumps(new_doc))
+
+    result = SBOMDiff(old_path, new_path).compare()
+    assert [(c.name, c.version_diff) for c in result.changed] == \
+        [("torch", ("2.9.0", "2.10.0"))]
+
+
+# ---------------------------------------------------------------------------
+# Everything else about the document is unchanged.
+# ---------------------------------------------------------------------------
+
+def test_model_components_keep_their_stable_bom_ref():
+    assert _by_name(_doc(), "model.safetensors")["bom-ref"] == \
+        "artifact-0-model.safetensors"
+
+
+def test_description_string_is_unchanged():
+    desc = _by_name(_doc(), "model.safetensors")["description"]
+    assert desc == ("Risk: LOW | Framework: SafeTensors | Legal: OK | "
+                    "License: Apache-2.0")
+
+
+def test_sha256_is_emitted_when_present():
+    hashes = _by_name(_doc(), "model.safetensors")["hashes"]
+    assert hashes[0]["alg"] == "SHA-256"
+    assert hashes[0]["content"] == "a" * 64
+
+
+@pytest.mark.parametrize("sentinel", ["remote_unhashed", "hash_error"])
+def test_scanner_sentinels_are_never_emitted_as_digests(sentinel):
+    """The bug #111 fixed: a sentinel shipped inside a SHA-256 entry made every
+    remote SBOM fail CycloneDX validation."""
+    results = _results()
+    results["artifacts"][0]["hash"] = sentinel
+    doc = json.loads(build_cyclonedx_json(results))
+    assert "hashes" not in _by_name(doc, "model.safetensors")
+
+
+def test_licenses_are_emitted_when_known():
+    assert _by_name(_doc(), "model.safetensors")["licenses"]
+
+
+def test_unknown_license_produces_no_licenses_entry():
+    results = _results()
+    results["artifacts"][0]["license"] = "Unknown"
+    doc = json.loads(build_cyclonedx_json(results))
+    assert "licenses" not in _by_name(doc, "model.safetensors")
+
+
+def test_aisbom_properties_are_attached():
+    props = _by_name(_doc(), "model.safetensors").get("properties", [])
+    assert any(p["name"].startswith("aisbom:") for p in props)
+
+
+# ---------------------------------------------------------------------------
+# Schema-version behaviour is untouched by the extraction.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("version", ["1.5", "1.6", "1.7"])
+def test_requested_schema_version_is_honoured(version):
+    doc = json.loads(build_cyclonedx_json(_results(), version))
+    assert doc["specVersion"] == version
+
+
+def test_model_card_is_spliced_into_17_only():
+    results = _results(hf_model_card={
+        "id": "org/model",
+        "cardData": {"license": "apache-2.0", "datasets": ["bookcorpus"]},
+        "pipeline_tag": "fill-mask",
+    })
+    at_17 = json.loads(build_cyclonedx_json(results, "1.7"))
+    at_16 = json.loads(build_cyclonedx_json(results, "1.6"))
+    assert "modelCard" in _by_name(at_17, "model.safetensors")
+    assert "modelCard" not in _by_name(at_16, "model.safetensors")
+
+
+def test_libraries_never_receive_a_model_card():
+    results = _results(hf_model_card={"id": "org/model", "pipeline_tag": "fill-mask"})
+    doc = json.loads(build_cyclonedx_json(results, "1.7"))
+    assert "modelCard" not in _by_name(doc, "torch")
+
+
+def test_an_empty_scan_still_produces_a_valid_document():
+    doc = json.loads(build_cyclonedx_json({"artifacts": [], "dependencies": []}))
+    assert doc["bomFormat"] == "CycloneDX"
+    assert doc["metadata"]["tools"]

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,0 +1,624 @@
+"""Tests for `aisbom score` — AIBOM completeness/quality grading (#114)."""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from aisbom import score
+from aisbom.cli import app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: three documents spanning the grade range.
+# ---------------------------------------------------------------------------
+
+def _minimal_sbom():
+    """The least a CycloneDX document can carry and still parse."""
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.7",
+        "components": [
+            {"type": "machine-learning-model", "name": "model.pt"},
+        ],
+    }
+
+
+def _partial_sbom():
+    """What a local `aisbom scan` actually produces today: hashes and identity,
+    no model card, no datasets, patchy licenses."""
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.7",
+        "serialNumber": "urn:uuid:11111111-1111-1111-1111-111111111111",
+        "metadata": {"timestamp": "2026-08-30T00:00:00+00:00"},
+        "components": [
+            {
+                "type": "machine-learning-model",
+                "name": "clean.safetensors",
+                "bom-ref": "artifact-0-clean.safetensors",
+                "hashes": [{"alg": "SHA-256", "content": "a" * 64}],
+                "licenses": [{"license": {"id": "Apache-2.0"}}],
+            },
+            {
+                "type": "machine-learning-model",
+                "name": "model.pt",
+                "bom-ref": "artifact-1-model.pt",
+                "hashes": [{"alg": "SHA-256", "content": "b" * 64}],
+            },
+            {
+                "type": "library",
+                "name": "torch",
+                "bom-ref": "lib-torch",
+                "version": "2.10.0",
+            },
+        ],
+    }
+
+
+def _complete_sbom():
+    """Everything a dimension can ask for, so the top of the scale is reachable."""
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.7",
+        "serialNumber": "urn:uuid:22222222-2222-2222-2222-222222222222",
+        "metadata": {
+            "timestamp": "2026-08-30T00:00:00+00:00",
+            "tools": {"components": [{"type": "application", "name": "aisbom-cli"}]},
+        },
+        "components": [
+            {
+                "type": "machine-learning-model",
+                "name": "bert.safetensors",
+                "bom-ref": "artifact-0-bert.safetensors",
+                "version": "main",
+                "hashes": [{"alg": "SHA-256", "content": "c" * 64}],
+                "licenses": [{"license": {"id": "Apache-2.0"}}],
+                "modelCard": {
+                    "modelParameters": {
+                        "task": "fill-mask",
+                        "architectureFamily": "bert",
+                        "datasets": [{"type": "dataset", "name": "bookcorpus"}],
+                    },
+                },
+            },
+            {
+                "type": "library",
+                "name": "torch",
+                "bom-ref": "lib-torch",
+                "version": "2.10.0",
+                "licenses": [{"license": {"id": "BSD-3-Clause"}}],
+            },
+        ],
+        "vulnerabilities": [
+            {"id": "aisbom-pickle-rce", "analysis": {"state": "not_affected"}}
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tracer bullet: the core API exists and grades the range.
+# ---------------------------------------------------------------------------
+
+def test_minimal_sbom_scores_low():
+    report = score.score_sbom(_minimal_sbom())
+    assert 0 <= report.overall <= 100
+    assert report.grade == "F"
+
+
+def test_complete_sbom_scores_high():
+    report = score.score_sbom(_complete_sbom())
+    assert report.grade == "A"
+
+
+def test_partial_sbom_lands_between_the_two():
+    minimal = score.score_sbom(_minimal_sbom()).overall
+    partial = score.score_sbom(_partial_sbom()).overall
+    complete = score.score_sbom(_complete_sbom()).overall
+    assert minimal < partial < complete
+
+
+# ---------------------------------------------------------------------------
+# The weighting scheme itself.
+# ---------------------------------------------------------------------------
+
+def test_weights_sum_to_100():
+    assert sum(d.weight for d in score.DIMENSIONS) == 100
+
+
+def test_every_dimension_is_reported():
+    report = score.score_sbom(_partial_sbom())
+    assert [d.key for d in report.dimensions] == [d.key for d in score.DIMENSIONS]
+
+
+def test_overall_is_the_weighted_mean_of_the_dimensions():
+    report = score.score_sbom(_partial_sbom())
+    expected = sum(d.score * d.weight for d in report.dimensions) / 100.0
+    assert report.overall == pytest.approx(expected, abs=0.05)
+
+
+@pytest.mark.parametrize(
+    "overall,grade",
+    [(100, "A"), (85, "A"), (84.9, "B"), (70, "B"), (69.9, "C"),
+     (55, "C"), (54.9, "D"), (40, "D"), (39.9, "F"), (0, "F")],
+)
+def test_grade_bands(overall, grade):
+    assert score.grade_for(overall) == grade
+
+
+# ---------------------------------------------------------------------------
+# Per-dimension behaviour.
+# ---------------------------------------------------------------------------
+
+def _dim(report, key):
+    return next(d for d in report.dimensions if d.key == key)
+
+
+def test_placeholder_version_earns_no_identity_credit():
+    """`version: "unknown"` carries no more information than an absent field."""
+    doc = _minimal_sbom()
+    doc["components"] = [
+        {"type": "library", "name": "numpy", "bom-ref": "r", "version": "unknown"},
+    ]
+    real = _minimal_sbom()
+    real["components"] = [
+        {"type": "library", "name": "numpy", "bom-ref": "r", "version": "2.1.0"},
+    ]
+    assert _dim(score.score_sbom(doc), "identity").score < \
+        _dim(score.score_sbom(real), "identity").score
+
+
+def test_model_components_are_not_penalised_for_having_no_version():
+    """A model file has a digest, not a release number."""
+    doc = _minimal_sbom()
+    doc["components"] = [
+        {"type": "machine-learning-model", "name": "m.pt", "bom-ref": "r"},
+    ]
+    assert _dim(score.score_sbom(doc), "identity").score == 100.0
+
+
+def test_hf_license_property_is_credited_and_named():
+    """#111 routes HF licenses to a property, not licenses[] — crediting it
+    stops the grade punishing users for a decision they cannot influence."""
+    doc = _minimal_sbom()
+    doc["components"] = [{
+        "type": "machine-learning-model",
+        "name": "bert.safetensors",
+        "bom-ref": "r",
+        "modelCard": {"properties": [
+            {"name": "aisbom:hf:license", "value": "apache-2.0"},
+        ]},
+    }]
+    dim = _dim(score.score_sbom(doc), "licenses")
+    assert dim.score == 100.0
+    assert any("aisbom:hf:license" in g and "apache-2.0" in g for g in dim.gaps)
+
+
+def test_a_component_with_no_license_anywhere_scores_zero():
+    doc = _minimal_sbom()
+    dim = _dim(score.score_sbom(doc), "licenses")
+    assert dim.score == 0.0
+    assert any("no license declared" in g for g in dim.gaps)
+
+
+def test_checksum_remediation_explains_the_remote_scan_cause():
+    """The cause lives on the dimension, not repeated on every component."""
+    dim = _dim(score.score_sbom(_minimal_sbom()), "checksums")
+    assert dim.score == 0.0
+    assert "remote scans" in dim.remediation
+    assert all("remote scans" not in g for g in dim.gaps)
+
+
+def test_empty_hash_entry_is_not_a_checksum():
+    doc = _minimal_sbom()
+    doc["components"][0]["hashes"] = [{"alg": "SHA-256"}]
+    assert _dim(score.score_sbom(doc), "checksums").score == 0.0
+
+
+def test_dependency_only_sbom_fails_the_ai_dimensions():
+    """An SBOM with no models is not an AIBOM, and says so rather than
+    collecting free points on dimensions it never had to satisfy."""
+    doc = _minimal_sbom()
+    doc["components"] = [
+        {"type": "library", "name": "torch", "bom-ref": "r", "version": "2.10.0"},
+    ]
+    report = score.score_sbom(doc)
+    for key in ("checksums", "modelcard", "datasets"):
+        assert _dim(report, key).score == 0.0
+    assert any("not an AIBOM" in g for g in _dim(report, "checksums").gaps)
+
+
+@pytest.mark.parametrize("params,expected", [
+    ({"task": "fill-mask"}, 100.0),
+    ({"architectureFamily": "bert"}, 100.0),
+    ({"modelArchitecture": "BertForMaskedLM"}, 100.0),
+    ({"datasets": [{"name": "x"}]}, 0.0),
+    ({}, 0.0),
+])
+def test_modelcard_needs_task_or_architecture(params, expected):
+    doc = _minimal_sbom()
+    doc["components"][0]["modelCard"] = {"modelParameters": params}
+    assert _dim(score.score_sbom(doc), "modelcard").score == expected
+
+
+def test_datasets_dimension_reads_model_parameters():
+    doc = _minimal_sbom()
+    doc["components"][0]["modelCard"] = {
+        "modelParameters": {"datasets": [{"type": "dataset", "name": "bookcorpus"}]}
+    }
+    assert _dim(score.score_sbom(doc), "datasets").score == 100.0
+
+
+def test_document_provenance_names_each_missing_field():
+    dim = _dim(score.score_sbom(_minimal_sbom()), "docprov")
+    assert dim.score == 25.0  # specVersion only
+    joined = " ".join(dim.gaps)
+    assert "metadata.tools" in joined and "serialNumber" in joined
+
+
+def test_malformed_components_are_ignored_not_fatal():
+    doc = _minimal_sbom()
+    doc["components"] = ["not a dict", None, {"type": "library", "name": "ok",
+                                              "bom-ref": "r", "version": "1.0"}]
+    report = score.score_sbom(doc)
+    assert report.component_count == 1
+
+
+def test_empty_document_scores_zero_without_raising():
+    report = score.score_sbom({"bomFormat": "CycloneDX"})
+    assert report.overall == 0.0
+    assert report.grade == "F"
+
+
+# ---------------------------------------------------------------------------
+# The improvement plan.
+# ---------------------------------------------------------------------------
+
+def test_improvement_plan_is_ranked_by_points_recoverable():
+    """The ordering is the feature: a one-flag ten-point fix must outrank a
+    sub-point missing version string."""
+    plan = score.score_sbom(_partial_sbom()).improvement_plan()
+    points = [d.points_recoverable for d in plan]
+    assert points == sorted(points, reverse=True)
+
+
+def test_improvement_plan_omits_complete_dimensions():
+    plan = score.score_sbom(_complete_sbom()).improvement_plan()
+    assert plan == []
+
+
+def test_points_recoverable_is_the_dimension_shortfall():
+    dim = _dim(score.score_sbom(_minimal_sbom()), "vex")
+    assert dim.score == 0.0
+    assert dim.points_recoverable == 10.0  # the full weight
+
+
+def test_potential_is_what_closing_every_gap_would_score():
+    report = score.score_sbom(_partial_sbom())
+    assert report.potential == pytest.approx(
+        min(100.0, report.overall + sum(d.points_recoverable
+                                        for d in report.dimensions)), abs=0.05
+    )
+    assert report.potential > report.overall
+
+
+def test_a_complete_document_has_no_potential_left():
+    report = score.score_sbom(_complete_sbom())
+    assert report.potential == pytest.approx(report.overall, abs=0.05)
+
+
+def test_incomplete_dimensions_carry_a_remediation():
+    for dim in score.score_sbom(_partial_sbom()).improvement_plan():
+        assert dim.remediation, f"{dim.key} has no remediation"
+        assert dim.summary, f"{dim.key} has no summary"
+
+
+def test_complete_dimensions_carry_no_remediation():
+    for dim in score.score_sbom(_complete_sbom()).dimensions:
+        assert dim.remediation is None
+
+
+def test_vex_remediation_names_the_actual_flag():
+    dim = _dim(score.score_sbom(_minimal_sbom()), "vex")
+    assert "--vex" in dim.remediation
+
+
+def test_gaps_are_not_repeated_per_component_in_the_remediation():
+    """The wall-of-lines problem: one remedy per dimension, not per component."""
+    report = score.score_sbom(_partial_sbom())
+    dim = _dim(report, "modelcard")
+    assert len(dim.gaps) == 2          # both models
+    assert isinstance(dim.remediation, str)   # but only one remedy
+
+
+# ---------------------------------------------------------------------------
+# VEX discovery.
+# ---------------------------------------------------------------------------
+
+def test_inline_vulnerabilities_satisfy_the_vex_dimension():
+    doc = _minimal_sbom()
+    doc["vulnerabilities"] = [{"id": "x"}]
+    assert _dim(score.score_sbom(doc), "vex").score == 100.0
+
+
+def test_sibling_vex_filenames_match_what_scan_writes(tmp_path):
+    """Mirrors cli._vex_paths so `scan --vex` then `score` needs no flags."""
+    paths = score.vex_paths_for(tmp_path / "sbom.json")
+    assert [p.name for p in paths] == ["sbom.openvex.json", "sbom.vex.cdx.json"]
+
+
+def test_discover_vex_finds_only_files_that_exist(tmp_path):
+    sbom = tmp_path / "sbom.json"
+    sbom.write_text("{}")
+    assert score.discover_vex(sbom) == []
+    openvex = tmp_path / "sbom.openvex.json"
+    openvex.write_text(json.dumps({"statements": [{"vulnerability": {"name": "x"}}]}))
+    assert score.discover_vex(sbom) == [openvex]
+
+
+def test_a_discovered_vex_document_scores_the_dimension(tmp_path):
+    sbom = tmp_path / "sbom.json"
+    sbom.write_text("{}")
+    (tmp_path / "sbom.openvex.json").write_text(
+        json.dumps({"statements": [{"vulnerability": {"name": "x"}}]})
+    )
+    report = score.score_sbom(_minimal_sbom(), vex_documents=score.discover_vex(sbom))
+    assert _dim(report, "vex").score == 100.0
+
+
+def test_an_empty_or_unreadable_vex_document_does_not_score(tmp_path):
+    empty = tmp_path / "sbom.openvex.json"
+    empty.write_text(json.dumps({"statements": []}))
+    broken = tmp_path / "broken.json"
+    broken.write_text("{not json")
+    report = score.score_sbom(_minimal_sbom(), vex_documents=[empty, broken])
+    assert _dim(report, "vex").score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Input handling.
+# ---------------------------------------------------------------------------
+
+def test_load_sbom_reads_a_cyclonedx_document(tmp_path):
+    path = tmp_path / "sbom.json"
+    path.write_text(json.dumps(_complete_sbom()))
+    assert score.load_sbom(path)["specVersion"] == "1.7"
+
+
+def test_load_sbom_rejects_spdx_23_by_name(tmp_path):
+    path = tmp_path / "s.json"
+    path.write_text(json.dumps({"spdxVersion": "SPDX-2.3", "packages": []}))
+    with pytest.raises(score.ScoreInputError, match="SPDX"):
+        score.load_sbom(path)
+
+
+def test_load_sbom_rejects_spdx_30_jsonld(tmp_path):
+    path = tmp_path / "s.json"
+    path.write_text(json.dumps({"@context": "x", "@graph": []}))
+    with pytest.raises(score.ScoreInputError, match="SPDX"):
+        score.load_sbom(path)
+
+
+def test_load_sbom_rejects_unrelated_json(tmp_path):
+    path = tmp_path / "s.json"
+    path.write_text(json.dumps({"hello": "world"}))
+    with pytest.raises(score.ScoreInputError, match="not a CycloneDX"):
+        score.load_sbom(path)
+
+
+def test_load_sbom_rejects_malformed_json(tmp_path):
+    path = tmp_path / "s.json"
+    path.write_text("{not json")
+    with pytest.raises(score.ScoreInputError, match="not valid JSON"):
+        score.load_sbom(path)
+
+
+def test_load_sbom_rejects_a_missing_file(tmp_path):
+    with pytest.raises(score.ScoreInputError, match="Could not read"):
+        score.load_sbom(tmp_path / "nope.json")
+
+
+def test_report_to_dict_is_json_serializable():
+    payload = score.score_sbom(_complete_sbom()).to_dict()
+    assert json.loads(json.dumps(payload))["grade"] == "A"
+    assert {d["key"] for d in payload["dimensions"]} == {d.key for d in score.DIMENSIONS}
+
+
+# ---------------------------------------------------------------------------
+# The CLI command.
+# ---------------------------------------------------------------------------
+
+def _write(tmp_path, doc, name="sbom.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps(doc))
+    return path
+
+
+def test_cli_scores_a_file_and_names_the_dimensions(tmp_path):
+    path = _write(tmp_path, _partial_sbom())
+    result = runner.invoke(app, ["score", str(path)])
+    assert result.exit_code == 0
+    assert "Component identity" in result.stdout
+    assert "Model-card coverage" in result.stdout
+
+
+def test_cli_json_output_is_parseable(tmp_path):
+    path = _write(tmp_path, _complete_sbom())
+    result = runner.invoke(app, ["score", str(path), "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["grade"] == "A"
+    assert len(payload["dimensions"]) == len(score.DIMENSIONS)
+
+
+def test_cli_fail_under_exits_2_when_below(tmp_path):
+    path = _write(tmp_path, _minimal_sbom())
+    result = runner.invoke(app, ["score", str(path), "--fail-under", "90"])
+    assert result.exit_code == 2
+
+
+def test_cli_fail_under_exits_0_when_at_or_above(tmp_path):
+    path = _write(tmp_path, _complete_sbom())
+    result = runner.invoke(app, ["score", str(path), "--fail-under", "100"])
+    assert result.exit_code == 0
+
+
+def test_cli_fail_under_still_gates_in_json_mode(tmp_path):
+    """A CI gate that only works in human mode is not a CI gate."""
+    path = _write(tmp_path, _minimal_sbom())
+    result = runner.invoke(app, ["score", str(path), "--fail-under", "90", "--json"])
+    assert result.exit_code == 2
+    assert json.loads(result.stdout)["grade"] == "F"
+
+
+def test_cli_rejects_spdx_with_exit_1(tmp_path):
+    path = _write(tmp_path, {"spdxVersion": "SPDX-2.3", "packages": []})
+    result = runner.invoke(app, ["score", str(path)])
+    assert result.exit_code == 1
+    assert "SPDX" in result.stdout
+
+
+def test_cli_rejects_an_unusable_target_with_exit_1(tmp_path):
+    result = runner.invoke(app, ["score", str(tmp_path / "nope.json")])
+    assert result.exit_code == 1
+    assert "Cannot score" in result.stdout
+
+
+def test_cli_missing_vex_override_is_an_error_not_a_silent_zero(tmp_path):
+    path = _write(tmp_path, _partial_sbom())
+    result = runner.invoke(
+        app, ["score", str(path), "--vex", str(tmp_path / "absent.json")]
+    )
+    assert result.exit_code == 1
+    assert "VEX document not found" in result.stdout
+
+
+def test_cli_autodiscovers_sibling_vex(tmp_path):
+    path = _write(tmp_path, _partial_sbom())
+    (tmp_path / "sbom.openvex.json").write_text(
+        json.dumps({"statements": [{"vulnerability": {"name": "x"}}]})
+    )
+    result = runner.invoke(app, ["score", str(path), "--json"])
+    payload = json.loads(result.stdout)
+    vex = next(d for d in payload["dimensions"] if d["key"] == "vex")
+    assert vex["score"] == 100.0
+
+
+def _plan_section(stdout):
+    """Just the 'How to improve' block — the dimension table above it lists
+    every dimension in fixed order and would mask the plan's ranking."""
+    return stdout.split("How to improve", 1)[1].split("Next steps", 1)[0]
+
+
+def test_cli_shows_a_ranked_improvement_plan_not_a_flat_gap_list(tmp_path):
+    path = _write(tmp_path, _partial_sbom())
+    result = runner.invoke(app, ["score", str(path)])
+    assert "How to improve" in result.stdout
+    plan = _plan_section(result.stdout)
+    # The richest fix (+15.0 model card) is listed before the poorest
+    # (+2.5 document provenance).
+    assert plan.index("Model-card coverage") < plan.index("Document provenance")
+
+
+def test_cli_omits_complete_dimensions_from_the_plan(tmp_path):
+    """Identity is already 100 on this fixture, so it is not a to-do."""
+    path = _write(tmp_path, _partial_sbom())
+    plan = _plan_section(runner.invoke(app, ["score", str(path)]).stdout)
+    assert "Component identity" not in plan
+
+
+def test_cli_collapses_repeated_gaps_by_default(tmp_path):
+    """Both models lack a model card, but the remedy is printed once and no
+    component is named — that collapse is what keeps a 50-model scan readable."""
+    path = _write(tmp_path, _partial_sbom())
+    plan = _plan_section(runner.invoke(app, ["score", str(path)]).stdout)
+    assert plan.count("task and architecture are read") == 1
+    assert "clean.safetensors" not in plan
+    assert "model.pt" not in plan
+
+
+def test_cli_verbose_lists_every_affected_component(tmp_path):
+    path = _write(tmp_path, _partial_sbom())
+    result = runner.invoke(app, ["score", str(path), "--verbose"])
+    assert "clean.safetensors" in result.stdout
+    assert "model.pt" in result.stdout
+
+
+def test_cli_prints_the_next_steps_footer(tmp_path):
+    path = _write(tmp_path, _partial_sbom())
+    result = runner.invoke(app, ["score", str(path)])
+    assert "Next steps" in result.stdout
+    assert "advisories" in result.stdout
+
+
+def test_cli_footer_does_not_sell_the_gaps(tmp_path):
+    """Almost every gap is fixable with the free CLI, so the footer points at
+    trend tracking — not at paying to fix what `--vex` fixes for nothing."""
+    path = _write(tmp_path, _partial_sbom())
+    result = runner.invoke(app, ["score", str(path)])
+    lowered = result.stdout.lower()
+    for pitch in ("upgrade", "pricing", "paid plan", "buy"):
+        assert pitch not in lowered
+
+
+def test_json_carries_remediation_and_recoverable_points(tmp_path):
+    path = _write(tmp_path, _partial_sbom())
+    payload = json.loads(runner.invoke(app, ["score", str(path), "--json"]).stdout)
+    assert payload["potential"] > payload["overall"]
+    vex = next(d for d in payload["dimensions"] if d["key"] == "vex")
+    assert vex["pointsRecoverable"] == 10.0
+    assert "--vex" in vex["remediation"]
+
+
+def test_json_still_carries_every_per_component_gap(tmp_path):
+    """Grouping is a human-output concern; machines get the full list."""
+    path = _write(tmp_path, _partial_sbom())
+    payload = json.loads(runner.invoke(app, ["score", str(path), "--json"]).stdout)
+    modelcard = next(d for d in payload["dimensions"] if d["key"] == "modelcard")
+    assert len(modelcard["gaps"]) == 2
+
+
+def test_cli_scores_a_scan_target_directory(tmp_path):
+    """AC #1's second half: score a target, not just a file."""
+    from aisbom.mock_generator import create_mock_restricted_file
+
+    create_mock_restricted_file(tmp_path)
+    result = runner.invoke(app, ["score", str(tmp_path), "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["models"] >= 1
+
+
+def test_scoring_a_directory_matches_scanning_then_scoring_the_file(tmp_path):
+    """`score <dir>` and `scan` + `score sbom.json` run the same builder, so a
+    grade cannot depend on which route the user took."""
+    from aisbom.mock_generator import create_mock_restricted_file
+
+    create_mock_restricted_file(tmp_path)
+    out = tmp_path / "out" / "sbom.json"
+    out.parent.mkdir()
+
+    scanned = runner.invoke(app, [
+        "scan", str(tmp_path), "--output", str(out), "--no-fail-on-risk",
+    ])
+    assert scanned.exit_code == 0
+
+    direct = json.loads(runner.invoke(
+        app, ["score", str(tmp_path), "--json"]).stdout)
+    via_file = json.loads(runner.invoke(
+        app, ["score", str(out), "--json"]).stdout)
+
+    assert direct["overall"] == via_file["overall"]
+    assert direct["grade"] == via_file["grade"]
+
+
+def test_cli_vex_override_is_honoured(tmp_path):
+    path = _write(tmp_path, _partial_sbom())
+    override = tmp_path / "elsewhere.json"
+    override.write_text(json.dumps({"statements": [{"vulnerability": {"name": "x"}}]}))
+    result = runner.invoke(app, ["score", str(path), "--vex", str(override), "--json"])
+    payload = json.loads(result.stdout)
+    vex = next(d for d in payload["dimensions"] if d["key"] == "vex")
+    assert vex["score"] == 100.0

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -334,14 +334,130 @@ def test_gaps_are_not_repeated_per_component_in_the_remediation():
 
 
 # ---------------------------------------------------------------------------
-# VEX discovery.
+# Review findings (PR #100).
 # ---------------------------------------------------------------------------
 
-def test_inline_vulnerabilities_satisfy_the_vex_dimension():
+@pytest.mark.parametrize("alg", ["MD5", "SHA-1"])
+def test_a_non_sha256_digest_earns_no_checksum_credit(alg):
+    """The dimension is defined as SHA-256; a weaker digest is not it."""
     doc = _minimal_sbom()
-    doc["vulnerabilities"] = [{"id": "x"}]
+    doc["components"][0]["hashes"] = [{"alg": alg, "content": "d" * 32}]
+    assert _dim(score.score_sbom(doc), "checksums").score == 0.0
+
+
+def test_a_malformed_sha256_earns_no_checksum_credit():
+    doc = _minimal_sbom()
+    doc["components"][0]["hashes"] = [{"alg": "SHA-256", "content": "not-a-digest"}]
+    assert _dim(score.score_sbom(doc), "checksums").score == 0.0
+
+
+def test_sha256_alongside_a_weaker_digest_still_counts():
+    doc = _minimal_sbom()
+    doc["components"][0]["hashes"] = [
+        {"alg": "MD5", "content": "d" * 32},
+        {"alg": "SHA-256", "content": "e" * 64},
+    ]
+    assert _dim(score.score_sbom(doc), "checksums").score == 100.0
+
+
+def test_vulnerabilities_without_an_analysis_state_are_not_vex():
+    """A vulnerability inventory is not an exploitability statement."""
+    doc = _minimal_sbom()
+    doc["vulnerabilities"] = [{"id": "CVE-2024-1", "ratings": [{"severity": "high"}]}]
+    assert _dim(score.score_sbom(doc), "vex").score == 0.0
+
+
+def test_vulnerabilities_with_an_analysis_state_are_vex():
+    doc = _minimal_sbom()
+    doc["vulnerabilities"] = [
+        {"id": "CVE-2024-1", "analysis": {"state": "not_affected"}}
+    ]
     assert _dim(score.score_sbom(doc), "vex").score == 100.0
 
+
+def _openvex(serial, ref="artifact-0-model.pt"):
+    return {
+        "@id": f"{serial}#openvex",
+        "statements": [{
+            "vulnerability": {"name": "AISBOM-PICKLE-RCE"},
+            "status": "not_affected",
+            "products": [{"@id": f"{serial}#{ref}"}],
+        }],
+    }
+
+
+def test_a_stale_sibling_vex_from_a_previous_scan_earns_nothing(tmp_path):
+    """Regenerating an SBOM without --vex leaves the old VEX files on disk.
+    They describe a document with a different serial, so crediting them would
+    award ten points for statements about a scan that no longer exists."""
+    doc = _minimal_sbom()
+    doc["serialNumber"] = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000000"
+    sbom = tmp_path / "sbom.json"
+    sbom.write_text(json.dumps(doc))
+    (tmp_path / "sbom.openvex.json").write_text(json.dumps(
+        _openvex("urn:uuid:bbbbbbbb-1111-1111-1111-111111111111")   # a prior run
+    ))
+    report = score.score_sbom(doc, vex_documents=score.discover_vex(sbom))
+    assert _dim(report, "vex").score == 0.0
+
+
+def test_a_sibling_vex_for_this_document_is_credited(tmp_path):
+    doc = _minimal_sbom()
+    doc["serialNumber"] = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000000"
+    sbom = tmp_path / "sbom.json"
+    sbom.write_text(json.dumps(doc))
+    (tmp_path / "sbom.openvex.json").write_text(
+        json.dumps(_openvex(doc["serialNumber"]))
+    )
+    report = score.score_sbom(doc, vex_documents=score.discover_vex(sbom))
+    assert _dim(report, "vex").score == 100.0
+
+
+def test_a_cyclonedx_vex_is_matched_on_its_serial_number(tmp_path):
+    doc = _minimal_sbom()
+    doc["serialNumber"] = "urn:uuid:aaaaaaaa-0000-0000-0000-000000000000"
+    sbom = tmp_path / "sbom.json"
+    sbom.write_text(json.dumps(doc))
+    (tmp_path / "sbom.vex.cdx.json").write_text(json.dumps({
+        "bomFormat": "CycloneDX",
+        "serialNumber": doc["serialNumber"],
+        "vulnerabilities": [{"id": "X", "analysis": {"state": "not_affected"}}],
+    }))
+    report = score.score_sbom(doc, vex_documents=score.discover_vex(sbom))
+    assert _dim(report, "vex").score == 100.0
+
+
+def test_vex_cannot_be_bound_to_a_document_with_no_serial(tmp_path):
+    """Without a serial there is nothing to bind the statements to, so the
+    claim that they describe *this* document cannot be checked."""
+    doc = _minimal_sbom()                      # no serialNumber
+    sbom = tmp_path / "sbom.json"
+    sbom.write_text(json.dumps(doc))
+    (tmp_path / "sbom.openvex.json").write_text(
+        json.dumps(_openvex("urn:uuid:cccccccc-2222-2222-2222-222222222222"))
+    )
+    report = score.score_sbom(doc, vex_documents=score.discover_vex(sbom))
+    assert _dim(report, "vex").score == 0.0
+
+
+def test_load_sbom_requires_the_cyclonedx_bomformat(tmp_path):
+    """`specVersion` alone does not identify a document as CycloneDX."""
+    path = tmp_path / "s.json"
+    path.write_text(json.dumps({"specVersion": "1.7", "components": []}))
+    with pytest.raises(score.ScoreInputError, match="not a CycloneDX"):
+        score.load_sbom(path)
+
+
+def test_load_sbom_rejects_a_document_declaring_another_bomformat(tmp_path):
+    path = tmp_path / "s.json"
+    path.write_text(json.dumps({"bomFormat": "SomethingElse", "specVersion": "1.7"}))
+    with pytest.raises(score.ScoreInputError, match="not a CycloneDX"):
+        score.load_sbom(path)
+
+
+# ---------------------------------------------------------------------------
+# VEX discovery.
+# ---------------------------------------------------------------------------
 
 def test_sibling_vex_filenames_match_what_scan_writes(tmp_path):
     """Mirrors cli._vex_paths so `scan --vex` then `score` needs no flags."""
@@ -359,12 +475,14 @@ def test_discover_vex_finds_only_files_that_exist(tmp_path):
 
 
 def test_a_discovered_vex_document_scores_the_dimension(tmp_path):
+    doc = _minimal_sbom()
+    doc["serialNumber"] = "urn:uuid:dddddddd-3333-3333-3333-333333333333"
     sbom = tmp_path / "sbom.json"
-    sbom.write_text("{}")
+    sbom.write_text(json.dumps(doc))
     (tmp_path / "sbom.openvex.json").write_text(
-        json.dumps({"statements": [{"vulnerability": {"name": "x"}}]})
+        json.dumps(_openvex(doc["serialNumber"]))
     )
-    report = score.score_sbom(_minimal_sbom(), vex_documents=score.discover_vex(sbom))
+    report = score.score_sbom(doc, vex_documents=score.discover_vex(sbom))
     assert _dim(report, "vex").score == 100.0
 
 
@@ -496,9 +614,10 @@ def test_cli_missing_vex_override_is_an_error_not_a_silent_zero(tmp_path):
 
 
 def test_cli_autodiscovers_sibling_vex(tmp_path):
-    path = _write(tmp_path, _partial_sbom())
+    doc = _partial_sbom()
+    path = _write(tmp_path, doc)
     (tmp_path / "sbom.openvex.json").write_text(
-        json.dumps({"statements": [{"vulnerability": {"name": "x"}}]})
+        json.dumps(_openvex(doc["serialNumber"], ref="artifact-1-model.pt"))
     )
     result = runner.invoke(app, ["score", str(path), "--json"])
     payload = json.loads(result.stdout)
@@ -580,6 +699,29 @@ def test_json_still_carries_every_per_component_gap(tmp_path):
     assert len(modelcard["gaps"]) == 2
 
 
+def test_cli_refuses_to_grade_a_partial_scan(tmp_path, monkeypatch):
+    """A fetch or parse failure is recorded in results["errors"] and the scan
+    returns normally, so scoring what survived would hand back a completeness
+    grade for a document that is missing the shard that failed."""
+    from aisbom import cli as cli_mod
+
+    class _PartialScanner:
+        def __init__(self, *a, **kw):
+            pass
+
+        def scan(self):
+            return {
+                "artifacts": [],
+                "dependencies": [],
+                "errors": [{"file": "broken.pt", "error": "unreadable"}],
+            }
+
+    monkeypatch.setattr(cli_mod, "DeepScanner", _PartialScanner)
+    result = runner.invoke(app, ["score", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "broken.pt" in result.stdout
+
+
 def test_cli_scores_a_scan_target_directory(tmp_path):
     """AC #1's second half: score a target, not just a file."""
     from aisbom.mock_generator import create_mock_restricted_file
@@ -615,9 +757,12 @@ def test_scoring_a_directory_matches_scanning_then_scoring_the_file(tmp_path):
 
 
 def test_cli_vex_override_is_honoured(tmp_path):
-    path = _write(tmp_path, _partial_sbom())
+    doc = _partial_sbom()
+    path = _write(tmp_path, doc)
     override = tmp_path / "elsewhere.json"
-    override.write_text(json.dumps({"statements": [{"vulnerability": {"name": "x"}}]}))
+    override.write_text(json.dumps(
+        _openvex(doc["serialNumber"], ref="artifact-1-model.pt")
+    ))
     result = runner.invoke(app, ["score", str(path), "--vex", str(override), "--json"])
     payload = json.loads(result.stdout)
     vex = next(d for d in payload["dimensions"] if d["key"] == "vex")


### PR DESCRIPTION
Implements aisbom-ops #114 (CLI P1.5).

A scan can come back perfectly clean and still produce an SBOM that names no licenses, carries no checksums and describes none of the models. `aisbom score` grades the document you are about to hand an auditor.

## Scoring

Seven dimensions weighted to 100 — 65 points of NTIA-style minimum elements, 25 of AI-specific description, 10 of VEX. A complete but generic SBOM tops out near 65, so an A is only reachable with the AI metadata filled in.

| Dimension | Weight |
|---|---|
| Component identity | 20 |
| Checksums | 20 |
| Licenses | 15 |
| Model-card coverage | 15 |
| Dataset provenance | 10 |
| VEX presence | 10 |
| Document provenance | 10 |

Grade bands are calibrated against measured output rather than the academic 90/80/70/60 scale, on which **every document AIsbom produces would be an F** — which reads as a miscalibrated grader, not as feedback:

| Document | Score | Grade |
|---|---|---|
| fixture: minimal | 15.8 | F |
| live: local scan | 53.6 | D |
| live: local scan `--vex` | 63.6 | C |
| live: `hf://` scan | 70.0 | B |
| live: `hf://` scan `--vex` | 80.0 | B |
| fixture: complete | 100.0 | A |

Each step up corresponds to a real user action.

## Two calibration decisions worth review

Both exist so the grade does not deduct points for architecture the user cannot influence:

1. **Licenses credits `aisbom:hf:license`.** #111 decision 5 deliberately routes Hugging Face licenses there instead of `licenses[]`, because backfilling `licenses[]` would silently change a compliance judgement. Scoring only `licenses[]` gave every `hf://` scan a 0 for a license AIsbom had successfully identified. The gap names which field it came from, so the non-standard location is still visible.

2. **Checksums still scores remote scans as a gap.** An AIBOM without digests genuinely is weaker for compliance, and the fix is actionable — so rather than excusing it, the remediation names the cause: range requests never read a whole file, scan a local copy. `hf://` consequently tops out at 80.

Scoring is **fixed-denominator** by design. Marking dimensions "not applicable" and renormalizing would make two grades incomparable, which is the whole value of a grade. That is also why SPDX input is rejected rather than partially scored — SPDX 2.3 has no structured home for model-card or dataset metadata, so grading it would mean parsing free-text prose or using a smaller denominator.

## Output is a worklist, not a verdict

Gaps are grouped by dimension and ranked by points recoverable, and one remedy prints per dimension rather than once per component:

```
How to improve (53.6 → 100.0 possible)
   +15.0  Model-card coverage — 4 of 4 model(s) declare no task or architecture
          → aisbom scan hf://<org>/<model>
   +10.7  Licenses — 5 of 7 component(s) declare no license
   +10.0  Dataset provenance — 4 of 4 model(s) name no training data
   +10.0  VEX presence — no exploitability statements
          → aisbom scan . --vex --output sbom.json
    +0.7  Component identity — 1 component(s) incompletely identified
```

The previous flat shape was 15 near-identical lines on a 7-component SBOM — roughly 150 on a 50-model repo — and gave a one-flag ten-point VEX fix the same visual weight as a sub-point missing version string. `--verbose` lists every affected component; `--json` always carries the full detail.

## Refactor and two output changes

`cli.scan`'s inline CycloneDX construction moved to `cyclonedx_gen`, so scoring a scan target and scanning produce the same document from the same code. Verified byte-identical against a pre-change SBOM apart from two deliberate additions:

- **`metadata.tools`** now self-identifies the producing tool — required by the NTIA minimum elements and scored by the new grade. Purely additive.
- **`version: "unknown"` is no longer emitted** for unpinned dependencies. Safe on upgrade: `SBOMDiff` already reads `component.get("version", "unknown")`, so an absent field and the literal string compare equal and no phantom drift is reported. Asserted against the real differ, with a companion test proving the differ still detects a genuine version change — so the first test cannot pass vacuously.

Everything else — descriptions, hashes, licenses, `aisbom:*` properties, modelCards, and the stamped `artifact-N-<name>` refs — is unchanged.

## Exit codes

`0` ok, `1` unreadable or non-CycloneDX input, `2` below `--fail-under`. Consistent with `--fail-on-risk` and `bypass-scorecard --check`.

## Verification

- `poetry run pytest --cov=aisbom --cov-fail-under=85` — **1082 passed**, coverage **92.86%** (`score` 97%, `cyclonedx_gen` 100%)
- `aisbom bypass-scorecard --check` — gate passed, no case below floor
- `score <dir>` and `scan` + `score sbom.json` both return 53.6 — asserted in a test, not just observed
- Footer honours `AISBOM_NO_TELEMETRY` (attribution dropped)
- CI smoke test #12 exercises all three input routes and asserts **both** gate outcomes, so a gate that stopped gating fails the build

## Follow-ups filed

- Lab700xOrg/aisbom-ops#129 — PyPI license resolution for `requirements.txt` pins (~10.7 pts)
- Lab700xOrg/aisbom-ops#130 — populate `modelCard` for local model files from HF metadata (~25 pts; this is the entire local-vs-`hf://` grade gap)