### PR TITLE
ci(binaries): smoke test the frozen binary before uploading release assets

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -77,6 +77,69 @@ jobs:
       - name: Build binary
         run: ./scripts/build_binaries.sh
 
+      # This workflow is the only path these executables take to users, and it
+      # runs solely on `release: published` — no PR check ever exercises it.
+      # A successful build does not prove the binary runs: a PyInstaller
+      # bootloader change (e.g. how the frozen executable resolves its own
+      # path) or a dropped `--collect-all` hook yields an artifact that builds
+      # cleanly and then fails on the user's machine. Assert the documented
+      # exit-code contract here, ahead of the upload, so a bad build fails the
+      # release instead of shipping.
+      - name: Smoke test the frozen binary
+        shell: bash
+        env:
+          # Also suppresses the version-check HTTP call, so the gate makes no
+          # network requests and cannot fail on a flaky endpoint.
+          AISBOM_NO_TELEMETRY: "1"
+          NO_COLOR: "1"
+        run: |
+          set -euo pipefail
+          BIN="dist/aisbom"
+
+          # The bootloader has to locate and unpack itself before anything else
+          # can be true.
+          "$BIN" --version
+          "$BIN" --help > /dev/null
+
+          "$BIN" generate-test-artifacts /tmp/fixtures
+          ls -l /tmp/fixtures
+
+          # Non-zero is the expected outcome for most of these, so capture the
+          # codes rather than letting `set -e` abort on the first CRITICAL.
+          set +e
+          "$BIN" scan /tmp/fixtures --output /tmp/sbom.json > /dev/null 2>&1
+          json_rc=$?
+          "$BIN" scan /tmp/fixtures --format spdx --output /tmp/sbom.spdx.json > /dev/null 2>&1
+          spdx_rc=$?
+          "$BIN" scan /tmp/fixtures --format markdown --no-fail-on-risk > /dev/null 2>&1
+          md_rc=$?
+          "$BIN" scan /tmp/fixtures --no-fail-on-risk > /dev/null 2>&1
+          nofail_rc=$?
+          "$BIN" scan /tmp/fixtures/does-not-exist > /dev/null 2>&1
+          missing_rc=$?
+          set -e
+
+          echo "json_rc=$json_rc spdx_rc=$spdx_rc md_rc=$md_rc nofail_rc=$nofail_rc missing_rc=$missing_rc"
+
+          # The exit codes downstream CI pipelines gate on: 2 = CRITICAL found,
+          # 1 = scan error, 0 = clean.
+          test "$json_rc"    -eq 2 || { echo "FAIL: CRITICAL CycloneDX scan exited $json_rc, expected 2"; exit 1; }
+          test "$spdx_rc"    -eq 2 || { echo "FAIL: CRITICAL SPDX scan exited $spdx_rc, expected 2"; exit 1; }
+          test "$md_rc"      -eq 0 || { echo "FAIL: markdown scan exited $md_rc, expected 0"; exit 1; }
+          test "$nofail_rc"  -eq 0 || { echo "FAIL: --no-fail-on-risk exited $nofail_rc, expected 0"; exit 1; }
+          test "$missing_rc" -eq 1 || { echo "FAIL: missing target exited $missing_rc, expected 1"; exit 1; }
+
+          # A bundling regression can still emit a syntactically valid but empty
+          # document, so assert the malicious component actually reached both
+          # serializers rather than just checking the files exist.
+          grep -q '"bomFormat": *"CycloneDX"' /tmp/sbom.json
+          grep -q '"specVersion"' /tmp/sbom.json
+          grep -q 'mock_malware.pt' /tmp/sbom.json
+          grep -q 'SPDX-2.3' /tmp/sbom.spdx.json
+          grep -q 'mock_malware.pt' /tmp/sbom.spdx.json
+
+          echo "OK: frozen ${{ matrix.asset_name }} passed the exit-code and SBOM contract"
+
       - name: Rename binary
         shell: bash
         run: |


### PR DESCRIPTION
## Why

`binaries.yml` built the three standalone binaries and uploaded them straight to the release **without ever executing one**. Because the workflow only triggers on `release: published`, no PR check exercises it either — so the first time a broken binary ran was on a user's machine, from an asset already published.

That is a live risk, not a hypothetical. Reviewing a recent PyInstaller bump, 6.22.0 → 6.22.2 refactored the bootloader's POSIX executable resolution (`_pyi_resolve_executable_posix()` now resolves the `/proc` entry with `realpath()` instead of `readlink()`) — i.e. how a frozen binary locates *itself* at startup. A regression there builds perfectly cleanly. The same is true of a dropped `--collect-all` hook: the build succeeds and the binary fails to import its serializers at runtime.

## What

Adds a `Smoke test the frozen binary` step to `build-and-upload`, positioned **after `Build binary` and before `Rename binary` / `Upload Release Asset`**, so a bad build fails the release instead of publishing.

It asserts the documented exit-code contract that downstream CI pipelines gate on:

| check | expected |
|---|---|
| CRITICAL scan, CycloneDX (`--output`) | `2` |
| CRITICAL scan, SPDX (`--format spdx`) | `2` |
| markdown render (`--no-fail-on-risk`) | `0` |
| clean run (`--no-fail-on-risk`) | `0` |
| missing target | `1` |

plus `--version` / `--help` (proves the bootloader can locate and unpack itself at all), and content assertions on both emitted documents — `"bomFormat": "CycloneDX"`, a `"specVersion"` key, `SPDX-2.3`, and `mock_malware.pt` present in both. The last one matters because a bundling regression can still produce a syntactically valid but empty document; checking the files merely exist would pass.

`AISBOM_NO_TELEMETRY: "1"` doubles as the switch that suppresses the version check's HTTP call (`version_check.py` returns early on it), so this gate makes no network requests and cannot fail on a flaky endpoint.

## Verification

`binaries.yml` cannot be exercised by a PR check, so it was run directly: the full matrix was executed on a temporary branch carrying a `push:` trigger and temporarily relaxed `v1.` tag gates. All three legs green, including the release gate job:

https://github.com/Lab700xOrg/aisbom/actions/runs/34006846218

```
aisbom-linux-amd64   json_rc=2 spdx_rc=2 md_rc=0 nofail_rc=0 missing_rc=1
aisbom-macos-amd64   json_rc=2 spdx_rc=2 md_rc=0 nofail_rc=0 missing_rc=1
aisbom-macos-arm64   json_rc=2 spdx_rc=2 md_rc=0 nofail_rc=0 missing_rc=1
```

`Upload Release Asset` correctly **skipped** on all three (its `startsWith(github.ref, 'refs/tags/')` guard), so the verification run published nothing.

The temporary branch, its `push:` trigger and the relaxed gates have all been deleted. **This PR contains only the smoke-test step** — no trigger changes, no gate changes:

```
.github/workflows/binaries.yml | 63 ++++++++++++++++++++++++++++++++++++++++++
1 file changed, 63 insertions(+)
```

## Known limitation — separate pre-existing bug

Worth recording here, because this step does **not** cover it. The verification run shows **both** macOS legs building `arm64`:

| leg | `setup-python` requested | PyInstaller reported |
|---|---|---|
| `aisbom-macos-amd64` | `architecture: x64` | `EXE target arch: arm64` |
| `aisbom-macos-arm64` | `architecture: arm64` | `EXE target arch: arm64` |

The matrix comment says "Run Intel build on M1 via Rosetta 2", but nothing invokes Rosetta — `scripts/build_binaries.sh` passes no `--target-arch`, so PyInstaller follows the running interpreter, and the `x64` request did not yield an x86_64 one on `macos-14`. Corroborating: the two published v1.3.3 macOS assets are 24118048 and 24118000 bytes, 48 bytes apart, which is implausible for genuinely different architectures.

So `aisbom-macos-amd64` is likely an arm64 binary that will not run on an Intel Mac. This smoke test **cannot** catch it — it executes the binary on an ARM runner, where arm64 runs natively and passes every assertion above. Fixing it needs the Intel build to genuinely produce x86_64, plus an architecture assertion; tracked separately rather than expanded into this PR, so the smoke test lands without blocking releases on an unrelated fix.
